### PR TITLE
feat: As a Dev, I want the DefaultPortal ID to be returned on deployment

### DIFF
--- a/src/PortalRegistry.sol
+++ b/src/PortalRegistry.sol
@@ -149,6 +149,7 @@ contract PortalRegistry is OwnableUpgradeable {
    * @param name the portal name
    * @param description the portal description
    * @param ownerName name of this portal's owner
+   * @return defaultPortalAddress the deployed portal's address
    */
   function deployDefaultPortal(
     address[] calldata modules,
@@ -156,10 +157,11 @@ contract PortalRegistry is OwnableUpgradeable {
     string memory description,
     bool isRevocable,
     string memory ownerName
-  ) external onlyIssuers(msg.sender) {
+  ) external onlyIssuers(msg.sender) returns (address defaultPortalAddress) {
     DefaultPortal defaultPortal = new DefaultPortal();
+    defaultPortalAddress = address(defaultPortal);
     defaultPortal.initialize(modules, router.getModuleRegistry(), router.getAttestationRegistry());
-    register(address(defaultPortal), name, description, isRevocable, ownerName);
+    register(defaultPortalAddress, name, description, isRevocable, ownerName);
   }
 
   /**

--- a/test/PortalRegistry.t.sol
+++ b/test/PortalRegistry.t.sol
@@ -160,7 +160,14 @@ contract PortalRegistryTest is Test {
     address[] memory modules = new address[](1);
     modules[0] = address(correctModule);
     vm.prank(user);
-    portalRegistry.deployDefaultPortal(modules, expectedName, expectedDescription, true, expectedOwnerName);
+    address defaultPortalAddress = portalRegistry.deployDefaultPortal(
+      modules,
+      expectedName,
+      expectedDescription,
+      true,
+      expectedOwnerName
+    );
+    assertFalse(defaultPortalAddress == address(0));
   }
 
   function test_deployDefaultPortal_OnlyIssuer() public {


### PR DESCRIPTION
## What does this PR do?

Returns the address for a freshly deployed `DefaultPortal`

### Related ticket

Fixes #123 

### Type of change

- [ ] Chore
- [ ] Bug fix
- [X] New feature
- [ ] Documentation update

## Check list

- [X] Unit tests for any smart contract change
- [X] Contracts and functions are documented
