### PR TITLE
feat: As a Dev, I want the EASPortal to be based on the AbstractPortal

### DIFF
--- a/src/portal/EASPortal.sol
+++ b/src/portal/EASPortal.sol
@@ -1,69 +1,81 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.21;
 
-import { Initializable } from "openzeppelin-contracts-upgradeable/contracts/proxy/utils/Initializable.sol";
 // solhint-disable-next-line max-line-length
-import { IERC165Upgradeable } from "openzeppelin-contracts-upgradeable/contracts/utils/introspection/ERC165Upgradeable.sol";
 import { AttestationRegistry } from "../AttestationRegistry.sol";
 import { ModuleRegistry } from "../ModuleRegistry.sol";
-import { SchemaRegistry } from "../SchemaRegistry.sol";
+import { AbstractPortal } from "../interface/AbstractPortal.sol";
 import { Attestation, AttestationPayload, Portal } from "../types/Structs.sol";
-
-struct AttestationRequestData {
-  address recipient;
-  uint64 expirationTime;
-  bool revocable;
-  bytes32 refUID;
-  bytes data;
-  uint256 value;
-}
-
-struct AttestationRequest {
-  bytes32 schema;
-  AttestationRequestData data;
-}
-
-abstract contract EASAbstractPortal {
-  function attest(AttestationRequest memory attestationRequest) external payable virtual;
-}
 
 /**
  * @title EAS Portal
  * @author Consensys
- * @notice This contract aims to integrate with dapps that are already integrated with EAS
+ * @notice This contract aims to provide a default portal
  */
