### PR TITLE
feat: Investigate mass import mechanism

### DIFF
--- a/src/AttestationRegistry.sol
+++ b/src/AttestationRegistry.sol
@@ -94,9 +94,10 @@ contract AttestationRegistry is OwnableUpgradeable {
     if (attestationPayload.attestationData.length == 0) revert AttestationDataFieldEmpty();
     // Auto increment attestation counter
     attestationIdCounter++;
+    bytes32 id = bytes32(abi.encode(attestationIdCounter));
     // Create attestation
-    Attestation memory attestation = Attestation(
-      bytes32(abi.encode(attestationIdCounter)),
+    attestations[id] = Attestation(
+      id,
       attestationPayload.schemaId,
       bytes32(0),
       attester,
@@ -109,8 +110,7 @@ contract AttestationRegistry is OwnableUpgradeable {
       attestationPayload.subject,
       attestationPayload.attestationData
     );
-    attestations[attestation.attestationId] = attestation;
-    emit AttestationRegistered(attestation.attestationId);
+    emit AttestationRegistered(id);
   }
 
   /**
@@ -120,6 +120,29 @@ contract AttestationRegistry is OwnableUpgradeable {
   function bulkAttest(AttestationPayload[] calldata attestationsPayloads, address attester) public {
     for (uint256 i = 0; i < attestationsPayloads.length; i++) {
       attest(attestationsPayloads[i], attester);
+    }
+  }
+
+  function massImport(AttestationPayload[] calldata attestationsPayloads, address portal) public onlyOwner {
+    for (uint256 i = 0; i < attestationsPayloads.length; i++) {
+      // Auto increment attestation counter
+      attestationIdCounter++;
+      bytes32 id = bytes32(abi.encode(attestationIdCounter));
+      // Create attestation
+      attestations[id] = Attestation(
+        id,
+        attestationsPayloads[i].schemaId,
+        bytes32(0),
+        msg.sender,
+        portal,
+        uint64(block.timestamp),
+        attestationsPayloads[i].expirationDate,
+        0,
+        version,
+        false,
+        attestationsPayloads[i].subject,
+        attestationsPayloads[i].attestationData
+      );
     }
   }
 

--- a/test/AttestationRegistry.t.sol
+++ b/test/AttestationRegistry.t.sol
@@ -150,6 +150,34 @@ contract AttestationRegistryTest is Test {
     attestationRegistry.bulkAttest(payloadsToAttest, attester);
   }
 
+  function test_massImport(AttestationPayload[2] memory attestationsPayloads) public {
+    vm.assume(attestationsPayloads[0].subject.length != 0);
+    vm.assume(attestationsPayloads[0].attestationData.length != 0);
+    vm.assume(attestationsPayloads[1].subject.length != 0);
+    vm.assume(attestationsPayloads[1].attestationData.length != 0);
+
+    SchemaRegistryMock schemaRegistryMock = SchemaRegistryMock(router.getSchemaRegistry());
+    attestationsPayloads[0].schemaId = schemaRegistryMock.getIdFromSchemaString("schemaString");
+    attestationsPayloads[1].schemaId = schemaRegistryMock.getIdFromSchemaString("schemaString");
+
+    AttestationPayload[] memory payloadsToAttest = new AttestationPayload[](2);
+    payloadsToAttest[0] = attestationsPayloads[0];
+    payloadsToAttest[1] = attestationsPayloads[1];
+
+    bool isRegistered1 = attestationRegistry.isRegistered(bytes32(abi.encode(1)));
+    assertFalse(isRegistered1);
+    bool isRegistered2 = attestationRegistry.isRegistered(bytes32(abi.encode(2)));
+    assertFalse(isRegistered2);
+
+    vm.prank(address(0));
+    attestationRegistry.massImport(payloadsToAttest, portal);
+
+    isRegistered1 = attestationRegistry.isRegistered(bytes32(abi.encode(1)));
+    assertTrue(isRegistered1);
+    isRegistered2 = attestationRegistry.isRegistered(bytes32(abi.encode(2)));
+    assertTrue(isRegistered2);
+  }
+
   function test_revoke(AttestationPayload memory attestationPayload) public {
     vm.assume(attestationPayload.subject.length != 0);
     vm.assume(attestationPayload.attestationData.length != 0);

--- a/test/integration/AttestationRegistryMass.t.sol
+++ b/test/integration/AttestationRegistryMass.t.sol
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.21;
+
+import { Test } from "forge-std/Test.sol";
+import { AttestationRegistry } from "../../src/AttestationRegistry.sol";
+import { PortalRegistry } from "../../src/PortalRegistry.sol";
+import { SchemaRegistry } from "../../src/SchemaRegistry.sol";
+import { ModuleRegistry } from "../../src/ModuleRegistry.sol";
+import { DefaultPortal } from "../../src/portal/DefaultPortal.sol";
+import { Attestation, AttestationPayload } from "../../src/types/Structs.sol";
+import { Router } from "../../src/Router.sol";
+
+contract AttestationRegistryMassTest is Test {
+  address public portalOwner = makeAddr("portalOwner");
+  Router public router;
+  AttestationRegistry public attestationRegistry;
+  PortalRegistry public portalRegistry;
+  SchemaRegistry public schemaRegistry;
+  ModuleRegistry public moduleRegistry;
+  bytes32 public schemaId;
+  AttestationPayload[] public payloadsToAttest;
+  bytes[][] public validationPayloads;
+  DefaultPortal public defaultPortal;
+
+  event Initialized(uint8 version);
+  event AttestationRegistered(bytes32 indexed attestationId);
+  event BulkAttestationsRegistered(Attestation[] attestations);
+  event AttestationRevoked(bytes32 attestationId, bytes32 replacedBy);
+  event BulkAttestationsRevoked(bytes32[] attestationId, bytes32[] replacedBy);
+  event VersionUpdated(uint16 version);
+
+  function setUp() public {
+    router = new Router();
+    router.initialize();
+
+    attestationRegistry = new AttestationRegistry();
+    router.updateAttestationRegistry(address(attestationRegistry));
+    vm.prank(address(0));
+    attestationRegistry.updateRouter(address(router));
+
+    portalRegistry = new PortalRegistry();
+    router.updatePortalRegistry(address(portalRegistry));
+    vm.prank(address(0));
+    portalRegistry.updateRouter(address(router));
+
+    schemaRegistry = new SchemaRegistry();
+    router.updateSchemaRegistry(address(schemaRegistry));
+    vm.prank(address(0));
+    schemaRegistry.updateRouter(address(router));
+
+    moduleRegistry = new ModuleRegistry();
+    router.updateModuleRegistry(address(moduleRegistry));
+    vm.prank(address(0));
+    moduleRegistry.updateRouter(address(router));
+
+    vm.prank(address(0));
+    portalRegistry.setIssuer(portalOwner);
+    vm.prank(portalOwner);
+    address[] memory modules = new address[](0);
+    defaultPortal = new DefaultPortal();
+    defaultPortal.initialize(modules, address(router));
+
+    vm.prank(portalOwner);
+    portalRegistry.register(address(defaultPortal), "Name", "Description", true, "Linea");
+
+    schemaId = schemaRegistry.getIdFromSchemaString("uint8 tier");
+    vm.prank(portalOwner);
+    schemaRegistry.createSchema("name", "description", "context", "uint8 tier");
+
+    AttestationPayload memory attestationPayload = AttestationPayload(
+      schemaId,
+      1794160904,
+      bytes(abi.encode(address(0x809e815596AbEB3764aBf81BE2DC39fBBAcc9949))),
+      bytes(abi.encode(uint8(4)))
+    );
+
+    payloadsToAttest.push(attestationPayload);
+    payloadsToAttest.push(attestationPayload);
+
+    // Create validation payloads
+    bytes[] memory validationPayload1 = new bytes[](1);
+    bytes[] memory validationPayload2 = new bytes[](1);
+
+    validationPayloads = new bytes[][](2);
+    validationPayloads[0] = validationPayload1;
+    validationPayloads[1] = validationPayload2;
+  }
+
+  function test_bulkAttest() public {
+    vm.prank(address(defaultPortal));
+    attestationRegistry.bulkAttest(payloadsToAttest, address(this));
+  }
+
+  function test_bulkAttestThroughPortal() public {
+    vm.prank(address(0));
+    defaultPortal.bulkAttest(payloadsToAttest, validationPayloads);
+  }
+
+  function test_massImport() public {
+    vm.prank(address(0));
+    attestationRegistry.massImport(payloadsToAttest, address(defaultPortal));
+  }
+}


### PR DESCRIPTION
## What does this PR do?

* Adds a `massImport` method to create cheap attestations in batch
* Adds some "integration tests" to compare the gas cost for issuing attestations via `massImport` and `bulkAttest`

### Related ticket

Fixes #156 

### Type of change

- [ ] Chore
- [ ] Bug fix
- [X] New feature
- [ ] Documentation update

## Check list

- [ ] Unit tests for any smart contract change
- [ ] Contracts and functions are documented
