### PR TITLE
feat: add msg.value and _attester() to hooks

### DIFF
--- a/src/example/EASPortal.sol
+++ b/src/example/EASPortal.sol
@@ -84,7 +84,7 @@ contract EASPortal is AbstractPortal {
     revert NoBulkRevocation();
   }
 
-  function _getAttester() public view override returns (address) {
+  function _attester() internal view override returns (address) {
     return msg.sender;
   }
 }

--- a/src/example/EASPortal.sol
+++ b/src/example/EASPortal.sol
@@ -83,8 +83,4 @@ contract EASPortal is AbstractPortal {
   function _onBulkRevoke(bytes32[] memory /*attestationIds*/) internal pure override {
     revert NoBulkRevocation();
   }
-
-  function _attester() internal view override returns (address) {
-    return msg.sender;
-  }
 }

--- a/src/example/NFTPortal.sol
+++ b/src/example/NFTPortal.sol
@@ -44,7 +44,11 @@ contract NFTPortal is AbstractPortal, ERC721 {
    * @notice Method run before a payload is attested
    * @param attestationPayload the attestation payload supposed to be attested
    */
-  function _onAttest(AttestationPayload memory attestationPayload) internal override {
+  function _onAttest(
+    AttestationPayload memory attestationPayload,
+    address /*attester*/,
+    uint256 /*value*/
+  ) internal override {
     numberOfAttestationsPerOwner[attestationPayload.subject]++;
   }
 

--- a/src/interface/AbstractPortal.sol
+++ b/src/interface/AbstractPortal.sol
@@ -48,9 +48,9 @@ abstract contract AbstractPortal is IERC165 {
   function attest(AttestationPayload memory attestationPayload, bytes[] memory validationPayloads) public payable {
     moduleRegistry.runModules(modules, attestationPayload, validationPayloads, msg.value);
 
-    _onAttest(attestationPayload);
+    _onAttest(attestationPayload, _attester(), msg.value);
 
-    attestationRegistry.attest(attestationPayload, _getAttester());
+    attestationRegistry.attest(attestationPayload, _attester());
   }
 
   /**
@@ -58,15 +58,12 @@ abstract contract AbstractPortal is IERC165 {
    * @param attestationsPayloads the payloads to attest
    * @param validationPayloads the payloads to validate via the modules to issue the attestations
    */
-  function bulkAttest(
-    AttestationPayload[] memory attestationsPayloads,
-    bytes[][] memory validationPayloads
-  ) public payable {
+  function bulkAttest(AttestationPayload[] memory attestationsPayloads, bytes[][] memory validationPayloads) public {
     moduleRegistry.bulkRunModules(modules, attestationsPayloads, validationPayloads);
 
     _onBulkAttest(attestationsPayloads, validationPayloads);
 
-    attestationRegistry.bulkAttest(attestationsPayloads, _getAttester());
+    attestationRegistry.bulkAttest(attestationsPayloads, _attester());
   }
 
   /**
@@ -83,9 +80,9 @@ abstract contract AbstractPortal is IERC165 {
   ) public payable {
     moduleRegistry.runModules(modules, attestationPayload, validationPayloads, msg.value);
 
-    _onReplace(attestationId, attestationPayload);
+    _onReplace(attestationId, attestationPayload, _attester(), msg.value);
 
-    attestationRegistry.replace(attestationId, attestationPayload, _getAttester());
+    attestationRegistry.replace(attestationId, attestationPayload, _attester());
   }
 
   /**
@@ -98,12 +95,12 @@ abstract contract AbstractPortal is IERC165 {
     bytes32[] memory attestationIds,
     AttestationPayload[] memory attestationsPayloads,
     bytes[][] memory validationPayloads
-  ) public payable {
+  ) public {
     moduleRegistry.bulkRunModules(modules, attestationsPayloads, validationPayloads);
 
     _onBulkReplace(attestationIds, attestationsPayloads, validationPayloads);
 
-    attestationRegistry.bulkReplace(attestationIds, attestationsPayloads, _getAttester());
+    attestationRegistry.bulkReplace(attestationIds, attestationsPayloads, _attester());
   }
 
   /**
@@ -149,22 +146,31 @@ abstract contract AbstractPortal is IERC165 {
    * @notice Defines the address of the entity issuing attestations to the subject
    * @dev We strongly encourage a reflection when overriding this rule: who should be set as the attester?
    */
-  function _getAttester() public view virtual returns (address) {
+  function _attester() internal view virtual returns (address) {
     return msg.sender;
   }
 
   /**
    * @notice Optional method run before a payload is attested
    * @param attestationPayload the attestation payload supposed to be attested
+   * @param attester the address of the attester
+   * @param value the value sent with the attestation
    */
-  function _onAttest(AttestationPayload memory attestationPayload) internal virtual {}
+  function _onAttest(AttestationPayload memory attestationPayload, address attester, uint256 value) internal virtual {}
 
   /**
    * @notice Optional method run when an attestation is replaced
    * @param attestationId the ID of the attestation being replaced
    * @param attestationPayload the attestation payload to create attestation and register it
+   * @param attester the address of the attester
+   * @param value the value sent with the attestation
    */
-  function _onReplace(bytes32 attestationId, AttestationPayload memory attestationPayload) internal virtual {}
+  function _onReplace(
+    bytes32 attestationId,
+    AttestationPayload memory attestationPayload,
+    address attester,
+    uint256 value
+  ) internal virtual {}
 
   /**
    * @notice Optional method run when attesting a batch of payloads

--- a/src/interface/AbstractPortal.sol
+++ b/src/interface/AbstractPortal.sol
@@ -48,9 +48,9 @@ abstract contract AbstractPortal is IERC165 {
   function attest(AttestationPayload memory attestationPayload, bytes[] memory validationPayloads) public payable {
     moduleRegistry.runModules(modules, attestationPayload, validationPayloads, msg.value);
 
-    _onAttest(attestationPayload, _attester(), msg.value);
+    _onAttest(attestationPayload, getAttester(), msg.value);
 
-    attestationRegistry.attest(attestationPayload, _attester());
+    attestationRegistry.attest(attestationPayload, getAttester());
   }
 
   /**
@@ -63,7 +63,7 @@ abstract contract AbstractPortal is IERC165 {
 
     _onBulkAttest(attestationsPayloads, validationPayloads);
 
-    attestationRegistry.bulkAttest(attestationsPayloads, _attester());
+    attestationRegistry.bulkAttest(attestationsPayloads, getAttester());
   }
 
   /**
@@ -80,9 +80,9 @@ abstract contract AbstractPortal is IERC165 {
   ) public payable {
     moduleRegistry.runModules(modules, attestationPayload, validationPayloads, msg.value);
 
-    _onReplace(attestationId, attestationPayload, _attester(), msg.value);
+    _onReplace(attestationId, attestationPayload, getAttester(), msg.value);
 
-    attestationRegistry.replace(attestationId, attestationPayload, _attester());
+    attestationRegistry.replace(attestationId, attestationPayload, getAttester());
   }
 
   /**
@@ -100,7 +100,7 @@ abstract contract AbstractPortal is IERC165 {
 
     _onBulkReplace(attestationIds, attestationsPayloads, validationPayloads);
 
-    attestationRegistry.bulkReplace(attestationIds, attestationsPayloads, _attester());
+    attestationRegistry.bulkReplace(attestationIds, attestationsPayloads, getAttester());
   }
 
   /**
@@ -146,7 +146,7 @@ abstract contract AbstractPortal is IERC165 {
    * @notice Defines the address of the entity issuing attestations to the subject
    * @dev We strongly encourage a reflection when overriding this rule: who should be set as the attester?
    */
-  function _attester() internal view virtual returns (address) {
+  function getAttester() public view virtual returns (address) {
     return msg.sender;
   }
 

--- a/test/example/EASPortal.t.sol
+++ b/test/example/EASPortal.t.sol
@@ -156,10 +156,4 @@ contract EASPortalTest is Test {
     bool isEASAbstractPortalSupported = easPortal.supportsInterface(type(AbstractPortal).interfaceId);
     assertEq(isEASAbstractPortalSupported, true);
   }
-
-  function test_getAttester() public {
-    vm.prank(attester);
-    address registeredAttester = easPortal._getAttester();
-    assertEq(registeredAttester, attester);
-  }
 }

--- a/test/portal/DefaultPortal.t.sol
+++ b/test/portal/DefaultPortal.t.sol
@@ -201,11 +201,4 @@ contract DefaultPortalTest is Test {
     bool isAbstractPortalSupported = defaultPortal.supportsInterface(type(AbstractPortal).interfaceId);
     assertEq(isAbstractPortalSupported, true);
   }
-
-  function test_getAttester() public {
-    address attester = makeAddr("attester");
-    vm.prank(attester);
-    address registeredAttester = defaultPortal._getAttester();
-    assertEq(registeredAttester, attester);
-  }
 }


### PR DESCRIPTION
## What does this PR do?

- Adds msg.value and attester to onAttest and onReplace hooks. This allows for custom portal logic on attestations with fees as well as information on the attester field which is not in the AttestationPayload struct
- Makes _attester() function visibility internal
- Removes "payable" modifier from bulkAttest and bulkReplace which cannot handle msg.value

### Related ticket

Fixes #

### Type of change

- [ ] Chore
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update

## Check list

- [x] Unit tests for any smart contract change
- [x] Contracts and functions are documented
