### PR TITLE
feat: add lifecycle hooks to abstract contract

### DIFF
--- a/src/AttestationRegistry.sol
+++ b/src/AttestationRegistry.sol
@@ -83,7 +83,9 @@ contract AttestationRegistry is OwnableUpgradeable {
    * @param attestationPayload the attestation payload to create attestation and register it
    * @dev This method is only callable by a registered Portal
    */
-  function attest(AttestationPayload calldata attestationPayload) external onlyPortals(msg.sender) {
+  function attest(
+    AttestationPayload calldata attestationPayload
+  ) external onlyPortals(msg.sender) returns (Attestation memory) {
     // Verify the schema id exists
     SchemaRegistry schemaRegistry = SchemaRegistry(router.getSchemaRegistry());
     if (!schemaRegistry.isRegistered(attestationPayload.schemaId)) revert SchemaNotRegistered();

--- a/src/AttestationRegistry.sol
+++ b/src/AttestationRegistry.sol
@@ -136,8 +136,18 @@ contract AttestationRegistry is OwnableUpgradeable {
    * @param attestationId the attestation identifier
    * @return true if the attestation is registered, false otherwise
    */
-  function isRegistered(bytes32 attestationId) public view returns (bool) {
+  function isRegistered(uint256 attestationId) public view returns (bool) {
     return attestations[attestationId].attestationId != bytes32(0);
+  }
+
+  /**
+   * @notice Checks whether a portal issues revocable attestations
+   * @param portalId the portal address (ID)
+   * @return true if the attestations issued by this portal are revocable, false otherwise
+   */
+  function isRevocable(address portalId) public view returns (bool) {
+    PortalRegistry portalRegistry = PortalRegistry(router.getPortalRegistry());
+    return portalRegistry.getPortalByAddress(portalId).isRevocable;
   }
 
   /**
@@ -155,7 +165,7 @@ contract AttestationRegistry is OwnableUpgradeable {
    * @param attestationId the attestation identifier
    * @return the attestation
    */
-  function getAttestation(bytes32 attestationId) public view returns (Attestation memory) {
+  function getAttestation(uint256 attestationId) public view returns (Attestation memory) {
     if (!isRegistered(attestationId)) revert AttestationNotAttested();
     return attestations[attestationId];
   }

--- a/src/AttestationRegistry.sol
+++ b/src/AttestationRegistry.sol
@@ -111,6 +111,9 @@ contract AttestationRegistry is OwnableUpgradeable {
     attestations[attestation.attestationId] = attestation;
     emit AttestationRegistered(attestation);
 
+    return attestation;
+  }
+
   /**
    * @notice Revokes an attestation for given identifier and can replace it by an other one
    * @param attestationId the attestation ID to revoke
@@ -136,18 +139,8 @@ contract AttestationRegistry is OwnableUpgradeable {
    * @param attestationId the attestation identifier
    * @return true if the attestation is registered, false otherwise
    */
-  function isRegistered(uint256 attestationId) public view returns (bool) {
+  function isRegistered(bytes32 attestationId) public view returns (bool) {
     return attestations[attestationId].attestationId != bytes32(0);
-  }
-
-  /**
-   * @notice Checks whether a portal issues revocable attestations
-   * @param portalId the portal address (ID)
-   * @return true if the attestations issued by this portal are revocable, false otherwise
-   */
-  function isRevocable(address portalId) public view returns (bool) {
-    PortalRegistry portalRegistry = PortalRegistry(router.getPortalRegistry());
-    return portalRegistry.getPortalByAddress(portalId).isRevocable;
   }
 
   /**

--- a/src/AttestationRegistry.sol
+++ b/src/AttestationRegistry.sol
@@ -16,7 +16,8 @@ contract AttestationRegistry is OwnableUpgradeable {
   IRouter public router;
 
   uint16 private version;
-  uint private attestationIdCounter;
+  uint256 private attestationIdCounter;
+
   mapping(bytes32 attestationId => Attestation attestation) private attestations;
 
   /// @notice Error thrown when a non-portal tries to call a method that can only be called by a portal
@@ -109,7 +110,6 @@ contract AttestationRegistry is OwnableUpgradeable {
     );
     attestations[attestation.attestationId] = attestation;
     emit AttestationRegistered(attestation);
-  }
 
   /**
    * @notice Revokes an attestation for given identifier and can replace it by an other one
@@ -165,7 +165,7 @@ contract AttestationRegistry is OwnableUpgradeable {
    * @param attestationId the attestation identifier
    * @return the attestation
    */
-  function getAttestation(uint256 attestationId) public view returns (Attestation memory) {
+  function getAttestation(bytes32 attestationId) public view returns (Attestation memory) {
     if (!isRegistered(attestationId)) revert AttestationNotAttested();
     return attestations[attestationId];
   }

--- a/src/PortalRegistry.sol
+++ b/src/PortalRegistry.sol
@@ -125,7 +125,7 @@ contract PortalRegistry is OwnableUpgradeable {
       router.getModuleRegistry(),
       router.getAttestationRegistry()
     );
-    register(address(defaultPortal), name, description, isRevocable);
+    register(address(defaultPortal), name, description, isRevocable, ownerName);
   }
 
   /**

--- a/src/PortalRegistry.sol
+++ b/src/PortalRegistry.sol
@@ -120,11 +120,8 @@ contract PortalRegistry is OwnableUpgradeable {
     bool isRevocable,
     string memory ownerName
   ) external {
-    DefaultPortal defaultPortal = new DefaultPortal(
-      modules,
-      router.getModuleRegistry(),
-      router.getAttestationRegistry()
-    );
+    DefaultPortal defaultPortal = new DefaultPortal();
+    defaultPortal.initialize(modules, router.getModuleRegistry(), router.getAttestationRegistry());
     register(address(defaultPortal), name, description, isRevocable, ownerName);
   }
 

--- a/src/PortalRegistry.sol
+++ b/src/PortalRegistry.sol
@@ -120,9 +120,12 @@ contract PortalRegistry is OwnableUpgradeable {
     bool isRevocable,
     string memory ownerName
   ) external {
-    DefaultPortal defaultPortal = new DefaultPortal();
-    defaultPortal.initialize(modules, router.getModuleRegistry(), router.getAttestationRegistry());
-    register(address(defaultPortal), name, description, isRevocable, ownerName);
+    DefaultPortal defaultPortal = new DefaultPortal(
+      modules,
+      router.getModuleRegistry(),
+      router.getAttestationRegistry()
+    );
+    register(address(defaultPortal), name, description, isRevocable);
   }
 
   /**

--- a/src/interface/AbstractPortal.sol
+++ b/src/interface/AbstractPortal.sol
@@ -5,15 +5,24 @@ import { AttestationRegistry } from "../AttestationRegistry.sol";
 import { ModuleRegistry } from "../ModuleRegistry.sol";
 import { Attestation, AttestationPayload } from "../types/Structs.sol";
 import "openzeppelin-contracts-upgradeable/contracts/utils/introspection/ERC165Upgradeable.sol";
+import { Initializable } from "openzeppelin-contracts-upgradeable/contracts/proxy/utils/Initializable.sol";
 
-abstract contract AbstractPortal is IERC165Upgradeable {
+abstract contract AbstractPortal is Initializable, IERC165Upgradeable {
   address[] public modules;
   ModuleRegistry public moduleRegistry;
   AttestationRegistry public attestationRegistry;
 
   error ModulePayloadMismatch();
 
-  constructor(address[] memory _modules, address _moduleRegistry, address _attestationRegistry) {
+  /**
+   * @notice Contract initialization
+   */
+  function initialize(
+    address[] calldata _modules,
+    address _moduleRegistry,
+    address _attestationRegistry
+  ) public initializer {
+    // Store module registry and attestation registry addresses and modules
     attestationRegistry = AttestationRegistry(_attestationRegistry);
     moduleRegistry = ModuleRegistry(_moduleRegistry);
     modules = _modules;

--- a/src/interface/AbstractPortal.sol
+++ b/src/interface/AbstractPortal.sol
@@ -1,16 +1,73 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.8.21;
 
+import { AttestationRegistry } from "../AttestationRegistry.sol";
+import { ModuleRegistry } from "../ModuleRegistry.sol";
 import { Attestation, AttestationPayload } from "../types/Structs.sol";
+import { IERC165 } from "openzeppelin-contracts/contracts/utils/introspection/ERC165.sol";
 
-//TODO: Add hooks with basic implementation
-abstract contract AbstractPortal {
+abstract contract AbstractPortal is IERC165 {
+  address[] modules;
+  ModuleRegistry moduleRegistry;
+  AttestationRegistry attestationRegistry;
+
+  error ModulePayloadMismatch();
+
+  constructor(address[] memory _modules, address _moduleRegistry, address _attestationRegistry) {
+    attestationRegistry = AttestationRegistry(_attestationRegistry);
+    moduleRegistry = ModuleRegistry(_moduleRegistry);
+    modules = _modules;
+  }
+
+  function _beforeAttest(Attestation memory attestation, uint256 value) internal virtual;
+
+  function _afterAttest(Attestation memory attestation, uint256 value) internal virtual;
+
   function attest(
     AttestationPayload memory attestationPayload,
     bytes[] memory validationPayload
-  ) external payable virtual;
+  ) external payable virtual {
+    if (modules.length != 0) _runModules(validationPayload);
+
+    Attestation memory attestation = _buildAttestation(attestationPayload);
+
+    _beforeAttest(attestation, msg.value);
+
+    attestationRegistry.attest(attestation);
+
+    _afterAttest(attestation, msg.value);
+  }
+
+  function getModules() external view returns (address[] memory) {
+    return modules;
+  }
+
+  function supportsInterface(bytes4 interfaceID) public pure override returns (bool) {
+    return interfaceID == type(AbstractPortal).interfaceId || interfaceID == type(IERC165).interfaceId;
+  }
+
+  function _buildAttestation(AttestationPayload memory attestationPayload) internal view returns (Attestation memory) {
+    uint256 attestationId = attestationRegistry.getAttestationId();
+    uint16 version = attestationRegistry.getVersionNumber();
+    return
+      Attestation(
+        attestationId,
+        attestationPayload.schemaId,
+        attestationPayload.attester,
+        address(this),
+        attestationPayload.subject,
+        block.timestamp,
+        attestationPayload.expirationDate,
+        false,
+        version,
+        attestationPayload.attestationData
+      );
+  }
 
   function revoke(bytes32 attestationId, bytes32 replacedBy) external virtual;
 
-  function getModules() external virtual returns (address[] memory);
+  function _runModules(bytes[] memory validationPayload) internal {
+    if (modules.length != validationPayload.length) revert ModulePayloadMismatch();
+    moduleRegistry.runModules(modules, validationPayload);
+  }
 }

--- a/src/interface/AbstractPortal.sol
+++ b/src/interface/AbstractPortal.sol
@@ -27,10 +27,7 @@ abstract contract AbstractPortal is IERC165Upgradeable {
    * @notice attest the schema with given attestationPayload and validationPayload
    * @dev Runs all modules for the portal and registers the attestation using AttestationRegistry
    */
-  function attest(
-    AttestationPayload memory attestationPayload,
-    bytes[] memory validationPayload
-  ) external payable virtual {
+  function attest(AttestationPayload memory attestationPayload, bytes[] memory validationPayload) external payable {
     if (modules.length != 0) _runModules(validationPayload);
 
     _beforeAttest(attestationPayload, msg.value);

--- a/src/interface/AbstractPortal.sol
+++ b/src/interface/AbstractPortal.sol
@@ -41,7 +41,7 @@ abstract contract AbstractPortal is Initializable, IERC165Upgradeable {
 
     _beforeAttest(attestationPayload, msg.value);
 
-    Attestation memory attestation = attestationRegistry.attest(attestationPayload, msg.sender);
+    Attestation memory attestation = attestationRegistry.attest(attestationPayload);
 
     _afterAttest(attestation);
   }

--- a/src/portal/DefaultPortal.sol
+++ b/src/portal/DefaultPortal.sol
@@ -38,21 +38,7 @@ contract DefaultPortal is Initializable, AbstractPortal {
 
   function _beforeAttest(AttestationPayload memory attestation, uint256 value) internal override {}
 
-  function _afterAttest(Attestation memory attestation, uint256 value) internal override {}
-
-  /**
-   * @notice attest the schema with given attestationPayload and validationPayload
-   * @dev Runs all modules for the portal and registers the attestation using AttestationRegistry
-   */
-  function attest(
-    AttestationPayload memory attestationPayload,
-    bytes[] memory validationPayload
-  ) external payable override {
-    // Run all modules
-    moduleRegistry.runModules(modules, validationPayload);
-    // Register attestation using attestation registry
-    attestationRegistry.attest(attestationPayload);
-  }
+  function _afterAttest(Attestation memory attestation) internal override {}
 
   /**
    * @notice Revokes an attestation for given identifier and can replace it by an other one
@@ -61,12 +47,5 @@ contract DefaultPortal is Initializable, AbstractPortal {
    */
   function revoke(bytes32 attestationId, bytes32 replacedBy) external override {
     attestationRegistry.revoke(attestationId, replacedBy);
-  }
-
-  /**
-   * @notice Implements supports interface method declaring it is an AbstractPortal
-   */
-  function supportsInterface(bytes4 interfaceID) public pure override returns (bool) {
-    return interfaceID == type(AbstractPortal).interfaceId || interfaceID == type(IERC165Upgradeable).interfaceId;
   }
 }

--- a/src/portal/DefaultPortal.sol
+++ b/src/portal/DefaultPortal.sol
@@ -33,13 +33,7 @@ contract DefaultPortal is Initializable, AbstractPortal, IERC165Upgradeable {
     modules = _modules;
   }
 
-  /**
-   * @notice Get all modules from the default portal clone
-   * @return The Modules
-   */
-  function getModules() external view override returns (address[] memory) {
-    return modules;
-  }
+  function _beforeAttest(Attestation memory attestation, uint256 value) internal override {}
 
   /**
    * @notice attest the schema with given attestationPayload and validationPayload
@@ -70,4 +64,6 @@ contract DefaultPortal is Initializable, AbstractPortal, IERC165Upgradeable {
   function supportsInterface(bytes4 interfaceID) public pure override returns (bool) {
     return interfaceID == type(AbstractPortal).interfaceId || interfaceID == type(IERC165Upgradeable).interfaceId;
   }
+
+  function _afterAttest(Attestation memory attestation, uint256 value) internal override {}
 }

--- a/src/portal/DefaultPortal.sol
+++ b/src/portal/DefaultPortal.sol
@@ -3,7 +3,6 @@ pragma solidity 0.8.21;
 
 import { Initializable } from "openzeppelin-contracts-upgradeable/contracts/proxy/utils/Initializable.sol";
 // solhint-disable-next-line max-line-length
-import { IERC165Upgradeable } from "openzeppelin-contracts-upgradeable/contracts/utils/introspection/ERC165Upgradeable.sol";
 import { AttestationRegistry } from "../AttestationRegistry.sol";
 import { ModuleRegistry } from "../ModuleRegistry.sol";
 import { AbstractPortal } from "../interface/AbstractPortal.sol";
@@ -14,10 +13,14 @@ import { Attestation, AttestationPayload, Portal } from "../types/Structs.sol";
  * @author Consensys
  * @notice This contract aims to provide a default portal
  */
-contract DefaultPortal is Initializable, AbstractPortal, IERC165Upgradeable {
-  address[] public modules;
-  ModuleRegistry public moduleRegistry;
-  AttestationRegistry public attestationRegistry;
+contract DefaultPortal is Initializable, AbstractPortal {
+  constructor(
+    address[] memory _modules,
+    address _moduleRegistry,
+    address _attestationRegistry
+  ) AbstractPortal(_modules, _moduleRegistry, _attestationRegistry) {
+    _disableInitializers();
+  }
 
   /**
    * @notice Contract initialization
@@ -33,7 +36,9 @@ contract DefaultPortal is Initializable, AbstractPortal, IERC165Upgradeable {
     modules = _modules;
   }
 
-  function _beforeAttest(Attestation memory attestation, uint256 value) internal override {}
+  function _beforeAttest(AttestationPayload memory attestation, uint256 value) internal override {}
+
+  function _afterAttest(Attestation memory attestation, uint256 value) internal override {}
 
   /**
    * @notice attest the schema with given attestationPayload and validationPayload
@@ -64,6 +69,4 @@ contract DefaultPortal is Initializable, AbstractPortal, IERC165Upgradeable {
   function supportsInterface(bytes4 interfaceID) public pure override returns (bool) {
     return interfaceID == type(AbstractPortal).interfaceId || interfaceID == type(IERC165Upgradeable).interfaceId;
   }
-
-  function _afterAttest(Attestation memory attestation, uint256 value) internal override {}
 }

--- a/src/portal/DefaultPortal.sol
+++ b/src/portal/DefaultPortal.sol
@@ -17,21 +17,7 @@ contract DefaultPortal is AbstractPortal {
 
   function _afterAttest(Attestation memory attestation) internal override {}
 
-  /**
-   * @notice Revokes an attestation for given identifier and can replace it by an other one
-   * @param attestationId the attestation ID to revoke
-   * @param replacedBy the replacing attestation ID
-   */
-  function revoke(bytes32 attestationId, bytes32 replacedBy) external override {
-    attestationRegistry.revoke(attestationId, replacedBy);
-  }
+  function _onRevoke(bytes32 attestationId, bytes32 replacedBy) internal override {}
 
-  /**
-   * @notice Bulk revokes attestations for given identifiers and can replace them by new ones
-   * @param attestationIds the attestations IDs to revoke
-   * @param replacedBy the replacing attestations IDs (leave an ID empty to just revoke)
-   */
-  function bulkRevoke(bytes32[] memory attestationIds, bytes32[] memory replacedBy) external override {
-    attestationRegistry.bulkRevoke(attestationIds, replacedBy);
-  }
+  function _onBulkRevoke(bytes32[] memory attestationIds, bytes32[] memory replacedBy) internal override {}
 }

--- a/src/portal/DefaultPortal.sol
+++ b/src/portal/DefaultPortal.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.8.21;
 
-import { Initializable } from "openzeppelin-contracts-upgradeable/contracts/proxy/utils/Initializable.sol";
 // solhint-disable-next-line max-line-length
 import { AttestationRegistry } from "../AttestationRegistry.sol";
 import { ModuleRegistry } from "../ModuleRegistry.sol";
@@ -13,29 +12,7 @@ import { Attestation, AttestationPayload, Portal } from "../types/Structs.sol";
  * @author Consensys
  * @notice This contract aims to provide a default portal
  */
-contract DefaultPortal is Initializable, AbstractPortal {
-  constructor(
-    address[] memory _modules,
-    address _moduleRegistry,
-    address _attestationRegistry
-  ) AbstractPortal(_modules, _moduleRegistry, _attestationRegistry) {
-    _disableInitializers();
-  }
-
-  /**
-   * @notice Contract initialization
-   */
-  function initialize(
-    address[] calldata _modules,
-    address _moduleRegistry,
-    address _attestationRegistry
-  ) public initializer {
-    // Store module registry and attestation registry addresses and modules
-    attestationRegistry = AttestationRegistry(_attestationRegistry);
-    moduleRegistry = ModuleRegistry(_moduleRegistry);
-    modules = _modules;
-  }
-
+contract DefaultPortal is AbstractPortal {
   function _beforeAttest(AttestationPayload memory attestation, uint256 value) internal override {}
 
   function _afterAttest(Attestation memory attestation) internal override {}

--- a/src/types/Structs.sol
+++ b/src/types/Structs.sol
@@ -9,7 +9,7 @@ struct AttestationPayload {
 }
 
 struct Attestation {
-  uint256 attestationId; // The unique identifier of the attestation.
+  bytes32 attestationId; // The unique identifier of the attestation.
   bytes32 schemaId; // The identifier of the schema this attestation adheres to.
   address attester; // The address issuing the attestation to the subject.
   address portal; // The id of the portal that created the attestation.

--- a/src/types/Structs.sol
+++ b/src/types/Structs.sol
@@ -9,7 +9,7 @@ struct AttestationPayload {
 }
 
 struct Attestation {
-  bytes32 attestationId; // The unique identifier of the attestation.
+  uint256 attestationId; // The unique identifier of the attestation.
   bytes32 schemaId; // The identifier of the schema this attestation adheres to.
   address attester; // The address issuing the attestation to the subject.
   address portal; // The id of the portal that created the attestation.

--- a/test/PortalRegistry.t.sol
+++ b/test/PortalRegistry.t.sol
@@ -43,7 +43,7 @@ contract PortalRegistryTest is Test {
     router.updateModuleRegistry(moduleRegistryAddress);
     router.updateAttestationRegistry(attestationRegistryAddress);
 
-    validPortal = new ValidPortal(new address[](0), moduleRegistryAddress, attestationRegistryAddress);
+    validPortal = new ValidPortal();
   }
 
   function test_alreadyInitialized() public {
@@ -153,12 +153,6 @@ contract PortalRegistryTest is Test {
 }
 
 contract ValidPortal is AbstractPortal {
-  constructor(
-    address[] memory _modules,
-    address _moduleRegistry,
-    address _attestationRegistry
-  ) AbstractPortal(_modules, _moduleRegistry, _attestationRegistry) {}
-
   function _beforeAttest(AttestationPayload memory attestationPayload, uint256 value) internal override {}
 
   function revoke(bytes32 /*attestationId*/, bytes32 /*replacedBy*/) external override {}

--- a/test/PortalRegistry.t.sol
+++ b/test/PortalRegistry.t.sol
@@ -6,7 +6,7 @@ import { Test } from "forge-std/Test.sol";
 import { PortalRegistry } from "../src/PortalRegistry.sol";
 import { AbstractPortal } from "../src/interface/AbstractPortal.sol";
 import { CorrectModule } from "../src/example/CorrectModule.sol";
-import { AttestationPayload, Portal } from "../src/types/Structs.sol";
+import { AttestationPayload, Portal, Attestation } from "../src/types/Structs.sol";
 // solhint-disable-next-line max-line-length
 import { IERC165Upgradeable } from "openzeppelin-contracts-upgradeable/contracts/utils/introspection/IERC165Upgradeable.sol";
 import { Router } from "../src/Router.sol";
@@ -42,6 +42,8 @@ contract PortalRegistryTest is Test {
 
     router.updateModuleRegistry(moduleRegistryAddress);
     router.updateAttestationRegistry(attestationRegistryAddress);
+
+    validPortal = new ValidPortal(new address[](0), moduleRegistryAddress, attestationRegistryAddress);
   }
 
   function test_alreadyInitialized() public {
@@ -150,23 +152,18 @@ contract PortalRegistryTest is Test {
   }
 }
 
-contract ValidPortal is AbstractPortal, IERC165Upgradeable {
-  function test() public {}
+contract ValidPortal is AbstractPortal {
+  constructor(
+    address[] memory _modules,
+    address _moduleRegistry,
+    address _attestationRegistry
+  ) AbstractPortal(_modules, _moduleRegistry, _attestationRegistry) {}
 
-  function _beforeAttest(Attestation memory attestation, uint256 value) internal override {}
+  function _beforeAttest(AttestationPayload memory attestationPayload, uint256 value) internal override {}
 
   function revoke(bytes32 /*attestationId*/, bytes32 /*replacedBy*/) external override {}
 
-  function getModules() external pure override returns (address[] memory) {
-    address[] memory modules = new address[](2);
-    modules[0] = address(0);
-    modules[1] = address(1);
-    return modules;
-  }
-
-  function supportsInterface(bytes4 interfaceID) external pure returns (bool) {
-    return interfaceID == type(AbstractPortal).interfaceId || interfaceID == type(IERC165Upgradeable).interfaceId;
-  }
+  function _afterAttest(Attestation memory attestation) internal override {}
 }
 
 contract InvalidPortal {

--- a/test/PortalRegistry.t.sol
+++ b/test/PortalRegistry.t.sol
@@ -22,7 +22,7 @@ contract PortalRegistryTest is Test {
   string public expectedName = "Name";
   string public expectedDescription = "Description";
   string public expectedOwnerName = "Owner Name";
-  ValidPortal public validPortal = new ValidPortal();
+  ValidPortal public validPortal;
   InvalidPortal public invalidPortal = new InvalidPortal();
 
   event Initialized(uint8 version);

--- a/test/PortalRegistry.t.sol
+++ b/test/PortalRegistry.t.sol
@@ -192,15 +192,13 @@ contract PortalRegistryTest is Test {
 }
 
 contract ValidPortal is AbstractPortal {
-  function test() public {}
-
-  function _beforeAttest(AttestationPayload memory attestationPayload, uint256 value) internal override {}
-
-  function revoke(bytes32 /*attestationId*/, bytes32 /*replacedBy*/) external override {}
+  function _beforeAttest(AttestationPayload memory attestation, uint256 value) internal override {}
 
   function _afterAttest(Attestation memory attestation) internal override {}
 
-  function bulkRevoke(bytes32[] memory /*attestationIds*/, bytes32[] memory /*replacedBy*/) external override {}
+  function _onRevoke(bytes32 attestationId, bytes32 replacedBy) internal override {}
+
+  function _onBulkRevoke(bytes32[] memory attestationIds, bytes32[] memory replacedBy) internal override {}
 }
 
 contract InvalidPortal {

--- a/test/PortalRegistry.t.sol
+++ b/test/PortalRegistry.t.sol
@@ -153,10 +153,7 @@ contract PortalRegistryTest is Test {
 contract ValidPortal is AbstractPortal, IERC165Upgradeable {
   function test() public {}
 
-  function attest(
-    AttestationPayload memory /*attestationPayload*/,
-    bytes[] memory /*validationPayload*/
-  ) external payable override {}
+  function _beforeAttest(Attestation memory attestation, uint256 value) internal override {}
 
   function revoke(bytes32 /*attestationId*/, bytes32 /*replacedBy*/) external override {}
 

--- a/test/mocks/AttestationRegistryMock.sol
+++ b/test/mocks/AttestationRegistryMock.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.21;
 import { AttestationPayload } from "../../src/types/Structs.sol";
 
 contract AttestationRegistryMock {
-  uint256 public attestationId;
+  bytes32 public _attestationId;
   uint16 public version;
 
   event AttestationRegistered();
@@ -23,8 +23,8 @@ contract AttestationRegistryMock {
     emit AttestationRevoked(attestationId, replacedBy);
   }
 
-  function getAttestationId() public view returns (uint256) {
-    return attestationId;
+  function getAttestationId() public view returns (bytes32) {
+    return _attestationId;
   }
 
   function getVersionNumber() public view returns (uint16) {

--- a/test/mocks/AttestationRegistryMock.sol
+++ b/test/mocks/AttestationRegistryMock.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.8.21;
 
-import { AttestationPayload } from "../../src/types/Structs.sol";
+import { AttestationPayload, Attestation } from "../../src/types/Structs.sol";
 
 contract AttestationRegistryMock {
   bytes32 public _attestationId;
@@ -12,9 +12,27 @@ contract AttestationRegistryMock {
 
   function test() public {}
 
-  function attest(AttestationPayload calldata attestationPayload) public {
-    require(bytes32(attestationPayload.schemaId) != 0, "Invalid attestation");
+  function attest(
+    AttestationPayload calldata attestationPayload,
+    address attester
+  ) public returns (Attestation memory) {
+    require(bytes32(attestationPayload.schemaId) != 0 && attester != address(0), "Invalid attestation");
+    Attestation memory attestation = Attestation(
+      bytes32(keccak256(abi.encode((1)))),
+      attestationPayload.schemaId,
+      attester,
+      msg.sender,
+      attestationPayload.subject,
+      block.timestamp,
+      attestationPayload.expirationDate,
+      false,
+      0,
+      bytes32(0),
+      version,
+      attestationPayload.attestationData
+    );
     emit AttestationRegistered();
+    return attestation;
   }
 
   function revoke(bytes32 attestationId, bytes32 replacedBy) public {

--- a/test/mocks/AttestationRegistryMock.sol
+++ b/test/mocks/AttestationRegistryMock.sol
@@ -4,6 +4,9 @@ pragma solidity 0.8.21;
 import { AttestationPayload } from "../../src/types/Structs.sol";
 
 contract AttestationRegistryMock {
+  uint256 public attestationId;
+  uint16 public version;
+
   event AttestationRegistered();
   event AttestationRevoked(bytes32 attestationId, bytes32 replacedBy);
 
@@ -18,5 +21,13 @@ contract AttestationRegistryMock {
     require(bytes32(attestationId) != 0, "Invalid attestation");
     require(bytes32(replacedBy) != 0, "Invalid replacement attestation");
     emit AttestationRevoked(attestationId, replacedBy);
+  }
+
+  function getAttestationId() public view returns (uint256) {
+    return attestationId;
+  }
+
+  function getVersionNumber() public view returns (uint16) {
+    return version;
   }
 }

--- a/test/mocks/AttestationRegistryMock.sol
+++ b/test/mocks/AttestationRegistryMock.sol
@@ -12,15 +12,12 @@ contract AttestationRegistryMock {
 
   function test() public {}
 
-  function attest(
-    AttestationPayload calldata attestationPayload,
-    address attester
-  ) public returns (Attestation memory) {
-    require(bytes32(attestationPayload.schemaId) != 0 && attester != address(0), "Invalid attestation");
+  function attest(AttestationPayload calldata attestationPayload) public returns (Attestation memory) {
+    require(bytes32(attestationPayload.schemaId) != 0 && tx.origin != address(0), "Invalid attestation");
     Attestation memory attestation = Attestation(
       bytes32(keccak256(abi.encode((1)))),
       attestationPayload.schemaId,
-      attester,
+      tx.origin,
       msg.sender,
       attestationPayload.subject,
       block.timestamp,

--- a/test/mocks/ModuleRegistryMock.sol
+++ b/test/mocks/ModuleRegistryMock.sol
@@ -7,8 +7,5 @@ contract ModuleRegistryMock {
 
   function test() public {}
 
-  function runModules(address[] memory modulesAddresses, bytes[] memory validationPayload) public {
-    require(modulesAddresses.length > 0 && validationPayload.length >= 0, "Invalid input");
-    emit ModulesRunForAttestation();
-  }
+  function runModules(address[] memory modulesAddresses, bytes[] memory validationPayload) public {}
 }

--- a/test/portal/DefaultPortal.t.sol
+++ b/test/portal/DefaultPortal.t.sol
@@ -25,8 +25,14 @@ contract DefaultPortalTest is Test {
   event AttestationRevoked(bytes32 attestationId, bytes32 replacedBy);
 
   function setUp() public {
-    defaultPortal = new DefaultPortal(modules, address(moduleRegistryMock), address(attestationRegistryMock));
     modules.push(address(correctModule));
+    defaultPortal = new DefaultPortal(modules, address(moduleRegistryMock), address(attestationRegistryMock));
+  }
+
+  function test_setup() public {
+    assertEq(address(defaultPortal.modules(0)), address(modules[0]));
+    assertEq(address(defaultPortal.moduleRegistry()), address(moduleRegistryMock));
+    assertEq(address(defaultPortal.attestationRegistry()), address(attestationRegistryMock));
   }
 
   function test_initialize() public {
@@ -35,35 +41,26 @@ contract DefaultPortalTest is Test {
   }
 
   function test_getModules() public {
-    vm.expectEmit();
-    emit Initialized(1);
-    defaultPortal.initialize(modules, address(1), address(2));
-
     address[] memory _modules = defaultPortal.getModules();
     assertEq(_modules, modules);
   }
 
-  function test_attest() public {
-    vm.expectEmit();
-    emit Initialized(1);
-    defaultPortal.initialize(modules, address(moduleRegistryMock), address(attestationRegistryMock));
-
-    // Create attestation payload
-    AttestationPayload memory attestationPayload = AttestationPayload(
-      bytes32(uint256(1)),
-      bytes("subject"),
-      block.timestamp + 1 days,
-      new bytes(1)
-    );
-    // Create validation payload
-    bytes[] memory validationPayload = new bytes[](0);
-
-    vm.expectEmit(true, true, true, true);
-    emit ModulesRunForAttestation();
-    vm.expectEmit(true, true, true, true);
-    emit AttestationRegistered();
-    defaultPortal.attest(attestationPayload, validationPayload);
-  }
+  // function test_attest() public {
+  //   // Create attestation payload
+  //   AttestationPayload memory attestationPayload = AttestationPayload(
+  //     bytes32(uint256(1)),
+  //     bytes("subject"),
+  //     block.timestamp + 1 days,
+  //     new bytes(1)
+  //   );
+  //   // Create validation payload
+  //   bytes[] memory validationPayload = new bytes[](2);
+  //   // vm.expectEmit(true, true, true, true);
+  //   // emit ModulesRunForAttestation();
+  //   // vm.expectEmit(true, true, true, true);
+  //   // emit AttestationRegistered();
+  //   defaultPortal.attest(attestationPayload, validationPayload);
+  // }
 
   function test_revoke() public {
     vm.expectEmit();

--- a/test/portal/DefaultPortal.t.sol
+++ b/test/portal/DefaultPortal.t.sol
@@ -25,15 +25,11 @@ contract DefaultPortalTest is Test {
   event AttestationRevoked(bytes32 attestationId, bytes32 replacedBy);
 
   function setUp() public {
-    defaultPortal = new DefaultPortal();
+    defaultPortal = new DefaultPortal(modules, address(moduleRegistryMock), address(attestationRegistryMock));
     modules.push(address(correctModule));
   }
 
   function test_initialize() public {
-    vm.expectEmit();
-    emit Initialized(1);
-    defaultPortal.initialize(modules, address(1), address(2));
-
     vm.expectRevert("Initializable: contract is already initialized");
     defaultPortal.initialize(modules, address(1), address(2));
   }

--- a/test/portal/DefaultPortal.t.sol
+++ b/test/portal/DefaultPortal.t.sol
@@ -45,22 +45,20 @@ contract DefaultPortalTest is Test {
     assertEq(_modules, modules);
   }
 
-  // function test_attest() public {
-  //   // Create attestation payload
-  //   AttestationPayload memory attestationPayload = AttestationPayload(
-  //     bytes32(uint256(1)),
-  //     bytes("subject"),
-  //     block.timestamp + 1 days,
-  //     new bytes(1)
-  //   );
-  //   // Create validation payload
-  //   bytes[] memory validationPayload = new bytes[](2);
-  //   // vm.expectEmit(true, true, true, true);
-  //   // emit ModulesRunForAttestation();
-  //   // vm.expectEmit(true, true, true, true);
-  //   // emit AttestationRegistered();
-  //   defaultPortal.attest(attestationPayload, validationPayload);
-  // }
+  function test_attest() public {
+    // Create attestation payload
+    AttestationPayload memory attestationPayload = AttestationPayload(
+      bytes32(uint256(1)),
+      bytes("subject"),
+      block.timestamp + 1 days,
+      new bytes(1)
+    );
+    // Create validation payload
+    bytes[] memory validationPayload = new bytes[](2);
+    vm.expectEmit(true, true, true, true);
+    emit AttestationRegistered();
+    defaultPortal.attest(attestationPayload, validationPayload);
+  }
 
   function test_revoke() public {
     vm.expectEmit(true, true, true, true);

--- a/test/portal/DefaultPortal.t.sol
+++ b/test/portal/DefaultPortal.t.sol
@@ -63,10 +63,6 @@ contract DefaultPortalTest is Test {
   // }
 
   function test_revoke() public {
-    vm.expectEmit();
-    emit Initialized(1);
-    defaultPortal.initialize(modules, address(moduleRegistryMock), address(attestationRegistryMock));
-
     vm.expectEmit(true, true, true, true);
     emit AttestationRevoked(bytes32("1"), bytes32("2"));
     defaultPortal.revoke(bytes32("1"), bytes32("2"));

--- a/test/portal/DefaultPortal.t.sol
+++ b/test/portal/DefaultPortal.t.sol
@@ -26,7 +26,8 @@ contract DefaultPortalTest is Test {
 
   function setUp() public {
     modules.push(address(correctModule));
-    defaultPortal = new DefaultPortal(modules, address(moduleRegistryMock), address(attestationRegistryMock));
+    defaultPortal = new DefaultPortal();
+    defaultPortal.initialize(modules, address(moduleRegistryMock), address(attestationRegistryMock));
   }
 
   function test_setup() public {

--- a/test/portal/EASPortal.t.sol
+++ b/test/portal/EASPortal.t.sol
@@ -30,26 +30,26 @@ contract EASPortalTest is Test {
     easPortal.initialize(address(1));
   }
 
-  function test_attest() public {
-    vm.expectEmit();
-    emit Initialized(1);
-    easPortal.initialize(address(attestationRegistryMock));
+  // function test_attest() public {
+  //   vm.expectEmit();
+  //   emit Initialized(1);
+  //   easPortal.initialize(address(attestationRegistryMock));
 
-    // Create EAS attestation request
-    AttestationRequestData memory attestationRequestData = AttestationRequestData(
-      makeAddr("recipient"),
-      uint64(block.timestamp + 1 days),
-      false,
-      bytes32("refUID"),
-      new bytes(0),
-      uint256(1)
-    );
-    AttestationRequest memory attestationRequest = AttestationRequest(bytes32(uint256(1)), attestationRequestData);
+  //   // Create EAS attestation request
+  //   AttestationRequestData memory attestationRequestData = AttestationRequestData(
+  //     makeAddr("recipient"),
+  //     uint64(block.timestamp + 1 days),
+  //     false,
+  //     bytes32("refUID"),
+  //     new bytes(0),
+  //     uint256(1)
+  //   );
+  //   AttestationRequest memory attestationRequest = AttestationRequest(bytes32(uint256(1)), attestationRequestData);
 
-    vm.expectEmit(true, true, true, true);
-    emit AttestationRegistered();
-    easPortal.attest(attestationRequest);
-  }
+  //   vm.expectEmit(true, true, true, true);
+  //   emit AttestationRegistered();
+  //   easPortal.attest(attestationRequest);
+  // }
 
   function testSupportsInterface() public {
     bool isIERC165Supported = easPortal.supportsInterface(type(ERC165Upgradeable).interfaceId);

--- a/test/portal/EASPortal.t.sol
+++ b/test/portal/EASPortal.t.sol
@@ -30,26 +30,26 @@ contract EASPortalTest is Test {
     easPortal.initialize(address(1));
   }
 
-  // function test_attest() public {
-  //   vm.expectEmit();
-  //   emit Initialized(1);
-  //   easPortal.initialize(address(attestationRegistryMock));
+  function test_attest() public {
+    vm.expectEmit();
+    emit Initialized(1);
+    easPortal.initialize(address(attestationRegistryMock));
 
-  //   // Create EAS attestation request
-  //   AttestationRequestData memory attestationRequestData = AttestationRequestData(
-  //     makeAddr("recipient"),
-  //     uint64(block.timestamp + 1 days),
-  //     false,
-  //     bytes32("refUID"),
-  //     new bytes(0),
-  //     uint256(1)
-  //   );
-  //   AttestationRequest memory attestationRequest = AttestationRequest(bytes32(uint256(1)), attestationRequestData);
+    // Create EAS attestation request
+    AttestationRequestData memory attestationRequestData = AttestationRequestData(
+      makeAddr("recipient"),
+      uint64(block.timestamp + 1 days),
+      false,
+      bytes32("refUID"),
+      new bytes(0),
+      uint256(1)
+    );
+    AttestationRequest memory attestationRequest = AttestationRequest(bytes32(uint256(1)), attestationRequestData);
 
-  //   vm.expectEmit(true, true, true, true);
-  //   emit AttestationRegistered();
-  //   easPortal.attest(attestationRequest);
-  // }
+    vm.expectEmit(true, true, true, true);
+    emit AttestationRegistered();
+    easPortal.attest(attestationRequest);
+  }
 
   function testSupportsInterface() public {
     bool isIERC165Supported = easPortal.supportsInterface(type(ERC165Upgradeable).interfaceId);


### PR DESCRIPTION
## What does this PR do?

Moves Portal logic for the attest function into internal functions in the abstract contract to enforce correct Portal Behaviours.
Adds lifecycle hooks to Portals.
Changes attestationId to uint256 that increments.
Removes attestationId from AttestationPayload.
Removes version from AttestationPayload.

### Related ticket

Fixes #96

### Type of change

- [ ] Chore
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update

## Check list

- [x] Unit tests for any smart contract change
- [ ] Contracts and functions are documented
