### PR TITLE
feat: As a user, I want the Attestation ID to be more predictable

### DIFF
--- a/script/deployDefaultPortal.ts
+++ b/script/deployDefaultPortal.ts
@@ -1,0 +1,45 @@
+import { ethers, run } from "hardhat";
+
+async function main() {
+  console.log("Deploying CorrectModule...");
+  const CorrectModule = await ethers.getContractFactory("CorrectModule");
+  const correctModule = await CorrectModule.deploy();
+  await correctModule.waitForDeployment();
+  const correctModuleAddress = await correctModule.getAddress();
+
+  await run("verify:verify", {
+    address: correctModuleAddress,
+  });
+
+  console.log(`CorrectModule successfully deployed and verified!`);
+  console.log(`CorrectModule is at ${correctModuleAddress}`);
+
+  console.log(`\n----\n`);
+
+  console.log("Deploying DefaultPortal...");
+
+  const PortalRegistry = await ethers.getContractFactory("PortalRegistry");
+  const portalRegistry = await PortalRegistry.attach("0x83eEAA59D6d707d3044a7CB47E865c5Bf7375dB5");
+
+  const defaultPortalAddress = await portalRegistry.deployDefaultPortal(
+    [correctModuleAddress],
+    "Default Portal",
+    "Default Portal to issue standard attestations",
+    false,
+    "Consensys",
+  );
+
+  await run("verify:verify", {
+    address: defaultPortalAddress,
+  });
+
+  console.log(`DefaultPortal successfully deployed, registered and verified!`);
+  console.log(`DefaultPortal is at ${defaultPortalAddress}`);
+}
+
+// We recommend this pattern to be able to use async/await everywhere
+// and properly handle errors.
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/script/deployEASPortal.ts
+++ b/script/deployEASPortal.ts
@@ -1,0 +1,23 @@
+import { ethers, run } from "hardhat";
+
+async function main() {
+  console.log("Deploying EASPortal...");
+  const EASPortal = await ethers.getContractFactory("EASPortal");
+  const easPortal = await EASPortal.deploy();
+  await easPortal.waitForDeployment();
+  const easPortalAddress = await easPortal.getAddress();
+
+  await run("verify:verify", {
+    address: easPortalAddress,
+  });
+
+  console.log(`EASPortal successfully deployed, registered and verified!`);
+  console.log(`EASPortal is at ${easPortalAddress}`);
+}
+
+// We recommend this pattern to be able to use async/await everywhere
+// and properly handle errors.
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/script/deployEverything.ts
+++ b/script/deployEverything.ts
@@ -1,0 +1,207 @@
+import { ethers, run, upgrades } from "hardhat";
+
+async function main() {
+  console.log(`START SCRIPT`);
+
+  /*console.log("Deploying Router...");
+  const Router = await ethers.getContractFactory("Router");
+  const router = await upgrades.deployProxy(Router);
+  await router.waitForDeployment();
+  const routerProxyAddress = await router.getAddress();
+  const routerImplementationAddress = await upgrades.erc1967.getImplementationAddress(routerProxyAddress);
+
+  await run("verify:verify", {
+    address: routerProxyAddress,
+  });
+
+  console.log(`Router successfully deployed and verified!`);
+  console.log(`Proxy is at ${routerProxyAddress}`);
+  console.log(`Implementation is at ${routerImplementationAddress}`);
+
+  console.log(`\n----\n`);
+
+  console.log("Deploying AttestationRegistry...");
+  const AttestationRegistry = await ethers.getContractFactory("AttestationRegistry");
+  const attestationRegistry = await upgrades.deployProxy(AttestationRegistry);
+  await attestationRegistry.waitForDeployment();
+  const attestationRegistryProxyAddress = await attestationRegistry.getAddress();
+  const attestationRegistryImplementationAddress = await upgrades.erc1967.getImplementationAddress(
+    attestationRegistryProxyAddress,
+  );
+
+  await run("verify:verify", {
+    address: attestationRegistryProxyAddress,
+  });
+
+  console.log(`AttestationRegistry successfully deployed and verified!`);
+  console.log(`Proxy is at ${attestationRegistryProxyAddress}`);
+  console.log(`Implementation is at ${attestationRegistryImplementationAddress}`);
+
+  console.log(`\n----\n`);
+
+  console.log("Deploying ModuleRegistry...");
+  const ModuleRegistry = await ethers.getContractFactory("ModuleRegistry");
+  const moduleRegistry = await upgrades.deployProxy(ModuleRegistry);
+  await moduleRegistry.waitForDeployment();
+  const moduleRegistryProxyAddress = await moduleRegistry.getAddress();
+  const moduleRegistryImplementationAddress = await upgrades.erc1967.getImplementationAddress(
+    moduleRegistryProxyAddress,
+  );
+
+  await run("verify:verify", {
+    address: moduleRegistryProxyAddress,
+  });
+
+  console.log(`ModuleRegistry successfully deployed and verified!`);
+  console.log(`Proxy is at ${moduleRegistryProxyAddress}`);
+  console.log(`Implementation is at ${moduleRegistryImplementationAddress}`);
+
+  console.log(`\n----\n`);*/
+
+  console.log("Deploying PortalRegistry...");
+  const PortalRegistry = await ethers.getContractFactory("PortalRegistry");
+  const portalRegistry = await upgrades.deployProxy(PortalRegistry);
+  await portalRegistry.waitForDeployment();
+  const portalRegistryProxyAddress = await portalRegistry.getAddress();
+  const portalRegistryImplementationAddress = await upgrades.erc1967.getImplementationAddress(
+    portalRegistryProxyAddress,
+  );
+
+  await run("verify:verify", {
+    address: portalRegistryProxyAddress,
+  });
+
+  console.log(`PortalRegistry successfully deployed and verified!`);
+  console.log(`Proxy is at ${portalRegistryProxyAddress}`);
+  console.log(`Implementation is at ${portalRegistryImplementationAddress}`);
+
+  console.log(`\n----\n`);
+
+  /*console.log("Deploying SchemaRegistry...");
+  const SchemaRegistry = await ethers.getContractFactory("SchemaRegistry");
+  const schemaRegistry = await upgrades.deployProxy(SchemaRegistry);
+  await schemaRegistry.waitForDeployment();
+  const schemaRegistryProxyAddress = await schemaRegistry.getAddress();
+  const schemaRegistryImplementationAddress = await upgrades.erc1967.getImplementationAddress(
+    schemaRegistryProxyAddress,
+  );
+
+  await run("verify:verify", {
+    address: schemaRegistryProxyAddress,
+  });
+
+  console.log(`SchemaRegistry successfully deployed and verified!`);
+  console.log(`Proxy is at ${schemaRegistryProxyAddress}`);
+  console.log(`Implementation is at ${schemaRegistryImplementationAddress}`);
+
+  console.log(`\n----\n`);
+
+  console.log("Updating Router with the registries addresses...");
+  await router.updateAttestationRegistry(attestationRegistryProxyAddress);
+  await router.updateModuleRegistry(moduleRegistryProxyAddress);
+  await router.updatePortalRegistry(portalRegistryProxyAddress);
+  await router.updateSchemaRegistry(schemaRegistryProxyAddress);
+  console.log("Router updated with the registries addresses!");
+
+  console.log(`\n----\n`);
+
+  console.log(`Updating registries with the Router address...`);
+
+  console.log("Updating AttestationRegistry with the Router address...");
+  await attestationRegistry.updateRouter(routerProxyAddress);
+  console.log("AttestationRegistry updated!");
+
+  console.log("Updating ModuleRegistry with the Router address...");
+  await moduleRegistry.updateRouter(routerProxyAddress);
+  console.log("ModuleRegistry updated!");
+
+  console.log("Updating PortalRegistry with the Router address...");
+  await portalRegistry.updateRouter(routerProxyAddress);
+  console.log("PortalRegistry updated!");
+
+  console.log("Updating SchemaRegistry with the Router address...");
+  await schemaRegistry.updateRouter(routerProxyAddress);
+  console.log("SchemaRegistry updated!");
+
+  console.log("Registries updated with the Router address!");
+
+  console.log(`\n----\n`);*/
+
+  console.log("Deploying CorrectModule...");
+  const CorrectModule = await ethers.getContractFactory("CorrectModule");
+  const correctModule = await CorrectModule.deploy();
+  await correctModule.waitForDeployment();
+  const correctModuleAddress = await correctModule.getAddress();
+
+  await run("verify:verify", {
+    address: correctModuleAddress,
+  });
+
+  console.log(`CorrectModule successfully deployed and verified!`);
+  console.log(`CorrectModule is at ${correctModuleAddress}`);
+
+  console.log(`\n----\n`);
+
+  console.log("Deploying DefaultPortal...");
+
+  const defaultPortalAddress = await portalRegistry.deployDefaultPortal(
+    [correctModuleAddress],
+    "Default Portal",
+    "Default Portal to issue standard attestations",
+    false,
+    "Consensys",
+  );
+
+  await run("verify:verify", {
+    address: defaultPortalAddress,
+  });
+
+  console.log(`DefaultPortal successfully deployed, registered and verified!`);
+  console.log(`DefaultPortal is at ${defaultPortalAddress}`);
+
+  console.log(`\n----\n`);
+
+  /*console.log("Deploying EASPortal...");
+  const EASPortal = await ethers.getContractFactory("EASPortal");
+  const easPortal = await EASPortal.deploy();
+  await easPortal.waitForDeployment();
+  const easPortalAddress = await easPortal.getAddress();
+
+  await run("verify:verify", {
+    address: easPortalAddress,
+  });
+
+  console.log("Registering EASPortal on the PortalRegistry...");
+  await portalRegistry.register(
+    easPortalAddress,
+    "EAS Portal",
+    "Ethereum Attestation Service compatible Portal",
+    false,
+    "Consensys",
+  );
+
+  console.log(`EASPortal successfully deployed, registered and verified!`);
+  console.log(`EASPortal is at ${easPortalAddress}`);
+
+  console.log(`\n----\n`);*/
+
+  console.log(`** SUMMARY **`);
+  /*console.log(`Router = ${routerProxyAddress}`);
+  console.log(`AttestationRegistry = ${attestationRegistryProxyAddress}`);
+  console.log(`ModuleRegistry = ${moduleRegistryProxyAddress}`);*/
+  console.log(`PortalRegistry = ${portalRegistryProxyAddress}`);
+  //console.log(`SchemaRegistry = ${schemaRegistryProxyAddress}`);
+  console.log(`DefaultPortal = ${defaultPortalAddress}`);
+  //console.log(`EASPortal = ${easPortalAddress}`);
+
+  console.log(`END SCRIPT`);
+
+  ["0x8173FD66EC40B793C679F834063A5D0802975B4496ACBA0B39ED8B6C2B3FCA57", "0x12", 110, "0x12"];
+}
+
+// We recommend this pattern to be able to use async/await everywhere
+// and properly handle errors.
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/src/AttestationRegistry.sol
+++ b/src/AttestationRegistry.sol
@@ -44,7 +44,7 @@ contract AttestationRegistry is OwnableUpgradeable {
   error BulkRevocationInvalidParams();
 
   /// @notice Event emitted when an attestation is registered
-  event AttestationRegistered(Attestation attestation);
+  event AttestationRegistered(bytes32 indexed attestationId, Attestation attestation);
   /// @notice Event emitted when a list of attestations is registered
   event BulkAttestationsRegistered(Attestation[] attestations);
   /// @notice Event emitted when an attestation is revoked
@@ -104,7 +104,7 @@ contract AttestationRegistry is OwnableUpgradeable {
     attestationIdCounter++;
     // Create attestation
     Attestation memory attestation = Attestation(
-      bytes32(keccak256(abi.encode((attestationIdCounter)))),
+      bytes32(abi.encode(attestationIdCounter)),
       attestationPayload.schemaId,
       tx.origin,
       msg.sender,
@@ -118,7 +118,7 @@ contract AttestationRegistry is OwnableUpgradeable {
       attestationPayload.attestationData
     );
     attestations[attestation.attestationId] = attestation;
-    emit AttestationRegistered(attestation);
+    emit AttestationRegistered(attestation.attestationId, attestation);
     return attestation;
   }
 

--- a/src/interface/AbstractPortal.sol
+++ b/src/interface/AbstractPortal.sol
@@ -36,7 +36,7 @@ abstract contract AbstractPortal is Initializable, IERC165Upgradeable {
   function attest(
     AttestationPayload memory attestationPayload,
     bytes[] memory validationPayload
-  ) public payable virtual {
+  ) public payable virtual returns (bytes32) {
     if (modules.length != 0) _runModules(validationPayload);
 
     _beforeAttest(attestationPayload, msg.value);
@@ -44,6 +44,8 @@ abstract contract AbstractPortal is Initializable, IERC165Upgradeable {
     Attestation memory attestation = attestationRegistry.attest(attestationPayload);
 
     _afterAttest(attestation);
+
+    return attestation.attestationId;
   }
 
   /**

--- a/test/AttestationRegistry.t.sol
+++ b/test/AttestationRegistry.t.sol
@@ -19,7 +19,7 @@ contract AttestationRegistryTest is Test {
   address public schemaRegistryAddress;
 
   event Initialized(uint8 version);
-  event AttestationRegistered(Attestation attestation);
+  event AttestationRegistered(bytes32 indexed attestationId, Attestation attestation);
   event BulkAttestationsRegistered(Attestation[] attestations);
   event AttestationRevoked(bytes32 attestationId, bytes32 replacedBy);
   event BulkAttestationsRevoked(bytes32[] attestationId, bytes32[] replacedBy);
@@ -68,11 +68,13 @@ contract AttestationRegistryTest is Test {
   function test_attest(AttestationPayload memory attestationPayload) public {
     vm.assume(attestationPayload.subject.length != 0);
     vm.assume(attestationPayload.attestationData.length != 0);
+
     SchemaRegistryMock schemaRegistryMock = SchemaRegistryMock(router.getSchemaRegistry());
     attestationPayload.schemaId = schemaRegistryMock.getIdFromSchemaString("schemaString");
+
     Attestation memory attestation = _createAttestation(attestationPayload, 1);
     vm.expectEmit(true, true, true, true);
-    emit AttestationRegistered(attestation);
+    emit AttestationRegistered(attestation.attestationId, attestation);
     vm.prank(portal);
     attestationRegistry.attest(attestationPayload);
 
@@ -157,10 +159,10 @@ contract AttestationRegistryTest is Test {
     vm.startPrank(portal);
     attestationRegistry.attest(attestationPayload);
     // Assert initial state is a valid attestation
-    bytes32 attestationId = bytes32(keccak256(abi.encode((1))));
+    bytes32 attestationId = bytes32(abi.encode(1));
     Attestation memory registeredAttestation = attestationRegistry.getAttestation(attestationId);
 
-    assertEq(registeredAttestation.attestationId, bytes32(keccak256(abi.encode((1)))));
+    assertEq(registeredAttestation.attestationId, bytes32(abi.encode(1)));
     assertFalse(registeredAttestation.revoked);
     assertEq(registeredAttestation.revocationDate, 0);
     assertEq(registeredAttestation.replacedBy, bytes32(0));
@@ -173,7 +175,7 @@ contract AttestationRegistryTest is Test {
     vm.stopPrank();
 
     // Assert final state is a revoked attestation
-    Attestation memory revokedAttestation = attestationRegistry.getAttestation(bytes32(keccak256(abi.encode((1)))));
+    Attestation memory revokedAttestation = attestationRegistry.getAttestation(bytes32(abi.encode(1)));
     assertTrue(revokedAttestation.revoked);
     assertEq(revokedAttestation.revocationDate, block.timestamp);
     assertEq(revokedAttestation.replacedBy, bytes32(0));
@@ -189,18 +191,18 @@ contract AttestationRegistryTest is Test {
     attestationRegistry.attest(attestationPayload);
 
     vm.expectEmit();
-    emit AttestationRevoked(bytes32(keccak256(abi.encode((1)))), bytes32(0));
-    attestationRegistry.revoke(bytes32(keccak256(abi.encode((1)))), "");
+    emit AttestationRevoked(bytes32(abi.encode(1)), bytes32(0));
+    attestationRegistry.revoke(bytes32(abi.encode(1)), "");
 
     vm.expectRevert(AttestationRegistry.AlreadyRevoked.selector);
-    attestationRegistry.revoke(bytes32(keccak256(abi.encode((1)))), "");
+    attestationRegistry.revoke(bytes32(abi.encode(1)), "");
 
     vm.stopPrank();
   }
 
   function test_revoke_AttestationNotAttested() public {
     vm.expectRevert(AttestationRegistry.AttestationNotAttested.selector);
-    attestationRegistry.revoke(bytes32(keccak256(abi.encode((1)))), "");
+    attestationRegistry.revoke(bytes32(abi.encode(1)), "");
   }
 
   function test_revoke_OnlyAttestingPortal(AttestationPayload memory attestationPayload) public {
@@ -215,7 +217,7 @@ contract AttestationRegistryTest is Test {
 
     vm.expectRevert(AttestationRegistry.OnlyAttestingPortal.selector);
     vm.prank(user);
-    attestationRegistry.revoke(bytes32(keccak256(abi.encode((1)))), "");
+    attestationRegistry.revoke(bytes32(abi.encode(1)), "");
   }
 
   function test_revoke_AttestationNotRevocable(AttestationPayload memory attestationPayload) public {
@@ -239,7 +241,7 @@ contract AttestationRegistryTest is Test {
     attestationRegistry.attest(attestationPayload);
 
     vm.expectRevert(AttestationRegistry.AttestationNotRevocable.selector);
-    attestationRegistry.revoke(bytes32(keccak256(abi.encode((1)))), "");
+    attestationRegistry.revoke(bytes32(abi.encode(1)), "");
 
     vm.stopPrank();
   }
@@ -255,7 +257,7 @@ contract AttestationRegistryTest is Test {
     vm.stopPrank();
     vm.startPrank(portal, user);
     vm.expectRevert(AttestationRegistry.OnlyAttester.selector);
-    attestationRegistry.revoke(bytes32(keccak256(abi.encode((1)))), "");
+    attestationRegistry.revoke(bytes32(abi.encode(1)), "");
 
     vm.stopPrank();
   }
@@ -279,16 +281,16 @@ contract AttestationRegistryTest is Test {
 
     // Do revert and replace the attestation
     vm.expectEmit(true, true, true, true);
-    emit AttestationRevoked(bytes32(keccak256(abi.encode((1)))), bytes32(keccak256(abi.encode((2)))));
-    attestationRegistry.revoke(bytes32(keccak256(abi.encode((1)))), bytes32(keccak256(abi.encode((2)))));
+    emit AttestationRevoked(bytes32(abi.encode(1)), bytes32(abi.encode(2)));
+    attestationRegistry.revoke(bytes32(abi.encode(1)), bytes32(abi.encode(2)));
 
     vm.stopPrank();
 
     // Assert final state is a revoked and replaced attestation
-    Attestation memory revokedAttestation = attestationRegistry.getAttestation(bytes32(keccak256(abi.encode((1)))));
+    Attestation memory revokedAttestation = attestationRegistry.getAttestation(bytes32(abi.encode(1)));
     assertTrue(revokedAttestation.revoked);
     assertEq(revokedAttestation.revocationDate, block.timestamp);
-    assertEq(revokedAttestation.replacedBy, bytes32(keccak256(abi.encode((2)))));
+    assertEq(revokedAttestation.replacedBy, bytes32(abi.encode(2)));
   }
 
   function test_bulkRevoke(AttestationPayload[3] memory attestationPayloads) public {
@@ -312,9 +314,9 @@ contract AttestationRegistryTest is Test {
     attestationRegistry.attest(attestationPayloads[1]);
     attestationRegistry.attest(attestationPayloads[2]);
 
-    bytes32 attestationId1 = bytes32(keccak256(abi.encode((1))));
-    bytes32 attestationId2 = bytes32(keccak256(abi.encode((2))));
-    bytes32 attestationId3 = bytes32(keccak256(abi.encode((3))));
+    bytes32 attestationId1 = bytes32(abi.encode(1));
+    bytes32 attestationId2 = bytes32(abi.encode(2));
+    bytes32 attestationId3 = bytes32(abi.encode(3));
 
     // Assert initial state is a valid attestation
     Attestation memory registeredAttestation1 = attestationRegistry.getAttestation(attestationId1);
@@ -360,8 +362,8 @@ contract AttestationRegistryTest is Test {
   }
 
   function test_bulkRevoke_InvalidParams() public {
-    bytes32 attestationId1 = bytes32(keccak256(abi.encode((1))));
-    bytes32 attestationId2 = bytes32(keccak256(abi.encode((2))));
+    bytes32 attestationId1 = bytes32(abi.encode(1));
+    bytes32 attestationId2 = bytes32(abi.encode(2));
 
     bytes32[] memory attestationsToRevoke = new bytes32[](2);
     attestationsToRevoke[0] = attestationId1;
@@ -389,7 +391,7 @@ contract AttestationRegistryTest is Test {
   function test_isRegistered(AttestationPayload memory attestationPayload) public {
     vm.assume(attestationPayload.subject.length != 0);
     vm.assume(attestationPayload.attestationData.length != 0);
-    bool isRegistered = attestationRegistry.isRegistered(bytes32(keccak256(abi.encode((1)))));
+    bool isRegistered = attestationRegistry.isRegistered(bytes32(abi.encode(1)));
     assertFalse(isRegistered);
     SchemaRegistryMock schemaRegistryMock = SchemaRegistryMock(router.getSchemaRegistry());
     attestationPayload.schemaId = schemaRegistryMock.getIdFromSchemaString("schemaString");
@@ -421,7 +423,7 @@ contract AttestationRegistryTest is Test {
 
   function test_getAttestation_AttestationNotAttested() public {
     vm.expectRevert(AttestationRegistry.AttestationNotAttested.selector);
-    attestationRegistry.getAttestation(bytes32(keccak256(abi.encode((1)))));
+    attestationRegistry.getAttestation(bytes32(abi.encode(1)));
   }
 
   function test_incrementVersionNumber() public {
@@ -470,7 +472,7 @@ contract AttestationRegistryTest is Test {
     SchemaRegistryMock schemaRegistryMock = SchemaRegistryMock(router.getSchemaRegistry());
     schemaRegistryMock.createSchema("name", "description", "context", "schemaString");
     Attestation memory attestation = Attestation(
-      bytes32(keccak256(abi.encode((id)))),
+      bytes32(abi.encode(id)),
       attestationPayload.schemaId,
       tx.origin,
       portal,

--- a/test/mocks/AttestationRegistryMock.sol
+++ b/test/mocks/AttestationRegistryMock.sol
@@ -17,7 +17,7 @@ contract AttestationRegistryMock {
   function attest(AttestationPayload calldata attestationPayload) public returns (Attestation memory) {
     require(bytes32(attestationPayload.schemaId) != 0 && tx.origin != address(0), "Invalid attestation payload");
     Attestation memory attestation = Attestation(
-      bytes32(keccak256(abi.encode((1)))),
+      bytes32(abi.encode(1)),
       attestationPayload.schemaId,
       tx.origin,
       msg.sender,


### PR DESCRIPTION
## What does this PR do?

Removes the hash to generate the `Attestation`'s ID

### Related ticket

Fixes #118 

### Type of change

- [ ] Chore
- [ ] Bug fix
- [X] New feature
- [ ] Documentation update

## Check list

- [X] Unit tests for any smart contract change
- [X] Contracts and functions are documented
