### PR TITLE
Update AttestationRegistry.sol: Gas Optimizations

### DIFF
--- a/src/AttestationRegistry.sol
+++ b/src/AttestationRegistry.sol
@@ -15,9 +15,9 @@ import { IRouter } from "./interface/IRouter.sol";
 contract AttestationRegistry is OwnableUpgradeable {
   IRouter public router;
 
-  mapping(bytes32 attestationId => Attestation attestation) private attestations;
-
   uint16 private version;
+
+  mapping(bytes32 attestationId => Attestation attestation) private attestations;
 
   /// @notice Error thrown when a non-portal tries to call a method that can only be called by a portal
   error OnlyPortal();


### PR DESCRIPTION
As defined in the title, these changes let the EVM store fewer slots of data and save gas.
Take a look at this and then there be gonna a brief explanation about it:

![Screenshot (15)](https://github.com/Consensys/linea-attestation-registry/assets/88618913/ae0021d7-fc51-4ace-adca-c87eafab3182)

Usually, the EVM stores the state variables in slots and there are total 2**256 slots per contract as far I am concerned. In each slot, only 32 bytes of data is allowed and these slots costs gas. Thus, more the slots, more the amount you be paying for it.
In order to use less slots as possible, we should practice optimized ordering of state variables. Let me show you how:

Suppose I got a contract and there's 3 state variables in it, uint256, address or interface type address (like it's in the file) and a bool

```
// this contract used up 3 slots
contract demo1{
    address public owner; // takes up 20 bytes of data - slot 0
    uint256 public myNum; // takes up 32 bytes of data - slot 1
    bool public isPassed; // takes up 1 byte of data - slot 3
}
```
As you see in the above contract, first slot takes up 20 bytes of data and is left with 12 bytes, which wasn't sufficient for `myNum` and it got another slot i.e `slot1`. Lastly, boolean value was left with no choice other than occupying one more slot with 31 bytes of space left.
What if we order our variables like this:

```
contract demo2{
    address public owner; // takes up 20 bytes - slot 0
    bool public isPassed; // takes up 1 byte - slot 0
    uint256 public myNum; // takes up 32 bytes - slot 1
}
```
Like this we used 1 slot less.

This is what I did in the code, `IRouter` is a type of address in the form of interface and hence covers up 20 bytes, and `uint16` covers up 2 bytes (uint256 -> 256 / 8 => 32, similarly   uint16 -> 16/8 => 2) 😄

For more detail, refer this -> https://coinsbench.com/solidity-layout-and-access-of-storage-variables-simply-explained-1ce964d7c738