### PR TITLE
chore: Add two code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @alainncls @fdemiramon @satyajeetkolhapure
+* @alainncls @fdemiramon @satyajeetkolhapure @orbmis @0xEillo


### PR DESCRIPTION
## What does this PR do?

Add @orbmis and @0xEillo as code owners

### Type of change

- [X] Chore
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update

## Check list

- [ ] Unit tests for any smart contract change
- [ ] Contracts and functions are documented
