### PR TITLE
feat: add attestations field to portal entity

### DIFF
--- a/subgraph/schema.graphql
+++ b/subgraph/schema.graphql
@@ -1,39 +1,40 @@
 type Attestation @entity {
-    id: ID!
-    schemaId: Bytes!
-    replacedBy: Bytes!
-    attester: Bytes!
-    portal: Bytes!
-    attestedDate: BigInt!
-    expirationDate: BigInt!
-    revocationDate: BigInt!
-    version: BigInt!
-    revoked: Boolean!
-    subject: Bytes!
-    attestationData: Bytes!
+  id: ID!
+  schemaId: Bytes!
+  replacedBy: Bytes!
+  attester: Bytes!
+  portal: Portal!
+  attestedDate: BigInt!
+  expirationDate: BigInt!
+  revocationDate: BigInt!
+  version: BigInt!
+  revoked: Boolean!
+  subject: Bytes!
+  attestationData: Bytes!
 }
 
 type Module @entity {
-    id: ID!
-    moduleAddress: Bytes!
-    name: String!
-    description: String!
+  id: ID!
+  moduleAddress: Bytes!
+  name: String!
+  description: String!
 }
 
 type Portal @entity {
-    id: ID!
-    ownerAddress: Bytes!
-    modules: [Bytes!]
-    isRevocable: Boolean!
-    name: String!
-    description: String!
-    ownerName: String!
+  id: ID!
+  ownerAddress: Bytes!
+  modules: [Bytes!]
+  isRevocable: Boolean!
+  name: String!
+  description: String!
+  ownerName: String!
+  attestations: [Attestation!]! @derivedFrom(field: "portal")
 }
 
 type Schema @entity {
-    id: ID!
-    name: String!
-    description: String!
-    context: String!
-    schema: String!
+  id: ID!
+  name: String!
+  description: String!
+  context: String!
+  schema: String!
 }

--- a/subgraph/src/attestation-registry.ts
+++ b/subgraph/src/attestation-registry.ts
@@ -13,7 +13,7 @@ export function handleAttestationRegistered(event: AttestationRegisteredEvent): 
   attestation.schemaId = attestationData.schemaId;
   attestation.replacedBy = attestationData.replacedBy;
   attestation.attester = attestationData.attester;
-  attestation.portal = attestationData.portal;
+  attestation.portal = attestationData.portal.toHexString();
   attestation.attestedDate = attestationData.attestedDate;
   attestation.expirationDate = attestationData.expirationDate;
   attestation.revocationDate = attestationData.revocationDate;


### PR DESCRIPTION
## What does this PR do?

Adds an attestations field to the portal entity in the subgraph. This makes it easy to query attestations created by a certain portal.

### Related ticket

Fixes #

### Type of change

- [ ] Chore
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update

## Check list

- [ ] Unit tests for any smart contract change
- [ ] Contracts and functions are documented
