### PR TITLE
feat: Optimize the issuance of attestations

### DIFF
--- a/src/AttestationRegistry.sol
+++ b/src/AttestationRegistry.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.21;
 
 import { OwnableUpgradeable } from "openzeppelin-contracts-upgradeable/contracts/access/OwnableUpgradeable.sol";
-import { Attestation, AttestationPayload, Portal } from "./types/Structs.sol";
+import { Attestation, AttestationPayload } from "./types/Structs.sol";
 import { PortalRegistry } from "./PortalRegistry.sol";
 import { SchemaRegistry } from "./SchemaRegistry.sol";
 import { IRouter } from "./interface/IRouter.sol";
@@ -16,7 +16,7 @@ contract AttestationRegistry is OwnableUpgradeable {
   IRouter public router;
 
   uint16 private version;
-  uint256 private attestationIdCounter;
+  uint32 private attestationIdCounter;
 
   mapping(bytes32 attestationId => Attestation attestation) private attestations;
 
@@ -123,7 +123,7 @@ contract AttestationRegistry is OwnableUpgradeable {
    * @param attestationsPayloads the attestations payloads to create attestations and register them
    */
   function bulkAttest(AttestationPayload[] calldata attestationsPayloads) public {
-    for (uint i = 0; i < attestationsPayloads.length; i++) {
+    for (uint256 i = 0; i < attestationsPayloads.length; i++) {
       attest(attestationsPayloads[i]);
     }
   }
@@ -156,7 +156,7 @@ contract AttestationRegistry is OwnableUpgradeable {
   function bulkRevoke(bytes32[] memory attestationIds, bytes32[] memory replacedBy) external {
     if (attestationIds.length != replacedBy.length) revert BulkRevocationInvalidParams();
 
-    for (uint i = 0; i < attestationIds.length; i++) {
+    for (uint256 i = 0; i < attestationIds.length; i++) {
       revoke(attestationIds[i], replacedBy[i]);
     }
 
@@ -214,7 +214,7 @@ contract AttestationRegistry is OwnableUpgradeable {
    * @notice Gets the attestation id counter
    * @return The attestationIdCounter
    */
-  function getAttestationIdCounter() public view returns (uint) {
+  function getAttestationIdCounter() public view returns (uint32) {
     return attestationIdCounter;
   }
 }

--- a/src/AttestationRegistry.sol
+++ b/src/AttestationRegistry.sol
@@ -45,8 +45,6 @@ contract AttestationRegistry is OwnableUpgradeable {
 
   /// @notice Event emitted when an attestation is registered
   event AttestationRegistered(bytes32 indexed attestationId);
-  /// @notice Event emitted when a list of attestations is registered
-  event BulkAttestationsRegistered(Attestation[] attestations);
   /// @notice Event emitted when an attestation is revoked
   event AttestationRevoked(bytes32 attestationId, bytes32 replacedBy);
   /// @notice Event emitted when a list of attestations is revoked

--- a/src/ModuleRegistry.sol
+++ b/src/ModuleRegistry.sol
@@ -115,7 +115,7 @@ contract ModuleRegistry is OwnableUpgradeable {
       revert ModuleAlreadyExists();
     }
 
-    modules[moduleAddress] = Module(name, description, moduleAddress);
+    modules[moduleAddress] = Module(moduleAddress, name, description);
     moduleAddresses.push(moduleAddress);
     emit ModuleRegistered(name, description, moduleAddress);
   }
@@ -137,7 +137,7 @@ contract ModuleRegistry is OwnableUpgradeable {
     if (modulesAddresses.length != validationPayload.length) revert ModuleValidationPayloadMismatch();
 
     // For each module check if it is registered and call run method
-    for (uint i = 0; i < modulesAddresses.length; i++) {
+    for (uint32 i = 0; i < modulesAddresses.length; i++) {
       if (!isRegistered(modulesAddresses[i])) revert ModuleNotRegistered();
       AbstractModule(modulesAddresses[i]).run(attestationPayload, validationPayload, tx.origin);
     }
@@ -154,7 +154,7 @@ contract ModuleRegistry is OwnableUpgradeable {
     AttestationPayload[] memory attestationsPayloads,
     bytes[][] memory validationPayloads
   ) public {
-    for (uint i = 0; i < modulesAddresses.length; i++) {
+    for (uint32 i = 0; i < modulesAddresses.length; i++) {
       runModules(modulesAddresses, attestationsPayloads[i], validationPayloads[i]);
     }
   }

--- a/src/PortalRegistry.sol
+++ b/src/PortalRegistry.sol
@@ -135,7 +135,7 @@ contract PortalRegistry is OwnableUpgradeable {
     address[] memory modules = AbstractPortal(id).getModules();
 
     // Add portal to mapping
-    Portal memory newPortal = Portal(id, name, description, modules, isRevocable, msg.sender, ownerName);
+    Portal memory newPortal = Portal(id, msg.sender, modules, isRevocable, name, description, ownerName);
     portals[id] = newPortal;
     portalAddresses.push(id);
 

--- a/src/example/EASPortal.sol
+++ b/src/example/EASPortal.sol
@@ -1,10 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.21;
 
-import { AttestationRegistry } from "../AttestationRegistry.sol";
-import { ModuleRegistry } from "../ModuleRegistry.sol";
 import { AbstractPortal } from "../interface/AbstractPortal.sol";
-import { Attestation, AttestationPayload, Portal } from "../types/Structs.sol";
+import { AttestationPayload } from "../types/Structs.sol";
 
 /**
  * @title EAS Portal

--- a/src/example/EASPortal.sol
+++ b/src/example/EASPortal.sol
@@ -14,11 +14,11 @@ contract EASPortal is AbstractPortal {
   // this definition was taken from: https://github.com/ethereum-attestation-service/eas-contracts/blob/master/contracts/IEAS.sol#L9
   struct AttestationRequestData {
     address recipient;
-    bytes32 refUID;
     uint64 expirationTime;
-    uint256 value;
     bool revocable;
+    bytes32 refUID;
     bytes data;
+    uint256 value;
   }
 
   // @notice This struct is defined in EAS's contracts' codebase

--- a/src/example/EASPortal.sol
+++ b/src/example/EASPortal.sol
@@ -16,11 +16,11 @@ contract EASPortal is AbstractPortal {
   // this definition was taken from: https://github.com/ethereum-attestation-service/eas-contracts/blob/master/contracts/IEAS.sol#L9
   struct AttestationRequestData {
     address recipient;
-    uint64 expirationTime;
-    bool revocable;
     bytes32 refUID;
-    bytes data;
+    uint64 expirationTime;
     uint256 value;
+    bool revocable;
+    bytes data;
   }
 
   // @notice This struct is defined in EAS's contracts' codebase
@@ -33,7 +33,7 @@ contract EASPortal is AbstractPortal {
 
   function _beforeAttest(AttestationPayload memory attestation, uint256 value) internal override {}
 
-  function _afterAttest(Attestation memory attestation) internal override {}
+  function _afterAttest() internal override {}
 
   function _onRevoke(bytes32 attestationId, bytes32 replacedBy) internal override {}
 
@@ -49,8 +49,8 @@ contract EASPortal is AbstractPortal {
 
     AttestationPayload memory attestationPayload = AttestationPayload(
       attestationRequest.schema,
+      attestationRequest.data.expirationTime,
       abi.encodePacked(attestationRequest.data.recipient),
-      uint256(attestationRequest.data.expirationTime),
       attestationRequest.data.data
     );
 
@@ -61,11 +61,11 @@ contract EASPortal is AbstractPortal {
     AttestationPayload[] memory attestationsPayloads = new AttestationPayload[](attestationsRequests.length);
     bytes[][] memory validationPayloads = new bytes[][](attestationsRequests.length);
 
-    for (uint i = 0; i < attestationsRequests.length; i++) {
+    for (uint256 i = 0; i < attestationsRequests.length; i++) {
       attestationsPayloads[i] = AttestationPayload(
         attestationsRequests[i].schema,
+        attestationsRequests[i].data.expirationTime,
         abi.encodePacked(attestationsRequests[i].data.recipient),
-        uint256(attestationsRequests[i].data.expirationTime),
         attestationsRequests[i].data.data
       );
 

--- a/src/interface/AbstractPortal.sol
+++ b/src/interface/AbstractPortal.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.21;
 
 import { AttestationRegistry } from "../AttestationRegistry.sol";
 import { ModuleRegistry } from "../ModuleRegistry.sol";
-import { Attestation, AttestationPayload } from "../types/Structs.sol";
+import { AttestationPayload } from "../types/Structs.sol";
 // solhint-disable-next-line max-line-length
 import { IERC165Upgradeable } from "openzeppelin-contracts-upgradeable/contracts/utils/introspection/ERC165Upgradeable.sol";
 import { Initializable } from "openzeppelin-contracts-upgradeable/contracts/proxy/utils/Initializable.sol";

--- a/src/interface/AbstractPortal.sol
+++ b/src/interface/AbstractPortal.sol
@@ -36,16 +36,14 @@ abstract contract AbstractPortal is Initializable, IERC165Upgradeable {
   function attest(
     AttestationPayload memory attestationPayload,
     bytes[] memory validationPayload
-  ) public payable virtual returns (bytes32) {
+  ) public payable virtual {
     if (modules.length != 0) _runModules(attestationPayload, validationPayload);
 
     _beforeAttest(attestationPayload, msg.value);
 
-    Attestation memory attestation = attestationRegistry.attest(attestationPayload);
+    attestationRegistry.attest(attestationPayload);
 
-    _afterAttest(attestation);
-
-    return attestation.attestationId;
+    _afterAttest();
   }
 
   /**
@@ -99,7 +97,7 @@ abstract contract AbstractPortal is Initializable, IERC165Upgradeable {
 
   function _beforeAttest(AttestationPayload memory attestationPayload, uint256 value) internal virtual;
 
-  function _afterAttest(Attestation memory attestation) internal virtual;
+  function _afterAttest() internal virtual;
 
   function _onRevoke(bytes32 attestationId, bytes32 replacedBy) internal virtual;
 

--- a/src/portal/DefaultPortal.sol
+++ b/src/portal/DefaultPortal.sol
@@ -15,7 +15,7 @@ import { Attestation, AttestationPayload, Portal } from "../types/Structs.sol";
 contract DefaultPortal is AbstractPortal {
   function _beforeAttest(AttestationPayload memory attestation, uint256 value) internal override {}
 
-  function _afterAttest(Attestation memory attestation) internal override {}
+  function _afterAttest() internal override {}
 
   function _onRevoke(bytes32 attestationId, bytes32 replacedBy) internal override {}
 

--- a/src/portal/DefaultPortal.sol
+++ b/src/portal/DefaultPortal.sol
@@ -1,11 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.21;
 
-// solhint-disable-next-line max-line-length
-import { AttestationRegistry } from "../AttestationRegistry.sol";
-import { ModuleRegistry } from "../ModuleRegistry.sol";
 import { AbstractPortal } from "../interface/AbstractPortal.sol";
-import { Attestation, AttestationPayload, Portal } from "../types/Structs.sol";
+import { AttestationPayload } from "../types/Structs.sol";
 
 /**
  * @title Default Portal

--- a/src/types/Structs.sol
+++ b/src/types/Structs.sol
@@ -3,23 +3,23 @@ pragma solidity 0.8.21;
 
 struct AttestationPayload {
   bytes32 schemaId; // The identifier of the schema this attestation adheres to.
+  uint64 expirationDate; // The expiration date of the attestation.
   bytes subject; // The ID of the attestee, EVM address, DID, URL etc.
-  uint256 expirationDate; // The expiration date of the attestation.
   bytes attestationData; // The attestation data.
 }
 
 struct Attestation {
   bytes32 attestationId; // The unique identifier of the attestation.
   bytes32 schemaId; // The identifier of the schema this attestation adheres to.
+  bytes32 replacedBy; // Whether the attestation was replaced by a new one.
   address attester; // The address issuing the attestation to the subject.
   address portal; // The id of the portal that created the attestation.
-  bytes subject; // The ID of the attestee, EVM address, DID, URL etc.
-  uint256 attestedDate; // The date the attestation is issued.
-  uint256 expirationDate; // The expiration date of the attestation.
-  bool revoked; // Whether the attestation is revoked or not.
-  uint256 revocationDate; // The date when the attestation was revoked.
-  bytes32 replacedBy; // Whether the attestation was replaced by a new one.
+  uint64 attestedDate; // The date the attestation is issued.
+  uint64 expirationDate; // The expiration date of the attestation.
+  uint64 revocationDate; // The date when the attestation was revoked.
   uint16 version; // Version of the registry when the attestation was created.
+  bool revoked; // Whether the attestation is revoked or not.
+  bytes subject; // The ID of the attestee, EVM address, DID, URL etc.
   bytes attestationData; // The attestation data.
 }
 
@@ -32,16 +32,16 @@ struct Schema {
 
 struct Portal {
   address id; // The unique identifier of the portal.
-  string name; // The name of the portal.
-  string description; // A description of the portal.
+  address ownerAddress; // The address of the owner of this portal.
   address[] modules; // Addresses of modules implemented by the portal.
   bool isRevocable; // Whether attestations issued can be revoked.
-  address ownerAddress; // The address of the owner of this portal.
+  string name; // The name of the portal.
+  string description; // A description of the portal.
   string ownerName; // The name of the owner of this portal.
 }
 
 struct Module {
+  address moduleAddress; // The address of the module.
   string name; // The name of the module.
   string description; // A description of the module.
-  address moduleAddress; // The address of the module.
 }

--- a/test/AttestationRegistry.t.sol
+++ b/test/AttestationRegistry.t.sol
@@ -19,7 +19,7 @@ contract AttestationRegistryTest is Test {
   address public schemaRegistryAddress;
 
   event Initialized(uint8 version);
-  event AttestationRegistered(bytes32 indexed attestationId, Attestation attestation);
+  event AttestationRegistered(bytes32 indexed attestationId);
   event BulkAttestationsRegistered(Attestation[] attestations);
   event AttestationRevoked(bytes32 attestationId, bytes32 replacedBy);
   event BulkAttestationsRevoked(bytes32[] attestationId, bytes32[] replacedBy);
@@ -74,7 +74,7 @@ contract AttestationRegistryTest is Test {
 
     Attestation memory attestation = _createAttestation(attestationPayload, 1);
     vm.expectEmit(true, true, true, true);
-    emit AttestationRegistered(attestation.attestationId, attestation);
+    emit AttestationRegistered(attestation.attestationId);
     vm.prank(portal);
     attestationRegistry.attest(attestationPayload);
 
@@ -141,13 +141,12 @@ contract AttestationRegistryTest is Test {
     payloadsToAttest[1] = attestationsPayloads[1];
 
     vm.expectEmit(true, true, true, true);
-
-    emit BulkAttestationsRegistered(attestations);
+    emit AttestationRegistered(attestations[0].attestationId);
+    vm.expectEmit(true, true, true, true);
+    emit AttestationRegistered(attestations[1].attestationId);
     vm.prank(portal);
 
-    Attestation[] memory registeredAttestations = attestationRegistry.bulkAttest(payloadsToAttest);
-    _assertAttestation(attestation1, registeredAttestations[0]);
-    _assertAttestation(attestation2, registeredAttestations[1]);
+    attestationRegistry.bulkAttest(payloadsToAttest);
   }
 
   function test_revoke(AttestationPayload memory attestationPayload) public {
@@ -474,15 +473,15 @@ contract AttestationRegistryTest is Test {
     Attestation memory attestation = Attestation(
       bytes32(abi.encode(id)),
       attestationPayload.schemaId,
+      bytes32(0),
       tx.origin,
       portal,
-      attestationPayload.subject,
-      block.timestamp,
+      uint64(block.timestamp),
       attestationPayload.expirationDate,
-      false,
       0,
-      bytes32(0),
       versionNumber,
+      false,
+      attestationPayload.subject,
       attestationPayload.attestationData
     );
     return attestation;

--- a/test/AttestationRegistry.t.sol
+++ b/test/AttestationRegistry.t.sol
@@ -7,7 +7,7 @@ import { AttestationRegistry } from "../src/AttestationRegistry.sol";
 import { PortalRegistryMock } from "./mocks/PortalRegistryMock.sol";
 import { PortalRegistry } from "../src/PortalRegistry.sol";
 import { SchemaRegistryMock } from "./mocks/SchemaRegistryMock.sol";
-import { Attestation, AttestationPayload, Portal } from "../src/types/Structs.sol";
+import { Attestation, AttestationPayload } from "../src/types/Structs.sol";
 import { Router } from "../src/Router.sol";
 
 contract AttestationRegistryTest is Test {
@@ -444,7 +444,7 @@ contract AttestationRegistryTest is Test {
     SchemaRegistryMock schemaRegistryMock = SchemaRegistryMock(router.getSchemaRegistry());
     attestationPayload.schemaId = schemaRegistryMock.getIdFromSchemaString("schemaString");
     schemaRegistryMock.createSchema("name", "description", "context", "schemaString");
-    uint version = attestationRegistry.getAttestationIdCounter();
+    uint32 version = attestationRegistry.getAttestationIdCounter();
 
     assertEq(version, 0);
 

--- a/test/ModuleRegistry.t.sol
+++ b/test/ModuleRegistry.t.sol
@@ -38,8 +38,8 @@ contract ModuleRegistryTest is Test {
 
     attestationPayload = AttestationPayload(
       bytes32(uint256(1)),
-      bytes("subject"),
       uint64(block.timestamp + 1 days),
+      bytes("subject"),
       new bytes(1)
     );
   }
@@ -84,10 +84,10 @@ contract ModuleRegistryTest is Test {
     vm.prank(user);
     moduleRegistry.register(expectedName, expectedDescription, expectedAddress);
 
-    (string memory name, string memory description, address moduleAddress) = moduleRegistry.modules(expectedAddress);
+    (address moduleAddress, string memory name, string memory description) = moduleRegistry.modules(expectedAddress);
+    assertEq(moduleAddress, expectedAddress);
     assertEq(name, expectedName);
     assertEq(description, expectedDescription);
-    assertEq(moduleAddress, expectedAddress);
   }
 
   function testCannotRegisterModuleWithInvalidIssuer() public {

--- a/test/ModuleRegistry.t.sol
+++ b/test/ModuleRegistry.t.sol
@@ -6,7 +6,6 @@ import { Test } from "forge-std/Test.sol";
 import { ModuleRegistry } from "../src/ModuleRegistry.sol";
 import { CorrectModule } from "../src/example/CorrectModule.sol";
 import { IncorrectModule } from "../src/example/IncorrectModule.sol";
-import { AbstractModule } from "../src/interface/AbstractModule.sol";
 import { PortalRegistryMock } from "./mocks/PortalRegistryMock.sol";
 import { AttestationPayload } from "../src/types/Structs.sol";
 import { Router } from "../src/Router.sol";

--- a/test/PortalRegistry.t.sol
+++ b/test/PortalRegistry.t.sol
@@ -6,9 +6,7 @@ import { Test } from "forge-std/Test.sol";
 import { PortalRegistry } from "../src/PortalRegistry.sol";
 import { AbstractPortal } from "../src/interface/AbstractPortal.sol";
 import { CorrectModule } from "../src/example/CorrectModule.sol";
-import { AttestationPayload, Portal, Attestation } from "../src/types/Structs.sol";
-// solhint-disable-next-line max-line-length
-import { IERC165Upgradeable } from "openzeppelin-contracts-upgradeable/contracts/utils/introspection/IERC165Upgradeable.sol";
+import { AttestationPayload, Portal } from "../src/types/Structs.sol";
 import { Router } from "../src/Router.sol";
 import { AttestationRegistryMock } from "./mocks/AttestationRegistryMock.sol";
 import { ModuleRegistryMock } from "./mocks/ModuleRegistryMock.sol";

--- a/test/PortalRegistry.t.sol
+++ b/test/PortalRegistry.t.sol
@@ -95,11 +95,11 @@ contract PortalRegistryTest is Test {
 
     Portal memory expectedPortal = Portal(
       address(validPortal),
-      expectedName,
-      expectedDescription,
+      user,
       new address[](0),
       true,
-      user,
+      expectedName,
+      expectedDescription,
       expectedOwnerName
     );
 
@@ -198,7 +198,7 @@ contract ValidPortal is AbstractPortal {
 
   function _beforeAttest(AttestationPayload memory attestationPayload, uint256 value) internal override {}
 
-  function _afterAttest(Attestation memory attestation) internal override {}
+  function _afterAttest() internal override {}
 
   function _onRevoke(bytes32 attestationId, bytes32 replacedBy) internal override {}
 

--- a/test/Router.t.sol
+++ b/test/Router.t.sol
@@ -3,7 +3,6 @@ pragma solidity 0.8.21;
 
 import { Vm } from "forge-std/Vm.sol";
 import { Test } from "forge-std/Test.sol";
-import { SchemaRegistry } from "../src/SchemaRegistry.sol";
 import { Router } from "../src/Router.sol";
 
 contract RouterTest is Test {

--- a/test/example/EASPortal.t.sol
+++ b/test/example/EASPortal.t.sol
@@ -33,11 +33,11 @@ contract EASPortalTest is Test {
     // Create EAS attestation request
     EASPortal.AttestationRequestData memory attestationRequestData = EASPortal.AttestationRequestData(
       makeAddr("recipient"),
-      bytes32("refUID"),
       uint64(block.timestamp + 1 days),
-      uint256(1),
       false,
-      new bytes(0)
+      bytes32("refUID"),
+      new bytes(0),
+      uint256(1)
     );
     EASPortal.AttestationRequest memory attestationRequest = EASPortal.AttestationRequest(
       bytes32(uint256(1)),
@@ -53,11 +53,11 @@ contract EASPortalTest is Test {
     // Create EAS attestation request
     EASPortal.AttestationRequestData memory attestationRequestData = EASPortal.AttestationRequestData(
       makeAddr("recipient"),
-      bytes32("refUID"),
       uint64(block.timestamp + 1 days),
-      uint256(1),
       false,
-      new bytes(0)
+      bytes32("refUID"),
+      new bytes(0),
+      uint256(1)
     );
 
     EASPortal.AttestationRequest[] memory attestationsRequests = new EASPortal.AttestationRequest[](2);

--- a/test/example/EASPortal.t.sol
+++ b/test/example/EASPortal.t.sol
@@ -35,11 +35,11 @@ contract EASPortalTest is Test {
     // Create EAS attestation request
     EASPortal.AttestationRequestData memory attestationRequestData = EASPortal.AttestationRequestData(
       makeAddr("recipient"),
-      uint64(block.timestamp + 1 days),
-      false,
       bytes32("refUID"),
-      new bytes(0),
-      uint256(1)
+      uint64(block.timestamp + 1 days),
+      uint256(1),
+      false,
+      new bytes(0)
     );
     EASPortal.AttestationRequest memory attestationRequest = EASPortal.AttestationRequest(
       bytes32(uint256(1)),
@@ -55,11 +55,11 @@ contract EASPortalTest is Test {
     // Create EAS attestation request
     EASPortal.AttestationRequestData memory attestationRequestData = EASPortal.AttestationRequestData(
       makeAddr("recipient"),
-      uint64(block.timestamp + 1 days),
-      false,
       bytes32("refUID"),
-      new bytes(0),
-      uint256(1)
+      uint64(block.timestamp + 1 days),
+      uint256(1),
+      false,
+      new bytes(0)
     );
 
     EASPortal.AttestationRequest[] memory attestationsRequests = new EASPortal.AttestationRequest[](2);

--- a/test/example/EASPortal.t.sol
+++ b/test/example/EASPortal.t.sol
@@ -5,8 +5,6 @@ import { Vm } from "forge-std/Vm.sol";
 import { Test } from "forge-std/Test.sol";
 import { EASPortal } from "../../src/example/EASPortal.sol";
 import { AbstractPortal } from "../../src/interface/AbstractPortal.sol";
-import { AttestationPayload } from "../../src/types/Structs.sol";
-import { CorrectModule } from "../../src/example/CorrectModule.sol";
 import { AttestationRegistryMock } from "../mocks/AttestationRegistryMock.sol";
 import { ModuleRegistryMock } from "../mocks/ModuleRegistryMock.sol";
 import { ERC165Upgradeable } from "openzeppelin-contracts-upgradeable/contracts/utils/introspection/ERC165Upgradeable.sol";

--- a/test/example/MsgSenderModule.t.sol
+++ b/test/example/MsgSenderModule.t.sol
@@ -23,8 +23,8 @@ contract MsgSenderModuleTest is Test {
 
     attestationPayload = AttestationPayload(
       bytes32(uint256(1)),
-      bytes("subject"),
       uint64(block.timestamp + 1 days),
+      bytes("subject"),
       new bytes(1)
     );
   }

--- a/test/mocks/AttestationRegistryMock.sol
+++ b/test/mocks/AttestationRegistryMock.sol
@@ -19,15 +19,15 @@ contract AttestationRegistryMock {
     Attestation memory attestation = Attestation(
       bytes32(abi.encode(1)),
       attestationPayload.schemaId,
+      bytes32(0),
       tx.origin,
       msg.sender,
-      attestationPayload.subject,
-      block.timestamp,
+      uint64(block.timestamp),
       attestationPayload.expirationDate,
-      false,
       0,
-      bytes32(0),
       version,
+      false,
+      attestationPayload.subject,
       attestationPayload.attestationData
     );
     emit AttestationRegistered();

--- a/test/mocks/ModuleRegistryMock.sol
+++ b/test/mocks/ModuleRegistryMock.sol
@@ -20,9 +20,9 @@ contract ModuleRegistryMock {
     AttestationPayload[] memory attestationsPayloads,
     bytes[][] memory validationPayloads
   ) public {
-    require(modulesAddresses.length >= 0, "Invalid input for modulesAddresses");
-    require(attestationsPayloads.length >= 0, "Invalid input for attestationsPayloads");
-    require(validationPayloads.length >= 0, "Invalid input for validationPayloads");
+    require(modulesAddresses.length >= 0, "Invalid modulesAddresses");
+    require(attestationsPayloads.length >= 0, "Invalid attestationsPayloads");
+    require(validationPayloads.length >= 0, "Invalid validationPayloads");
     emit ModulesBulkRunForAttestation();
   }
 }

--- a/test/mocks/PortalRegistryMock.sol
+++ b/test/mocks/PortalRegistryMock.sol
@@ -19,7 +19,7 @@ contract PortalRegistryMock {
     bool isRevocable,
     string memory ownerName
   ) external {
-    Portal memory newPortal = Portal(id, name, description, new address[](0), isRevocable, msg.sender, ownerName);
+    Portal memory newPortal = Portal(id, msg.sender, new address[](0), isRevocable, name, description, ownerName);
     portals[id] = newPortal;
     emit PortalRegistered(name, description, id);
   }

--- a/test/portal/DefaultPortal.t.sol
+++ b/test/portal/DefaultPortal.t.sol
@@ -60,8 +60,8 @@ contract DefaultPortalTest is Test {
     // Create attestation payload
     AttestationPayload memory attestationPayload = AttestationPayload(
       bytes32(uint256(1)),
+      uint64(block.timestamp + 1 days),
       bytes("subject"),
-      block.timestamp + 1 days,
       new bytes(1)
     );
     // Create validation payload


### PR DESCRIPTION
## What does this PR do?

Optimizes various points to get cheaper attestation issuance:
- Smaller events data
- Less events
- No useless returned value
- Timestamp as `uint64`
- Better packed struct definition

### Related ticket

Fixes #145 

### Type of change

- [X] Chore
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update

## Check list

- [X] Unit tests for any smart contract change
- [X] Contracts and functions are documented
