### PR TITLE
fix: The mass import feature should emit an AttestationRegistered event for each attestation created

### DIFF
--- a/src/AttestationRegistry.sol
+++ b/src/AttestationRegistry.sol
@@ -145,6 +145,7 @@ contract AttestationRegistry is OwnableUpgradeable {
         attestationsPayloads[i].subject,
         attestationsPayloads[i].attestationData
       );
+      emit AttestationRegistered(id);
     }
   }
 

--- a/test/AttestationRegistry.t.sol
+++ b/test/AttestationRegistry.t.sol
@@ -164,18 +164,12 @@ contract AttestationRegistryTest is Test {
     payloadsToAttest[0] = attestationsPayloads[0];
     payloadsToAttest[1] = attestationsPayloads[1];
 
-    bool isRegistered1 = attestationRegistry.isRegistered(bytes32(abi.encode(1)));
-    assertFalse(isRegistered1);
-    bool isRegistered2 = attestationRegistry.isRegistered(bytes32(abi.encode(2)));
-    assertFalse(isRegistered2);
-
+    vm.expectEmit(true, true, true, true);
+    emit AttestationRegistered(bytes32(abi.encode(1)));
+    vm.expectEmit(true, true, true, true);
+    emit AttestationRegistered(bytes32(abi.encode(2)));
     vm.prank(address(0));
     attestationRegistry.massImport(payloadsToAttest, portal);
-
-    isRegistered1 = attestationRegistry.isRegistered(bytes32(abi.encode(1)));
-    assertTrue(isRegistered1);
-    isRegistered2 = attestationRegistry.isRegistered(bytes32(abi.encode(2)));
-    assertTrue(isRegistered2);
   }
 
   function test_replace(AttestationPayload memory attestationPayload) public {


### PR DESCRIPTION
## What does this PR do?

As the `massImport` method doesn't emit an event on attestation creation, it can't be processed by an indexer. This PR adds this event.

### Related ticket

Fixes #215 

### Type of change

- [ ] Chore
- [X] Bug fix
- [ ] New feature
- [ ] Documentation update

## Check list

- [ ] Unit tests for any smart contract change
- [ ] Contracts and functions are documented
