### PR TITLE
feat: As an Issuer, I want the context of a Schema to be optional

### DIFF
--- a/src/SchemaRegistry.sol
+++ b/src/SchemaRegistry.sol
@@ -28,8 +28,6 @@ contract SchemaRegistry is OwnableUpgradeable {
   error SchemaNameMissing();
   /// @notice Error thrown when attempting to add a Schema without a string to define it
   error SchemaStringMissing();
-  /// @notice Error thrown when attempting to add a Schema without a context
-  error SchemaContextMissing();
   /// @notice Error thrown when attempting to get a Schema that is not registered
   error SchemaNotRegistered();
 
@@ -94,7 +92,6 @@ contract SchemaRegistry is OwnableUpgradeable {
   ) public onlyIssuers(msg.sender) {
     if (bytes(name).length == 0) revert SchemaNameMissing();
     if (bytes(schemaString).length == 0) revert SchemaStringMissing();
-    if (bytes(context).length == 0) revert SchemaContextMissing();
 
     bytes32 schemaId = getIdFromSchemaString(schemaString);
 
@@ -114,7 +111,6 @@ contract SchemaRegistry is OwnableUpgradeable {
    */
   function updateContext(bytes32 schemaId, string memory context) public onlyIssuers(msg.sender) {
     if (!isRegistered(schemaId)) revert SchemaNotRegistered();
-    if (bytes(context).length == 0) revert SchemaContextMissing();
     schemas[schemaId].context = context;
   }
 

--- a/test/SchemaRegistry.t.sol
+++ b/test/SchemaRegistry.t.sol
@@ -93,12 +93,6 @@ contract SchemaRegistryTest is Test {
     schemaRegistry.createSchema(expectedName, expectedDescription, expectedContext, "");
   }
 
-  function testCannotCreateSchemaWithoutContext() public {
-    vm.expectRevert(SchemaRegistry.SchemaContextMissing.selector);
-    vm.prank(user);
-    schemaRegistry.createSchema(expectedName, expectedDescription, "", expectedString);
-  }
-
   function testCannotCreateSchemaTwice() public {
     vm.startPrank(user);
     schemaRegistry.createSchema(expectedName, expectedDescription, expectedContext, expectedString);
@@ -138,12 +132,11 @@ contract SchemaRegistryTest is Test {
     vm.stopPrank();
   }
 
-  function testCannotUpdateContextWithSchemaContextMissing() public {
+  function testCanUpdateContextWithEmptySchemaContext() public {
     vm.startPrank(user);
     schemaRegistry.createSchema(expectedName, expectedDescription, expectedContext, expectedString);
-
-    vm.expectRevert(SchemaRegistry.SchemaContextMissing.selector);
     schemaRegistry.updateContext(expectedId, "");
+    assertEq(schemaRegistry.getSchema(expectedId).context, "");
     vm.stopPrank();
   }
 


### PR DESCRIPTION
## What does this PR do?

Makes the `context` field of the Schema metadata optional

### Related ticket

Fixes #212 

### Type of change

- [ ] Chore
- [ ] Bug fix
- [X] New feature
- [ ] Documentation update

## Check list

- [X] Unit tests for any smart contract change
- [X] Contracts and functions are documented
