### PR TITLE
chore: Use Foundry's nightly version for the CI

### DIFF
--- a/.github/workflows/smart-contracts-test.yml
+++ b/.github/workflows/smart-contracts-test.yml
@@ -24,8 +24,6 @@ jobs:
 
       - name: "Install Foundry"
         uses: "foundry-rs/foundry-toolchain@v1"
-        with:
-          version: "nightly-b536f518fb2b161c24d591f95e336194ec809c25"
 
       - name: "Install Pnpm"
         uses: "pnpm/action-setup@v2"
@@ -59,8 +57,6 @@ jobs:
 
       - name: "Install Foundry"
         uses: "foundry-rs/foundry-toolchain@v1"
-        with:
-          version: "nightly-b536f518fb2b161c24d591f95e336194ec809c25"
 
       - name: "Show the Foundry config"
         run: "forge config"
@@ -86,8 +82,6 @@ jobs:
 
       - name: "Install Foundry"
         uses: "foundry-rs/foundry-toolchain@v1"
-        with:
-          version: "nightly-b536f518fb2b161c24d591f95e336194ec809c25"
 
       - name: "Run the unit tests"
         run: "forge test --match-path \"test/*\""
@@ -108,8 +102,6 @@ jobs:
 
       - name: "Install Foundry"
         uses: "foundry-rs/foundry-toolchain@v1"
-        with:
-          version: "nightly-b536f518fb2b161c24d591f95e336194ec809c25"
 
       - name: "Generate the coverage report using the unit tests"
         run: "forge coverage --match-path \"test/**/*.sol\" --report lcov"


### PR DESCRIPTION
## What does this PR do?

Switches back to the nightly version for Foundry after they fixed the regression blocking the `coverage` job

### Type of change

- [X] Chore
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update

## Check list

- [ ] Unit tests for any smart contract change
- [ ] Contracts and functions are documented
