### PR TITLE
fix: Portal should not be initializable/upgradeable

### DIFF
--- a/src/PortalRegistry.sol
+++ b/src/PortalRegistry.sol
@@ -157,8 +157,7 @@ contract PortalRegistry is OwnableUpgradeable {
     bool isRevocable,
     string memory ownerName
   ) external onlyIssuers(msg.sender) {
-    DefaultPortal defaultPortal = new DefaultPortal();
-    defaultPortal.initialize(modules, address(router));
+    DefaultPortal defaultPortal = new DefaultPortal(modules, address(router));
     register(address(defaultPortal), name, description, isRevocable, ownerName);
   }
 

--- a/src/example/EASPortal.sol
+++ b/src/example/EASPortal.sol
@@ -38,6 +38,8 @@ contract EASPortal is AbstractPortal {
   /// @notice Error thrown when trying to bulk revoke attestations
   error NoBulkRevocation();
 
+  constructor(address[] memory modules, address router) AbstractPortal(modules, router) {}
+
   function withdraw(address payable to, uint256 amount) external override {}
 
   function attest(AttestationRequest memory attestationRequest) public payable {

--- a/src/interface/AbstractPortal.sol
+++ b/src/interface/AbstractPortal.sol
@@ -5,12 +5,10 @@ import { AttestationRegistry } from "../AttestationRegistry.sol";
 import { ModuleRegistry } from "../ModuleRegistry.sol";
 import { PortalRegistry } from "../PortalRegistry.sol";
 import { AttestationPayload } from "../types/Structs.sol";
-// solhint-disable-next-line max-line-length
-import { IERC165Upgradeable } from "openzeppelin-contracts-upgradeable/contracts/utils/introspection/ERC165Upgradeable.sol";
-import { Initializable } from "openzeppelin-contracts-upgradeable/contracts/proxy/utils/Initializable.sol";
+import { IERC165 } from "openzeppelin-contracts/contracts/utils/introspection/ERC165.sol";
 import { IRouter } from "../interface/IRouter.sol";
 
-abstract contract AbstractPortal is Initializable, IERC165Upgradeable {
+abstract contract AbstractPortal is IERC165 {
   IRouter public router;
   address[] public modules;
   ModuleRegistry public moduleRegistry;
@@ -21,12 +19,12 @@ abstract contract AbstractPortal is Initializable, IERC165Upgradeable {
   error OnlyPortalOwner();
 
   /**
-   * @notice Contract initialization
+   * @notice Contract constructor
    * @param _modules list of modules to use for the portal (can be empty)
    * @param _router Router's address
+   * @dev This sets the addresses for the AttestationRegistry, ModuleRegistry and PortalRegistry
    */
-  function initialize(address[] calldata _modules, address _router) public virtual initializer {
-    // Store addresses for linked modules, ModuleRegistry and AttestationRegistry
+  constructor(address[] memory _modules, address _router) {
     modules = _modules;
     router = IRouter(_router);
     attestationRegistry = AttestationRegistry(router.getAttestationRegistry());
@@ -144,7 +142,7 @@ abstract contract AbstractPortal is Initializable, IERC165Upgradeable {
    * @return The list of modules addresses linked to the Portal
    */
   function supportsInterface(bytes4 interfaceID) public pure virtual override returns (bool) {
-    return interfaceID == type(AbstractPortal).interfaceId || interfaceID == type(IERC165Upgradeable).interfaceId;
+    return interfaceID == type(AbstractPortal).interfaceId || interfaceID == type(IERC165).interfaceId;
   }
 
   /**

--- a/src/portal/DefaultPortal.sol
+++ b/src/portal/DefaultPortal.sol
@@ -10,5 +10,7 @@ import { AbstractPortal } from "../interface/AbstractPortal.sol";
  * @dev This Portal does not add any logic to the AbstractPortal
  */
 contract DefaultPortal is AbstractPortal {
+  constructor(address[] memory modules, address router) AbstractPortal(modules, router) {}
+
   function withdraw(address payable to, uint256 amount) external override {}
 }

--- a/test/PortalRegistry.t.sol
+++ b/test/PortalRegistry.t.sol
@@ -43,7 +43,7 @@ contract PortalRegistryTest is Test {
     vm.prank(address(0));
     portalRegistry.setIssuer(user);
 
-    validPortalMock = new ValidPortalMock();
+    validPortalMock = new ValidPortalMock(new address[](0), address(router));
   }
 
   function test_alreadyInitialized() public {

--- a/test/example/EASPortal.t.sol
+++ b/test/example/EASPortal.t.sol
@@ -22,16 +22,11 @@ contract EASPortalTest is Test {
   event BulkAttestationsRegistered();
 
   function setUp() public {
-    easPortal = new EASPortal();
     router.initialize();
     router.updateModuleRegistry(address(moduleRegistryMock));
     router.updateAttestationRegistry(address(attestationRegistryMock));
-    easPortal.initialize(modules, address(router));
-  }
 
-  function test_initialize() public {
-    vm.expectRevert("Initializable: contract is already initialized");
-    easPortal.initialize(modules, address(router));
+    easPortal = new EASPortal(modules, address(router));
   }
 
   function test_attest() public {

--- a/test/integration/AttestationRegistryMass.t.sol
+++ b/test/integration/AttestationRegistryMass.t.sol
@@ -57,8 +57,7 @@ contract AttestationRegistryMassTest is Test {
     portalRegistry.setIssuer(portalOwner);
     vm.prank(portalOwner);
     address[] memory modules = new address[](0);
-    defaultPortal = new DefaultPortal();
-    defaultPortal.initialize(modules, address(router));
+    defaultPortal = new DefaultPortal(modules, address(router));
 
     vm.prank(portalOwner);
     portalRegistry.register(address(defaultPortal), "Name", "Description", true, "Linea");

--- a/test/mocks/ValidPortalMock.sol
+++ b/test/mocks/ValidPortalMock.sol
@@ -4,6 +4,8 @@ pragma solidity 0.8.21;
 import { AbstractPortal } from "../../src/interface/AbstractPortal.sol";
 
 contract ValidPortalMock is AbstractPortal {
+  constructor(address[] memory modules, address router) AbstractPortal(modules, router) {}
+
   function test() public {}
 
   function withdraw(address payable to, uint256 amount) external override {}

--- a/test/portal/DefaultPortal.t.sol
+++ b/test/portal/DefaultPortal.t.sol
@@ -32,17 +32,16 @@ contract DefaultPortalTest is Test {
   event BulkAttestationsRevoked(bytes32[] attestationId);
 
   function setUp() public {
-    modules.push(address(correctModule));
-    defaultPortal = new DefaultPortal();
     router.initialize();
     router.updateModuleRegistry(address(moduleRegistryMock));
     router.updateAttestationRegistry(address(attestationRegistryMock));
     router.updatePortalRegistry(address(portalRegistryMock));
 
+    modules.push(address(correctModule));
+    defaultPortal = new DefaultPortal(modules, address(router));
+
     vm.prank(portalOwner);
     portalRegistryMock.register(address(defaultPortal), "Name", "Description", true, "Owner name");
-
-    defaultPortal.initialize(modules, address(router));
   }
 
   function test_setup() public {
@@ -51,16 +50,6 @@ contract DefaultPortalTest is Test {
     assertEq(address(defaultPortal.attestationRegistry()), address(attestationRegistryMock));
     assertEq(address(defaultPortal.portalRegistry()), address(portalRegistryMock));
     assertEq(portalRegistryMock.getPortalByAddress(address(defaultPortal)).ownerAddress, portalOwner);
-  }
-
-  function test_initialize() public {
-    DefaultPortal defaultPortalTest = new DefaultPortal();
-    vm.expectEmit();
-    emit Initialized(1);
-    defaultPortalTest.initialize(modules, address(router));
-
-    vm.expectRevert("Initializable: contract is already initialized");
-    defaultPortalTest.initialize(modules, address(router));
   }
 
   function test_getModules() public {


### PR DESCRIPTION
## What does this PR do?

Prevents the portals from being initializable or upgradeable

### Related ticket

Fixes #198 

### Type of change

- [ ] Chore
- [X] Bug fix
- [ ] New feature
- [ ] Documentation update

## Check list

- [X] Unit tests for any smart contract change
- [ ] Contracts and functions are documented
