### PR TITLE
feat: Portals should pass attestationPayload to modules as well as validationPayload

### DIFF
--- a/src/ModuleRegistry.sol
+++ b/src/ModuleRegistry.sol
@@ -122,10 +122,15 @@ contract ModuleRegistry is OwnableUpgradeable {
 
   /** Execute the run method for all given Modules that are registered
    * @param modulesAddresses the addresses of the registered modules
+   * @param attestationPayload the payload to attest
    * @param validationPayload the payloads to check for each module
    * @dev check if modules are registered and execute run method for each module
    */
-  function runModules(address[] memory modulesAddresses, bytes[] memory validationPayload) public {
+  function runModules(
+    address[] memory modulesAddresses,
+    AttestationPayload memory attestationPayload,
+    bytes[] memory validationPayload
+  ) public {
     // If no modules provided, bypass module validation
     if (modulesAddresses.length == 0) return;
     // Each module involved must have a corresponding item from the validation payload
@@ -134,18 +139,23 @@ contract ModuleRegistry is OwnableUpgradeable {
     // For each module check if it is registered and call run method
     for (uint i = 0; i < modulesAddresses.length; i++) {
       if (!isRegistered(modulesAddresses[i])) revert ModuleNotRegistered();
-      AbstractModule(modulesAddresses[i]).run(validationPayload, tx.origin);
+      AbstractModule(modulesAddresses[i]).run(attestationPayload, validationPayload, tx.origin);
     }
   }
 
   /** Execute the run method for all given Modules that are registered
    * @param modulesAddresses the addresses of the registered modules
+   * @param attestationsPayloads the payloads to attest
    * @param validationPayloads the payloads to check for each module
    * @dev check if modules are registered and execute run method for each module
    */
-  function bulkRunModules(address[] memory modulesAddresses, bytes[][] memory validationPayloads) public {
+  function bulkRunModules(
+    address[] memory modulesAddresses,
+    AttestationPayload[] memory attestationsPayloads,
+    bytes[][] memory validationPayloads
+  ) public {
     for (uint i = 0; i < modulesAddresses.length; i++) {
-      runModules(modulesAddresses, validationPayloads[i]);
+      runModules(modulesAddresses, attestationsPayloads[i], validationPayloads[i]);
     }
   }
 

--- a/src/example/CorrectModule.sol
+++ b/src/example/CorrectModule.sol
@@ -9,7 +9,11 @@ import { IERC165Upgradeable } from "openzeppelin-contracts-upgradeable/contracts
 contract CorrectModule is AbstractModule, IERC165Upgradeable {
   function test() public {}
 
-  function run(bytes[] memory validationPayload, address /*msgSender*/) public pure override returns (bytes[] memory) {
+  function run(
+    AttestationPayload memory /*attestationPayload*/,
+    bytes[] memory validationPayload,
+    address /*txSender*/
+  ) public pure override returns (bytes[] memory) {
     return (validationPayload);
   }
 

--- a/src/example/MsgSenderModule.sol
+++ b/src/example/MsgSenderModule.sol
@@ -5,6 +5,7 @@ import { AbstractModule } from "../interface/AbstractModule.sol";
 // solhint-disable-next-line max-line-length
 import { IERC165Upgradeable } from "openzeppelin-contracts-upgradeable/contracts/utils/introspection/IERC165Upgradeable.sol";
 import { Initializable } from "openzeppelin-contracts-upgradeable/contracts/proxy/utils/Initializable.sol";
+import { AttestationPayload } from "../types/Structs.sol";
 
 /**
  * @title Msg Sender Module
@@ -29,6 +30,7 @@ contract MsgSenderModule is IERC165Upgradeable, AbstractModule, Initializable {
    * @notice The main method for the module, running the check
    */
   function run(
+    AttestationPayload memory /*_attestationPayload*/,
     bytes[] memory _validationPayload,
     address _txSender
   ) public view override returns (bytes[] memory validationPayload) {

--- a/src/interface/AbstractModule.sol
+++ b/src/interface/AbstractModule.sol
@@ -1,8 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.21;
 
+import { AttestationPayload } from "../types/Structs.sol";
+
 abstract contract AbstractModule {
   function run(
+    AttestationPayload memory attestationPayload,
     bytes[] memory validationPayload,
     address txSender
   ) public virtual returns (bytes[] memory moduleValidationPayload);

--- a/src/interface/AbstractPortal.sol
+++ b/src/interface/AbstractPortal.sol
@@ -37,7 +37,7 @@ abstract contract AbstractPortal is Initializable, IERC165Upgradeable {
     AttestationPayload memory attestationPayload,
     bytes[] memory validationPayload
   ) public payable virtual returns (bytes32) {
-    if (modules.length != 0) _runModules(validationPayload);
+    if (modules.length != 0) _runModules(attestationPayload, validationPayload);
 
     _beforeAttest(attestationPayload, msg.value);
 
@@ -59,7 +59,7 @@ abstract contract AbstractPortal is Initializable, IERC165Upgradeable {
   ) public payable {
     _onBulkAttest(attestationsPayloads, validationPayloads);
     // Run all modules for all payloads
-    moduleRegistry.bulkRunModules(modules, validationPayloads);
+    moduleRegistry.bulkRunModules(modules, attestationsPayloads, validationPayloads);
     // Register attestations using the attestation registry
     attestationRegistry.bulkAttest(attestationsPayloads);
   }
@@ -92,9 +92,9 @@ abstract contract AbstractPortal is Initializable, IERC165Upgradeable {
     return interfaceID == type(AbstractPortal).interfaceId || interfaceID == type(IERC165Upgradeable).interfaceId;
   }
 
-  function _runModules(bytes[] memory validationPayload) internal {
+  function _runModules(AttestationPayload memory attestationPayload, bytes[] memory validationPayload) internal {
     if (modules.length != validationPayload.length) revert ModulePayloadMismatch();
-    moduleRegistry.runModules(modules, validationPayload);
+    moduleRegistry.runModules(modules, attestationPayload, validationPayload);
   }
 
   function _beforeAttest(AttestationPayload memory attestationPayload, uint256 value) internal virtual;

--- a/src/portal/EASPortal.sol
+++ b/src/portal/EASPortal.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.21;
 
-// solhint-disable-next-line max-line-length
 import { AttestationRegistry } from "../AttestationRegistry.sol";
 import { ModuleRegistry } from "../ModuleRegistry.sol";
 import { AbstractPortal } from "../interface/AbstractPortal.sol";

--- a/test/example/MsgSenderModule.t.sol
+++ b/test/example/MsgSenderModule.t.sol
@@ -12,6 +12,7 @@ import { IERC165Upgradeable } from "openzeppelin-contracts-upgradeable/contracts
 contract MsgSenderModuleTest is Test {
   MsgSenderModule private msgSenderModule;
   address private expectedMsgSender = 0x809e815596AbEB3764aBf81BE2DC39fBBAcc9949;
+  AttestationPayload private attestationPayload;
 
   event ModuleRegistered(string name, string description, address moduleAddress);
   event Initialized(uint8 version);
@@ -19,6 +20,13 @@ contract MsgSenderModuleTest is Test {
   function setUp() public {
     msgSenderModule = new MsgSenderModule();
     msgSenderModule.initialize(expectedMsgSender);
+
+    attestationPayload = AttestationPayload(
+      bytes32(uint256(1)),
+      bytes("subject"),
+      uint64(block.timestamp + 1 days),
+      new bytes(1)
+    );
   }
 
   function testInitialize() public {
@@ -34,7 +42,7 @@ contract MsgSenderModuleTest is Test {
     bytes[] memory validationPayload = new bytes[](0);
     address msgSender = expectedMsgSender;
 
-    bytes[] memory _validationPayload = msgSenderModule.run(validationPayload, msgSender);
+    bytes[] memory _validationPayload = msgSenderModule.run(attestationPayload, validationPayload, msgSender);
 
     assertBytesArrayEq(_validationPayload, validationPayload);
   }
@@ -44,7 +52,7 @@ contract MsgSenderModuleTest is Test {
     bytes[] memory validationPayload = new bytes[](0);
     address incorrectMsgSender = address(1);
     vm.expectRevert(MsgSenderModule.WrongTransactionSender.selector);
-    msgSenderModule.run(validationPayload, incorrectMsgSender);
+    msgSenderModule.run(attestationPayload, validationPayload, incorrectMsgSender);
   }
 
   function testSupportsInterface() public {

--- a/test/mocks/ModuleRegistryMock.sol
+++ b/test/mocks/ModuleRegistryMock.sol
@@ -9,10 +9,19 @@ contract ModuleRegistryMock {
 
   function test() public {}
 
-  function runModules(address[] memory modulesAddresses, bytes[] memory validationPayload) public {}
+  function runModules(
+    address[] memory modulesAddresses,
+    AttestationPayload memory attestationPayload,
+    bytes[] memory validationPayload
+  ) public {}
 
-  function bulkRunModules(address[] memory modulesAddresses, bytes[][] memory validationPayloads) public {
+  function bulkRunModules(
+    address[] memory modulesAddresses,
+    AttestationPayload[] memory attestationsPayloads,
+    bytes[][] memory validationPayloads
+  ) public {
     require(modulesAddresses.length >= 0, "Invalid input for modulesAddresses");
+    require(attestationsPayloads.length >= 0, "Invalid input for attestationsPayloads");
     require(validationPayloads.length >= 0, "Invalid input for validationPayloads");
     emit ModulesBulkRunForAttestation();
   }


### PR DESCRIPTION
## What does this PR do?

Passes the `attestationPayload` to modules so that they can validate the attestation data

### Related ticket

Fixes #134 

### Type of change

- [ ] Chore
- [ ] Bug fix
- [X] New feature
- [ ] Documentation update

## Check list

- [X] Unit tests for any smart contract change
- [X] Contracts and functions are documented
