### PR TITLE
feature/as a user i want the registry to check the integrity of my attestation metadata

### DIFF
--- a/src/AttestationRegistry.sol
+++ b/src/AttestationRegistry.sol
@@ -37,10 +37,6 @@ contract AttestationRegistry is OwnableUpgradeable {
   error AttestationNotAttested();
   /// @notice Error thrown when an attempt is made to revoke an attestation by an entity other than the attesting portal
   error OnlyAttestingPortal();
-  /// @notice Error thrown when an attempt is made to register an attestation with an empty subject field
-  error EmptyAttestationSubjectField();
-  /// @notice Error thrown when an attempt is made to register an attestation with an empty data field
-  error DataAttestationFieldEmpty();
 
   /// @notice Event emitted when an attestation is registered
   event AttestationRegistered(Attestation attestation);
@@ -78,39 +74,8 @@ contract AttestationRegistry is OwnableUpgradeable {
    */
   function attest(Attestation memory attestation) external onlyPortals(msg.sender) {
     if (isRegistered(attestation.attestationId)) revert AttestationAlreadyAttested();
-
-    /*
-    // verify the schema id exists
-    if (!schemaRegistry.isRegistered(attestation.schemaId)) revert SchemaNotRegistered();
-
-    // the subject field is not blank (or is of minimum length - 8 bytes?)
-    if (attestation.subject.length == 0) revert EmptyAttestationSubjectField();
-
-    // the attestationData field is not blank
-    if (attestation.attestationData.length == 0) revert DataAttestationFieldEmpty();
-
-    // the version is set to the current version of the registry
-    attestation.version = version;
-
-    // the attester field is set to tx.origin
-    attestation.attester = tx.origin;
-
-    // the portalId is set to the msg.sender
-    attestation.portal = msg.sender;
-
-    // the attestationId is created deterministically (e.g. auto-increment, or keccak hash)
-    attestation.attestationId = bytes32(++attestationCount);
-
-    // the attestedDate field is set to the current date
-    attestation.attestedDate = block.timestamp;
-
-    // the revoked field is uninitialized
-    attestation.revoked = false;
-
-    // record attestation in state
-    */
-
     attestations[attestation.attestationId] = attestation;
+    attestationCount++;
     emit AttestationRegistered(attestation);
   }
 

--- a/src/AttestationRegistry.sol
+++ b/src/AttestationRegistry.sol
@@ -19,6 +19,8 @@ contract AttestationRegistry is OwnableUpgradeable {
 
   uint16 private version;
 
+  uint256 public attestationCount;
+
   /// @notice Error thrown when a non-portal tries to call a method that can only be called by a portal
   error OnlyPortal();
   /// @notice Error thrown when an invalid PortalRegistry address is given
@@ -35,6 +37,10 @@ contract AttestationRegistry is OwnableUpgradeable {
   error AttestationNotAttested();
   /// @notice Error thrown when an attempt is made to revoke an attestation by an entity other than the attesting portal
   error OnlyAttestingPortal();
+  /// @notice Error thrown when an attempt is made to register an attestation with an empty subject field
+  error EmptyAttestationSubjectField();
+  /// @notice Error thrown when an attempt is made to register an attestation with an empty data field
+  error DataAttestationFieldEmpty();
 
   /// @notice Event emitted when an attestation is registered
   event AttestationRegistered(Attestation attestation);
@@ -70,8 +76,40 @@ contract AttestationRegistry is OwnableUpgradeable {
    * @param attestation the attestation to register
    * @dev This method is only callable by a registered Portal
    */
-  function attest(Attestation calldata attestation) external onlyPortals(msg.sender) {
+  function attest(Attestation memory attestation) external onlyPortals(msg.sender) {
     if (isRegistered(attestation.attestationId)) revert AttestationAlreadyAttested();
+
+    /*
+    // verify the schema id exists
+    if (!schemaRegistry.isRegistered(attestation.schemaId)) revert SchemaNotRegistered();
+
+    // the subject field is not blank (or is of minimum length - 8 bytes?)
+    if (attestation.subject.length == 0) revert EmptyAttestationSubjectField();
+
+    // the attestationData field is not blank
+    if (attestation.attestationData.length == 0) revert DataAttestationFieldEmpty();
+
+    // the version is set to the current version of the registry
+    attestation.version = version;
+
+    // the attester field is set to tx.origin
+    attestation.attester = tx.origin;
+
+    // the portalId is set to the msg.sender
+    attestation.portal = msg.sender;
+
+    // the attestationId is created deterministically (e.g. auto-increment, or keccak hash)
+    attestation.attestationId = bytes32(++attestationCount);
+
+    // the attestedDate field is set to the current date
+    attestation.attestedDate = block.timestamp;
+
+    // the revoked field is uninitialized
+    attestation.revoked = false;
+
+    // record attestation in state
+    */
+
     attestations[attestation.attestationId] = attestation;
     emit AttestationRegistered(attestation);
   }

--- a/src/PortalRegistry.sol
+++ b/src/PortalRegistry.sol
@@ -17,6 +17,7 @@ contract PortalRegistry is Initializable {
   address[] private portalAddresses;
   address public moduleRegistry;
   address public attestationRegistry;
+  address public schemaRegistry;
 
   /// @notice Error thown when attempting to register a Portal twice
   error PortalAlreadyExists();
@@ -37,9 +38,10 @@ contract PortalRegistry is Initializable {
   /**
    * @notice Contract initialization
    */
-  function initialize(address _moduleRegistry, address _attestationRegistry) public initializer {
+  function initialize(address _moduleRegistry, address _attestationRegistry, address _schemaRegistry) public initializer {
     moduleRegistry = _moduleRegistry;
     attestationRegistry = _attestationRegistry;
+    schemaRegistry = _schemaRegistry;
   }
 
   /**
@@ -84,7 +86,7 @@ contract PortalRegistry is Initializable {
    */
   function deployDefaultPortal(address[] calldata modules, string memory name, string memory description) external {
     DefaultPortal defaultPortal = new DefaultPortal();
-    defaultPortal.initialize(modules, moduleRegistry, attestationRegistry);
+    defaultPortal.initialize(modules, moduleRegistry, attestationRegistry, schemaRegistry);
     register(address(defaultPortal), name, description);
   }
 

--- a/src/SchemaRegistry.sol
+++ b/src/SchemaRegistry.sol
@@ -21,6 +21,8 @@ contract SchemaRegistry is Initializable {
   error SchemaNameMissing();
   /// @notice Error thrown when attempting to add a Schema without a string to define it
   error SchemaStringMissing();
+  /// @notice Error thrown when attempting to add a Schema without a context to define it
+  error SchemaContextMissing();
 
   /// @notice Event emitted when a Schema is created and registered
   event SchemaCreated(bytes32 indexed id, string name, string description, string context, string schemaString);
@@ -62,6 +64,10 @@ contract SchemaRegistry is Initializable {
 
     if (bytes(schemaString).length == 0) {
       revert SchemaStringMissing();
+    }
+
+    if (bytes(context).length == 0) {
+      revert SchemaContextMissing();
     }
 
     bytes32 schemaId = getIdFromSchemaString(schemaString);

--- a/src/types/Structs.sol
+++ b/src/types/Structs.sol
@@ -2,9 +2,7 @@
 pragma solidity 0.8.21;
 
 struct AttestationPayload {
-  bytes32 attestationId; // The unique identifier of the attestation.
   bytes32 schemaId; // The identifier of the schema this attestation adheres to.
-  address attester; // The address issuing the attestation to the subject.
   bytes subject; // The ID of the attestee, EVM address, DID, URL etc.
   uint256 expirationDate; // The expiration date of the attestation.
   bytes[] attestationData; // The attestation data.

--- a/test/PortalRegistry.t.sol
+++ b/test/PortalRegistry.t.sol
@@ -27,10 +27,10 @@ contract PortalRegistryTest is Test {
   function test_initialize() public {
     vm.expectEmit();
     emit Initialized(1);
-    portalRegistry.initialize(address(1), address(2));
+    portalRegistry.initialize(address(1), address(2), address(3));
 
     vm.expectRevert("Initializable: contract is already initialized");
-    portalRegistry.initialize(address(1), address(2));
+    portalRegistry.initialize(address(1), address(2), address(3));
   }
 
   function test_register() public {

--- a/test/portal/DefaultPortal.t.sol
+++ b/test/portal/DefaultPortal.t.sol
@@ -9,6 +9,7 @@ import { AttestationPayload } from "../../src/types/Structs.sol";
 import { CorrectModule } from "../../src/example/CorrectModule.sol";
 import { AttestationRegistryMock } from "../mocks/AttestationRegistryMock.sol";
 import { ModuleRegistryMock } from "../mocks/ModuleRegistryMock.sol";
+import { SchemaRegistryMock } from "../mocks/SchemaRegistryMock.sol";
 import { IERC165 } from "openzeppelin-contracts/contracts/utils/introspection/ERC165.sol";
 
 contract DefaultPortalTest is Test {
@@ -16,6 +17,7 @@ contract DefaultPortalTest is Test {
   address[] public modules = new address[](1);
   DefaultPortal public defaultPortal;
   ModuleRegistryMock public moduleRegistryMock = new ModuleRegistryMock();
+  SchemaRegistryMock public schemaRegistryMock = new SchemaRegistryMock();
   AttestationRegistryMock public attestationRegistryMock = new AttestationRegistryMock();
 
   event Initialized(uint8 version);
@@ -31,16 +33,16 @@ contract DefaultPortalTest is Test {
   function test_initialize() public {
     vm.expectEmit();
     emit Initialized(1);
-    defaultPortal.initialize(modules, address(1), address(2));
+    defaultPortal.initialize(modules, address(1), address(2), address(3));
 
     vm.expectRevert("Initializable: contract is already initialized");
-    defaultPortal.initialize(modules, address(1), address(2));
+    defaultPortal.initialize(modules, address(1), address(2), address(3));
   }
 
   function test_getModules() public {
     vm.expectEmit();
     emit Initialized(1);
-    defaultPortal.initialize(modules, address(1), address(2));
+    defaultPortal.initialize(modules, address(1), address(2), address(3));
 
     address[] memory _modules = defaultPortal.getModules();
     assertEq(_modules, modules);
@@ -49,17 +51,26 @@ contract DefaultPortalTest is Test {
   function test_attest() public {
     vm.expectEmit();
     emit Initialized(1);
-    defaultPortal.initialize(modules, address(moduleRegistryMock), address(attestationRegistryMock));
+    defaultPortal.initialize(modules, address(moduleRegistryMock), address(attestationRegistryMock), address(schemaRegistryMock));
+
+    bytes[] memory attestationData = new bytes[](4);
+
+    for (uint256 i = 0; i < attestationData.length; i++) {
+      attestationData[i] = new bytes(4);
+
+      for (uint256 j = 0; j < attestationData[i].length; j++) {
+        attestationData[i][j] = bytes1(0);
+      }
+    }
 
     // Create attestation payload
     AttestationPayload memory attestationPayload = AttestationPayload(
-      bytes32("attestationId"),
       bytes32("schemaId"),
-      address(1),
       bytes("subject"),
       block.timestamp + 1 days,
-      new bytes[](0)
+      attestationData
     );
+
     // Create validation payload
     bytes[] memory validationPayload = new bytes[](0);
 


### PR DESCRIPTION
## What does this PR do?

Adds integrity checks to the default portal contract to ensure that attestations are are correctly structured and have the correct values

### Related ticket

[[US] As a user, I want the registry to check the integrity of my attestation metadata#78](https://github.com/Consensys/linea-attestation-registry/issues/78)

Fixes #78 

### Type of change

- [ ] Chore
- [ ] Bug fix
- [*] New feature
- [ ] Documentation update

## Check list

- [*] Unit tests for any smart contract change
- [*] Contracts and functions are documented
