### PR TITLE
fix: Fixes the Foundry version to avoid its latest regression

### DIFF
--- a/.github/workflows/smart-contracts-test.yml
+++ b/.github/workflows/smart-contracts-test.yml
@@ -24,6 +24,8 @@ jobs:
 
       - name: "Install Foundry"
         uses: "foundry-rs/foundry-toolchain@v1"
+        with:
+          version: "nightly-b536f518fb2b161c24d591f95e336194ec809c25"
 
       - name: "Install Pnpm"
         uses: "pnpm/action-setup@v2"
@@ -57,6 +59,8 @@ jobs:
 
       - name: "Install Foundry"
         uses: "foundry-rs/foundry-toolchain@v1"
+        with:
+          version: "nightly-b536f518fb2b161c24d591f95e336194ec809c25"
 
       - name: "Show the Foundry config"
         run: "forge config"
@@ -82,6 +86,8 @@ jobs:
 
       - name: "Install Foundry"
         uses: "foundry-rs/foundry-toolchain@v1"
+        with:
+          version: "nightly-b536f518fb2b161c24d591f95e336194ec809c25"
 
       - name: "Run the unit tests"
         run: "forge test --match-path \"test/*\""
@@ -102,6 +108,8 @@ jobs:
 
       - name: "Install Foundry"
         uses: "foundry-rs/foundry-toolchain@v1"
+        with:
+          version: "nightly-b536f518fb2b161c24d591f95e336194ec809c25"
 
       - name: "Generate the coverage report using the unit tests"
         run: "forge coverage --match-path \"test/**/*.sol\" --report lcov"


### PR DESCRIPTION
## What does this PR do?

Fixes the version of Foundry to avoid the latest regression that was introduced, preventing the `coverage` command to go through.


### Related ticket

Fixes #90 

### Type of change

- [ ] Chore
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update

## Check list

- [ ] Unit tests for any smart contract change
- [ ] Contracts and functions are documented