-contract EASPortal is Initializable, EASAbstractPortal, IERC165Upgradeable {
-  AttestationRegistry public attestationRegistry;
-
-  /**
-   * @notice Contract initialization
-   */
-  function initialize(address _attestationRegistry) public initializer {
-    // Store registries addresses
-    attestationRegistry = AttestationRegistry(_attestationRegistry);
+contract EASPortal is AbstractPortal {
+  struct AttestationRequestData {
+    address recipient;
+    uint64 expirationTime;
+    bool revocable;
+    bytes32 refUID;
+    bytes data;
+    uint256 value;
   }
 
-  /**
-   * @notice attest the schema with given attestationPayload and validationPayload
-   * @dev Runs all modules for the portal and stores the attestation in AttestationRegistry
-   */
-  function attest(AttestationRequest memory attestationRequest) external payable override {
-    AttestationRequestData memory attestationRequestData = attestationRequest.data;
+  struct AttestationRequest {
+    bytes32 schema;
+    AttestationRequestData data;
+  }
+
+  function _beforeAttest(AttestationPayload memory attestation, uint256 value) internal override {}
+
+  function _afterAttest(Attestation memory attestation) internal override {}
+
+  function _onRevoke(bytes32 attestationId, bytes32 replacedBy) internal override {}
+
+  function _onBulkAttest(
+    AttestationPayload[] memory attestationsPayloads,
+    bytes[][] memory validationPayloads
+  ) internal override {}
+
+  function _onBulkRevoke(bytes32[] memory attestationIds, bytes32[] memory replacedBy) internal override {}
+
+  function attest(AttestationRequest memory attestationRequest) external payable {
+    bytes[] memory validationPayload = new bytes[](0);
 
     AttestationPayload memory attestationPayload = AttestationPayload(
       attestationRequest.schema,
-      abi.encodePacked(attestationRequestData.recipient),
-      uint256(attestationRequestData.expirationTime),
-      attestationRequestData.data
+      abi.encodePacked(attestationRequest.data.recipient),
+      uint256(attestationRequest.data.expirationTime),
+      attestationRequest.data.data
     );
 
-    attestationRegistry.attest(attestationPayload);
+    super.attest(attestationPayload, validationPayload);
   }
 
-  /**
-   * @notice Implements supports interface method declaring it is an EASAbstractPortal
-   */
-  function supportsInterface(bytes4 interfaceID) public pure override returns (bool) {
-    return interfaceID == type(EASAbstractPortal).interfaceId || interfaceID == type(IERC165Upgradeable).interfaceId;
+  function bulkAttest(AttestationRequest[] memory attestationsRequests) external payable {
+    AttestationPayload[] memory attestationsPayloads = new AttestationPayload[](attestationsRequests.length);
+    bytes[][] memory validationPayloads = new bytes[][](attestationsRequests.length);
+
+    for (uint i = 0; i < attestationsRequests.length; i++) {
+      attestationsPayloads[i] = AttestationPayload(
+        attestationsRequests[i].schema,
+        abi.encodePacked(attestationsRequests[i].data.recipient),
+        uint256(attestationsRequests[i].data.expirationTime),
+        attestationsRequests[i].data.data
+      );
+
+      validationPayloads[i] = new bytes[](0);
+    }
+
+    super.bulkAttest(attestationsPayloads, validationPayloads);
+  }
+
+  function revoke(bytes32 /*attestationId*/, bytes32 /*replacedBy*/) external pure override {
+    revert("No revoking");
+  }
+
+  function bulkRevoke(bytes32[] memory /*attestationIds*/, bytes32[] memory /*replacedBy*/) external pure override {
+    revert("No bulk revoking");
   }
 }

--- a/test/PortalRegistry.t.sol
+++ b/test/PortalRegistry.t.sol
@@ -22,7 +22,7 @@ contract PortalRegistryTest is Test {
   string public expectedName = "Name";
   string public expectedDescription = "Description";
   string public expectedOwnerName = "Owner Name";
-  ValidPortal public validPortal = new ValidPortal();
+  ValidPortal public validPortal;
   InvalidPortal public invalidPortal = new InvalidPortal();
 
   event Initialized(uint8 version);
@@ -44,6 +44,8 @@ contract PortalRegistryTest is Test {
     router.updateAttestationRegistry(attestationRegistryAddress);
     vm.prank(address(0));
     portalRegistry.setIssuer(user);
+
+    validPortal = new ValidPortal();
   }
 
   function test_alreadyInitialized() public {
@@ -194,7 +196,7 @@ contract PortalRegistryTest is Test {
 contract ValidPortal is AbstractPortal {
   function test() public {}
 
-  function _beforeAttest(AttestationPayload memory attestation, uint256 value) internal override {}
+  function _beforeAttest(AttestationPayload memory attestationPayload, uint256 value) internal override {}
 
   function _afterAttest(Attestation memory attestation) internal override {}
 

--- a/test/mocks/AttestationRegistryMock.sol
+++ b/test/mocks/AttestationRegistryMock.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.21;
 
-import { Attestation, AttestationPayload } from "../../src/types/Structs.sol";
+import { Attestation, AttestationPayload, Attestation } from "../../src/types/Structs.sol";
 
 contract AttestationRegistryMock {
   bytes32 public _attestationId;
@@ -15,22 +15,22 @@ contract AttestationRegistryMock {
   function test() public {}
 
   function attest(AttestationPayload calldata attestationPayload) public returns (Attestation memory) {
-    require(bytes32(attestationPayload.schemaId) != 0, "Invalid attestation payload");
-    emit AttestationRegistered();
+    require(bytes32(attestationPayload.schemaId) != 0 && tx.origin != address(0), "Invalid attestation payload");
     Attestation memory attestation = Attestation(
-      bytes32(uint(1)),
+      bytes32(keccak256(abi.encode((1)))),
       attestationPayload.schemaId,
       tx.origin,
-      address(1),
+      msg.sender,
       attestationPayload.subject,
       block.timestamp,
       attestationPayload.expirationDate,
       false,
       0,
       bytes32(0),
-      1,
+      version,
       attestationPayload.attestationData
     );
+    emit AttestationRegistered();
     return attestation;
   }
 
@@ -46,16 +46,16 @@ contract AttestationRegistryMock {
     emit AttestationRevoked(attestationId, replacedBy);
   }
 
+  function bulkRevoke(bytes32[] memory attestationIds, bytes32[] memory replacedBy) public {
+    require(attestationIds.length > 0, "Invalid attestation");
+    emit BulkAttestationsRevoked(attestationIds, replacedBy);
+  }
+
   function getAttestationId() public view returns (bytes32) {
     return _attestationId;
   }
 
   function getVersionNumber() public view returns (uint16) {
     return version;
-  }
-
-  function bulkRevoke(bytes32[] memory attestationIds, bytes32[] memory replacedBy) public {
-    require(attestationIds.length > 0, "Invalid attestation");
-    emit BulkAttestationsRevoked(attestationIds, replacedBy);
   }
 }

--- a/test/mocks/ModuleRegistryMock.sol
+++ b/test/mocks/ModuleRegistryMock.sol
@@ -9,13 +9,11 @@ contract ModuleRegistryMock {
 
   function test() public {}
 
-  function runModules(address[] memory modulesAddresses, bytes[] memory validationPayload) public {
-    require(modulesAddresses.length > 0 && validationPayload.length >= 0, "Invalid input");
-    emit ModulesRunForAttestation();
-  }
+  function runModules(address[] memory modulesAddresses, bytes[] memory validationPayload) public {}
 
   function bulkRunModules(address[] memory modulesAddresses, bytes[][] memory validationPayloads) public {
-    require(modulesAddresses.length > 0 && validationPayloads.length >= 0, "Invalid input");
+    require(modulesAddresses.length >= 0, "Invalid input for modulesAddresses");
+    require(validationPayloads.length >= 0, "Invalid input for validationPayloads");
     emit ModulesBulkRunForAttestation();
   }
 }

--- a/test/portal/DefaultPortal.t.sol
+++ b/test/portal/DefaultPortal.t.sol
@@ -30,9 +30,15 @@ contract DefaultPortalTest is Test {
   event BulkAttestationsRevoked(bytes32[] attestationId, bytes32[] replacedBy);
 
   function setUp() public {
-    defaultPortal = new DefaultPortal();
     modules.push(address(correctModule));
+    defaultPortal = new DefaultPortal();
     defaultPortal.initialize(modules, address(moduleRegistryMock), address(attestationRegistryMock));
+  }
+
+  function test_setup() public {
+    assertEq(address(defaultPortal.modules(0)), address(modules[0]));
+    assertEq(address(defaultPortal.moduleRegistry()), address(moduleRegistryMock));
+    assertEq(address(defaultPortal.attestationRegistry()), address(attestationRegistryMock));
   }
 
   function test_initialize() public {


### PR DESCRIPTION
## What does this PR do?

This PR is a different implementation of the EASPortal. In this implementation, we maintain use the AbstractPortal contract instead of creating a new EASAbstractPortal. This will allow us to register the EASPortal to the PortalRegistry and avoids custom code for EAS

### Related ticket

Fixes #114 

### Type of change

- [ ] Chore
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update

## Check list

- [x] Unit tests for any smart contract change
- [x] Contracts and functions are documented
