### PR TITLE
feat: As an Attestation Issuer, I want to revoke an Attestation I issued

### DIFF
--- a/remappings.txt
+++ b/remappings.txt
@@ -2,5 +2,4 @@ ds-test/=lib/forge-std/lib/ds-test/src/
 erc4626-tests/=lib/openzeppelin-contracts-upgradeable/lib/erc4626-tests/
 forge-std/=lib/forge-std/src/
 openzeppelin-contracts-upgradeable/=lib/openzeppelin-contracts-upgradeable/
-openzeppelin-contracts/=lib/openzeppelin-contracts/
 openzeppelin/=lib/openzeppelin-contracts-upgradeable/contracts/

--- a/src/AttestationRegistry.sol
+++ b/src/AttestationRegistry.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.21;
 
 import { OwnableUpgradeable } from "openzeppelin-contracts-upgradeable/contracts/access/OwnableUpgradeable.sol";
-import { Attestation, AttestationPayload } from "./types/Structs.sol";
+import { Attestation, AttestationPayload, Portal } from "./types/Structs.sol";
 import { PortalRegistry } from "./PortalRegistry.sol";
 import { SchemaRegistry } from "./SchemaRegistry.sol";
 import { IRouter } from "./interface/IRouter.sol";
@@ -27,11 +27,15 @@ contract AttestationRegistry is OwnableUpgradeable {
   error AttestationNotAttested();
   /// @notice Error thrown when an attempt is made to revoke an attestation by an entity other than the attesting portal
   error OnlyAttestingPortal();
+  /// @notice Error thrown when an attempt is made to revoke an attestation by someone else than the orignal attester
+  error OnlyAttester();
+  /// @notice Error thrown when an attempt is made to revoke an attestation based on a non-revocable schema
+  error AttestationNotRevocable();
 
   /// @notice Event emitted when an attestation is registered
   event AttestationRegistered(Attestation attestation);
   /// @notice Event emitted when an attestation is revoked
-  event AttestationRevoked(bytes32 attestationId);
+  event AttestationRevoked(bytes32 attestationId, bytes32 replacedBy);
 
   /// @notice Event emitted when the version number is incremented
   event VersionUpdated(uint16 version);
@@ -92,16 +96,22 @@ contract AttestationRegistry is OwnableUpgradeable {
   }
 
   /**
-   * @notice Revokes an attestation of given identifier
-   * @param attestationId the attestation identifier
+   * @notice Revokes an attestation for given identifier and can replace it by an other one
+   * @param attestationId the attestation ID to revoke
+   * @param replacedBy the replacing attestation ID (leave empty to just revoke)
    */
-  function revoke(bytes32 attestationId) external {
+  function revoke(bytes32 attestationId, bytes32 replacedBy) external {
     if (!isRegistered(attestationId)) revert AttestationNotAttested();
     if (msg.sender != attestations[attestationId].portal) revert OnlyAttestingPortal();
+    if (tx.origin != attestations[attestationId].attester) revert OnlyAttester();
+    if (!isRevocable(attestations[attestationId].portal)) revert AttestationNotRevocable();
 
     attestations[attestationId].revoked = true;
+    attestations[attestationId].revocationDate = block.timestamp;
 
-    emit AttestationRevoked(attestationId);
+    if (isRegistered(replacedBy)) attestations[attestationId].replacedBy = replacedBy;
+
+    emit AttestationRevoked(attestationId, replacedBy);
   }
 
   /**
@@ -111,6 +121,16 @@ contract AttestationRegistry is OwnableUpgradeable {
    */
   function isRegistered(bytes32 attestationId) public view returns (bool) {
     return attestations[attestationId].attestationId != bytes32(0);
+  }
+
+  /**
+   * @notice Checks whether a portal issues revocable attestations
+   * @param portalId the portal address (ID)
+   * @return true if the attestations issued by this portal are revocable, false otherwise
+   */
+  function isRevocable(address portalId) public view returns (bool) {
+    PortalRegistry portalRegistry = PortalRegistry(router.getPortalRegistry());
+    return portalRegistry.getPortalByAddress(portalId).isRevocable;
   }
 
   /**

--- a/src/PortalRegistry.sol
+++ b/src/PortalRegistry.sol
@@ -64,8 +64,9 @@ contract PortalRegistry is OwnableUpgradeable {
    * @param id the portal address
    * @param name the portal name
    * @param description the portal description
+   * @param isRevocable whether the portal issues revocable attestations
    */
-  function register(address id, string memory name, string memory description) public {
+  function register(address id, string memory name, string memory description, bool isRevocable) public {
     // Check if portal already exists
     if (portals[id].id != address(0)) revert PortalAlreadyExists();
 
@@ -85,7 +86,7 @@ contract PortalRegistry is OwnableUpgradeable {
     address[] memory modules = AbstractPortal(id).getModules();
 
     // Add portal to mapping
-    Portal memory newPortal = Portal(id, name, description, modules);
+    Portal memory newPortal = Portal(id, name, description, modules, isRevocable);
     portals[id] = newPortal;
     portalAddresses.push(id);
 
@@ -99,10 +100,15 @@ contract PortalRegistry is OwnableUpgradeable {
    * @param name the portal name
    * @param description the portal description
    */
-  function deployDefaultPortal(address[] calldata modules, string memory name, string memory description) external {
+  function deployDefaultPortal(
+    address[] calldata modules,
+    string memory name,
+    string memory description,
+    bool isRevocable
+  ) external {
     DefaultPortal defaultPortal = new DefaultPortal();
     defaultPortal.initialize(modules, router.getModuleRegistry(), router.getAttestationRegistry());
-    register(address(defaultPortal), name, description);
+    register(address(defaultPortal), name, description, isRevocable);
   }
 
   /**

--- a/src/interface/AbstractPortal.sol
+++ b/src/interface/AbstractPortal.sol
@@ -10,5 +10,7 @@ abstract contract AbstractPortal {
     bytes[] memory validationPayload
   ) external payable virtual;
 
+  function revoke(bytes32 attestationId, bytes32 replacedBy) external virtual;
+
   function getModules() external virtual returns (address[] memory);
 }

--- a/src/portal/DefaultPortal.sol
+++ b/src/portal/DefaultPortal.sol
@@ -56,6 +56,15 @@ contract DefaultPortal is Initializable, AbstractPortal, IERC165Upgradeable {
   }
 
   /**
+   * @notice Revokes an attestation for given identifier and can replace it by an other one
+   * @param attestationId the attestation ID to revoke
+   * @param replacedBy the replacing attestation ID
+   */
+  function revoke(bytes32 attestationId, bytes32 replacedBy) external override {
+    attestationRegistry.revoke(attestationId, replacedBy);
+  }
+
+  /**
    * @notice Implements supports interface method declaring it is an AbstractPortal
    */
   function supportsInterface(bytes4 interfaceID) public pure override returns (bool) {

--- a/src/types/Structs.sol
+++ b/src/types/Structs.sol
@@ -17,13 +17,15 @@ struct Attestation {
   uint256 attestedDate; // The date the attestation is issued.
   uint256 expirationDate; // The expiration date of the attestation.
   bool revoked; // Whether the attestation is revoked or not.
+  uint256 revocationDate; // The date when the attestation was revoked.
+  bytes32 replacedBy; // Whether the attestation was replaced by a new one.
   uint16 version; // Version of the registry when the attestation was created.
   bytes attestationData; // The attestation data.
 }
 
 struct Schema {
-  string context; // The context of the schema.
   string name; // The name of the schema.
+  string context; // The context of the schema.
   string description; // A description of the schema.
   string schema; // The schema definition.
 }
@@ -33,6 +35,7 @@ struct Portal {
   string name; // The name of the portal.
   string description; // A description of the portal.
   address[] modules; // Addresses of modules implemented by the portal.
+  bool isRevocable; // Whether attestations issued can be revoked.
 }
 
 struct Module {

--- a/test/AttestationRegistry.t.sol
+++ b/test/AttestationRegistry.t.sol
@@ -7,7 +7,7 @@ import { AttestationRegistry } from "../src/AttestationRegistry.sol";
 import { PortalRegistryMock } from "./mocks/PortalRegistryMock.sol";
 import { PortalRegistry } from "../src/PortalRegistry.sol";
 import { SchemaRegistryMock } from "./mocks/SchemaRegistryMock.sol";
-import { Attestation, AttestationPayload } from "../src/types/Structs.sol";
+import { Attestation, AttestationPayload, Portal } from "../src/types/Structs.sol";
 import { Router } from "../src/Router.sol";
 
 contract AttestationRegistryTest is Test {
@@ -20,7 +20,7 @@ contract AttestationRegistryTest is Test {
 
   event Initialized(uint8 version);
   event AttestationRegistered(Attestation attestation);
-  event AttestationRevoked(bytes32 attestationId);
+  event AttestationRevoked(bytes32 attestationId, bytes32 replacedBy);
   event VersionUpdated(uint16 version);
 
   function setUp() public {
@@ -38,7 +38,7 @@ contract AttestationRegistryTest is Test {
     router.updatePortalRegistry(portalRegistryAddress);
     router.updateSchemaRegistry(schemaRegistryAddress);
 
-    PortalRegistry(portalRegistryAddress).register(portal, "Portal", "Portal");
+    PortalRegistry(portalRegistryAddress).register(portal, "Name", "Description", true);
   }
 
   function test_initialize_ContractAlreadyInitialized() public {
@@ -95,21 +95,40 @@ contract AttestationRegistryTest is Test {
 
   function test_revoke(AttestationPayload memory attestationPayload) public {
     uint attestationIdCounter = attestationRegistry.getAttestationIdCounter();
+
+  vm.assume(attestation.attestationId != bytes32(0));
+    attestation.portal = portal;
+    attestation.attester = tx.origin;
+    attestation.revoked = false;
+    attestation.revocationDate = 0;
+    attestation.replacedBy = bytes32(0);
+
     vm.startPrank(portal);
     attestationRegistry.attest(attestationPayload, user);
     bytes32 attestationId = bytes32(keccak256(abi.encode((attestationIdCounter))));
+
+    // Assert initial state is a valid attestation
+    Attestation memory registeredAttestation = attestationRegistry.getAttestation(attestation.attestationId);
+    assertFalse(registeredAttestation.revoked);
+    assertEq(registeredAttestation.revocationDate, 0);
+    assertEq(registeredAttestation.replacedBy, bytes32(0));
+
+    // Do revoke the attestation
     vm.expectEmit(true, true, true, true);
-    emit AttestationRevoked(attestationId);
-    attestationRegistry.revoke(attestationId);
+    emit AttestationRevoked(attestationId, bytes32(0));
+    attestationRegistry.revoke(attestationId, bytes32(0));
     vm.stopPrank();
 
-    Attestation memory registeredAttestation = attestationRegistry.getAttestation(attestationId);
-    assertEq(registeredAttestation.revoked, true);
+    // Assert final state is a revoked attestation
+    Attestation memory revokedAttestation = attestationRegistry.getAttestation(attestationId);
+    assertTrue(revokedAttestation.revoked);
+    assertEq(revokedAttestation.revocationDate, block.timestamp);
+    assertEq(revokedAttestation.replacedBy, bytes32(0));
   }
 
   function test_revoke_AttestationNotAttested() public {
     vm.expectRevert(AttestationRegistry.AttestationNotAttested.selector);
-    attestationRegistry.revoke(bytes32(uint256(1)));
+    attestationRegistry.revoke(bytes32(uint256(1)),"");
   }
 
   function test_revoke_OnlyAttestingPortal(AttestationPayload memory attestationPayload) public {
@@ -132,12 +151,84 @@ contract AttestationRegistryTest is Test {
 
     vm.expectRevert(AttestationRegistry.OnlyAttestingPortal.selector);
     vm.prank(user);
-    attestationRegistry.revoke(attestation.attestationId);
+    attestationRegistry.revoke(attestation.attestationId, "");
+  }
+
+  function test_revoke_AttestationNotRevocable(Attestation memory attestation) public {
+    address nonRevocablePortalAddress = makeAddr("portal2");
+    PortalRegistry(portalRegistryAddress).register(nonRevocablePortalAddress, "Name", "Description", false);
+
+    vm.assume(attestation.attestationId != bytes32(0));
+    attestation.portal = nonRevocablePortalAddress;
+    attestation.attester = tx.origin;
+    attestation.revoked = false;
+    attestation.revocationDate = 0;
+    attestation.replacedBy = bytes32(0);
+
+    vm.startPrank(nonRevocablePortalAddress);
+    attestationRegistry.attest(attestation);
+
+    vm.expectRevert(AttestationRegistry.AttestationNotRevocable.selector);
+    attestationRegistry.revoke(attestation.attestationId, "");
+    vm.stopPrank();
+  }
+
+  function test_revoke_OnlyAttester(Attestation memory attestation) public {
+    attestation.portal = portal;
+    attestation.attester = user;
+
+    vm.startPrank(portal);
+    attestationRegistry.attest(attestation);
+
+    vm.expectRevert(AttestationRegistry.OnlyAttester.selector);
+    attestationRegistry.revoke(attestation.attestationId, "");
+    vm.stopPrank();
+  }
+
+  function test_revokeAndReplace(
+    Attestation memory attestationOrigin,
+    Attestation memory attestationReplacement
+  ) public {
+    vm.assume(attestationOrigin.attestationId != bytes32(0));
+    attestationOrigin.portal = portal;
+    attestationOrigin.attester = tx.origin;
+    attestationOrigin.revoked = false;
+    attestationOrigin.revocationDate = 0;
+    attestationOrigin.replacedBy = bytes32(0);
+
+    vm.startPrank(portal);
+    attestationRegistry.attest(attestationOrigin);
+    attestationRegistry.attest(attestationReplacement);
+
+    // Do revert and replace the attestation
+    vm.expectEmit(true, true, true, true);
+    emit AttestationRevoked(attestationOrigin.attestationId, attestationReplacement.attestationId);
+    attestationRegistry.revoke(attestationOrigin.attestationId, attestationReplacement.attestationId);
+    vm.stopPrank();
+
+    // Assert final state is a revoked and replaced attestation
+    Attestation memory revokedAttestation = attestationRegistry.getAttestation(attestationOrigin.attestationId);
+    assertTrue(revokedAttestation.revoked);
+    assertEq(revokedAttestation.revocationDate, block.timestamp);
+    assertEq(revokedAttestation.replacedBy, attestationReplacement.attestationId);
+  }
+
+  function test_isRevocable() public {
+    bool isRevocable = attestationRegistry.isRevocable(portal);
+    assertTrue(isRevocable);
+  }
+
+  function test_isNotRevocable() public {
+    address nonRevocablePortal = makeAddr("nonRevocablePortal");
+    PortalRegistry(portalRegistryAddress).register(nonRevocablePortal, "Name", "Description", false);
+
+    bool isRevocable = attestationRegistry.isRevocable(nonRevocablePortal);
+    assertFalse(isRevocable);
   }
 
   function test_isRegistered(AttestationPayload memory attestationPayload) public {
     bool isRegistered = attestationRegistry.isRegistered(bytes32(uint256(1)));
-    assertEq(isRegistered, false);
+    assertFalse(isRegistered);
 
     uint attestationIdCounter = attestationRegistry.getAttestationIdCounter();
     uint16 versionNumber = attestationRegistry.getVersionNumber();
@@ -158,7 +249,10 @@ contract AttestationRegistryTest is Test {
     attestationRegistry.attest(attestationPayload, user);
 
     isRegistered = attestationRegistry.isRegistered(attestation.attestationId);
-    assertEq(isRegistered, true);
+    assertTrue(isRegistered);
+
+    isRegistered = attestationRegistry.isRegistered(bytes32(0));
+    assertFalse(isRegistered);
   }
 
   function test_getAttestation(AttestationPayload memory attestationPayload) public {

--- a/test/PortalRegistry.t.sol
+++ b/test/PortalRegistry.t.sol
@@ -68,7 +68,7 @@ contract PortalRegistryTest is Test {
   function test_register() public {
     vm.expectEmit();
     emit PortalRegistered(expectedName, expectedDescription, address(validPortal));
-    portalRegistry.register(address(validPortal), expectedName, expectedDescription);
+    portalRegistry.register(address(validPortal), expectedName, expectedDescription, true);
 
     uint256 portalCount = portalRegistry.getPortalsCount();
     assertEq(portalCount, 1);
@@ -80,39 +80,39 @@ contract PortalRegistryTest is Test {
   }
 
   function test_register_PortalAlreadyExists() public {
-    portalRegistry.register(address(validPortal), expectedName, expectedDescription);
+    portalRegistry.register(address(validPortal), expectedName, expectedDescription, true);
     vm.expectRevert(PortalRegistry.PortalAlreadyExists.selector);
-    portalRegistry.register(address(validPortal), expectedName, expectedDescription);
+    portalRegistry.register(address(validPortal), expectedName, expectedDescription, true);
   }
 
   function test_register_PortalAddressInvalid() public {
     vm.expectRevert(PortalRegistry.PortalAddressInvalid.selector);
-    portalRegistry.register(address(0), expectedName, expectedDescription);
+    portalRegistry.register(address(0), expectedName, expectedDescription, true);
 
     vm.expectRevert(PortalRegistry.PortalAddressInvalid.selector);
-    portalRegistry.register(user, expectedName, expectedDescription);
+    portalRegistry.register(user, expectedName, expectedDescription, true);
   }
 
   function test_register_PortalNameMissing() public {
     vm.expectRevert(PortalRegistry.PortalNameMissing.selector);
-    portalRegistry.register(address(validPortal), "", expectedDescription);
+    portalRegistry.register(address(validPortal), "", expectedDescription, true);
   }
 
   function test_register_PortalDescriptionMissing() public {
     vm.expectRevert(PortalRegistry.PortalDescriptionMissing.selector);
-    portalRegistry.register(address(validPortal), expectedName, "");
+    portalRegistry.register(address(validPortal), expectedName, "", true);
   }
 
   function test_register_PortalInvalid() public {
     vm.expectRevert(PortalRegistry.PortalInvalid.selector);
-    portalRegistry.register(address(invalidPortal), expectedName, expectedDescription);
+    portalRegistry.register(address(invalidPortal), expectedName, expectedDescription, true);
   }
 
   function test_deployDefaultPortal() public {
     CorrectModule correctModule = new CorrectModule();
     address[] memory modules = new address[](1);
     modules[0] = address(correctModule);
-    portalRegistry.deployDefaultPortal(modules, expectedName, expectedDescription);
+    portalRegistry.deployDefaultPortal(modules, expectedName, expectedDescription, true);
   }
 
   function test_getPortals_PortalNotRegistered() public {
@@ -122,7 +122,7 @@ contract PortalRegistryTest is Test {
 
   function test_isRegistered() public {
     assertEq(portalRegistry.isRegistered(address(validPortal)), false);
-    portalRegistry.register(address(validPortal), expectedName, expectedDescription);
+    portalRegistry.register(address(validPortal), expectedName, expectedDescription, true);
     assertEq(portalRegistry.isRegistered(address(validPortal)), true);
   }
 }
@@ -134,6 +134,8 @@ contract ValidPortal is AbstractPortal, IERC165Upgradeable {
     AttestationPayload memory /*attestationPayload*/,
     bytes[] memory /*validationPayload*/
   ) external payable override {}
+
+  function revoke(bytes32 /*attestationId*/, bytes32 /*replacedBy*/) external override {}
 
   function getModules() external pure override returns (address[] memory) {
     address[] memory modules = new address[](2);

--- a/test/mocks/AttestationRegistryMock.sol
+++ b/test/mocks/AttestationRegistryMock.sol
@@ -1,14 +1,22 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.8.21;
+
 import { AttestationPayload } from "../../src/types/Structs.sol";
 
 contract AttestationRegistryMock {
   event AttestationRegistered();
+  event AttestationRevoked(bytes32 attestationId, bytes32 replacedBy);
 
   function test() public {}
 
   function attest(AttestationPayload calldata attestationPayload, address attester) public {
     require(bytes32(attestationPayload.schemaId) != 0 && attester != address(0), "Invalid attestation");
     emit AttestationRegistered();
+  }
+
+  function revoke(bytes32 attestationId, bytes32 replacedBy) public {
+    require(bytes32(attestationId) != 0, "Invalid attestation");
+    require(bytes32(replacedBy) != 0, "Invalid replacement attestation");
+    emit AttestationRevoked(attestationId, replacedBy);
   }
 }

--- a/test/mocks/PortalRegistryMock.sol
+++ b/test/mocks/PortalRegistryMock.sol
@@ -1,18 +1,26 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.8.21;
 
+import { Portal } from "../../src/types/Structs.sol";
+
 contract PortalRegistryMock {
   event PortalRegistered(string name, string description, address portalAddress);
-  mapping(address id => bool registered) public portals;
+
+  mapping(address id => Portal portal) private portals;
 
   function test() public {}
 
-  function register(address id, string memory name, string memory description) external {
-    portals[id] = true;
+  function register(address id, string memory name, string memory description, bool isRevocable) external {
+    Portal memory newPortal = Portal(id, name, description, new address[](0), isRevocable);
+    portals[id] = newPortal;
     emit PortalRegistered(name, description, id);
   }
 
   function isRegistered(address id) public view returns (bool) {
+    return portals[id].id != address(0);
+  }
+
+  function getPortalByAddress(address id) public view returns (Portal memory) {
     return portals[id];
   }
 }

--- a/test/portal/DefaultPortal.t.sol
+++ b/test/portal/DefaultPortal.t.sol
@@ -22,6 +22,7 @@ contract DefaultPortalTest is Test {
   event PortalRegistered(string name, string description, address portalAddress);
   event ModulesRunForAttestation();
   event AttestationRegistered();
+  event AttestationRevoked(bytes32 attestationId, bytes32 replacedBy);
 
   function setUp() public {
     defaultPortal = new DefaultPortal();
@@ -66,6 +67,16 @@ contract DefaultPortalTest is Test {
     vm.expectEmit(true, true, true, true);
     emit AttestationRegistered();
     defaultPortal.attest(attestationPayload, validationPayload);
+  }
+
+  function test_revoke() public {
+    vm.expectEmit();
+    emit Initialized(1);
+    defaultPortal.initialize(modules, address(moduleRegistryMock), address(attestationRegistryMock));
+
+    vm.expectEmit(true, true, true, true);
+    emit AttestationRevoked(bytes32("1"), bytes32("2"));
+    defaultPortal.revoke(bytes32("1"), bytes32("2"));
   }
 
   function testSupportsInterface() public {


### PR DESCRIPTION
## What does this PR do?

Adds a `revoke` method to revoke (and potentially replace) an attestation

### Related ticket

Fixes #31 

### Type of change

- [ ] Chore
- [ ] Bug fix
- [X] New feature
- [ ] Documentation update

## Check list

- [X] Unit tests for any smart contract change
- [X] Contracts and functions are documented
