### PR TITLE
feat: As an Issuer, I want my module(s) not to be upgradeable

### DIFF
--- a/src/example/MsgSenderModule.sol
+++ b/src/example/MsgSenderModule.sol
@@ -4,15 +4,15 @@ pragma solidity 0.8.21;
 import { AbstractModule } from "../interface/AbstractModule.sol";
 // solhint-disable-next-line max-line-length
 import { IERC165Upgradeable } from "openzeppelin-contracts-upgradeable/contracts/utils/introspection/IERC165Upgradeable.sol";
-import { Initializable } from "openzeppelin-contracts-upgradeable/contracts/proxy/utils/Initializable.sol";
 import { AttestationPayload } from "../types/Structs.sol";
 
 /**
  * @title Msg Sender Module
  * @author Consensys
  * @notice This contract is an example of a module, able to check if the transaction sender is a given address
+ * @dev A module should not be initializable (to prevent it from being upgradeable)
  */
-contract MsgSenderModule is IERC165Upgradeable, AbstractModule, Initializable {
+contract MsgSenderModule is IERC165Upgradeable, AbstractModule {
   /// @dev The address expected by this module
   address public expectedMsgSender;
 
@@ -20,9 +20,9 @@ contract MsgSenderModule is IERC165Upgradeable, AbstractModule, Initializable {
   error WrongTransactionSender();
 
   /**
-   * @notice Contract initialization
+   * @param _expectedMsgSender the expected caller to be validated against
    */
-  function initialize(address _expectedMsgSender) public initializer {
+  constructor(address _expectedMsgSender) {
     expectedMsgSender = _expectedMsgSender;
   }
 

--- a/test/example/MsgSenderModule.t.sol
+++ b/test/example/MsgSenderModule.t.sol
@@ -15,11 +15,9 @@ contract MsgSenderModuleTest is Test {
   AttestationPayload private attestationPayload;
 
   event ModuleRegistered(string name, string description, address moduleAddress);
-  event Initialized(uint8 version);
 
   function setUp() public {
-    msgSenderModule = new MsgSenderModule();
-    msgSenderModule.initialize(expectedMsgSender);
+    msgSenderModule = new MsgSenderModule(expectedMsgSender);
 
     attestationPayload = AttestationPayload(
       bytes32(uint256(1)),
@@ -27,14 +25,6 @@ contract MsgSenderModuleTest is Test {
       bytes("subject"),
       new bytes(1)
     );
-  }
-
-  function testInitialize() public {
-    msgSenderModule = new MsgSenderModule();
-    vm.expectEmit();
-    emit Initialized(1);
-    msgSenderModule.initialize(expectedMsgSender);
-    assertEq(msgSenderModule.expectedMsgSender(), expectedMsgSender);
   }
 
   function testCorrectMsgSenderAddress() public {


### PR DESCRIPTION
## What does this PR do?

Removes the "initializable" behaviour of the `MsgSenderModule`, therefore making it not upgradeable.

### Related ticket

Fixes #178 

### Type of change

- [ ] Chore
- [ ] Bug fix
- [X] New feature
- [ ] Documentation update

## Check list

- [X] Unit tests for any smart contract change
- [X] Contracts and functions are documented
