### PR TITLE
fix: The NFTPortal should declare that the IPortal interface is implemented

### DIFF
--- a/contracts/src/examples/portals/NFTPortal.sol
+++ b/contracts/src/examples/portals/NFTPortal.sol
@@ -5,6 +5,7 @@ import { IERC721, ERC721 } from "openzeppelin-contracts/contracts/token/ERC721/E
 import { IERC165 } from "openzeppelin-contracts/contracts/utils/introspection/ERC165.sol";
 import { AbstractPortal } from "../../interface/AbstractPortal.sol";
 import { Attestation, AttestationPayload } from "../../types/Structs.sol";
+import { IPortal } from "../../interface/IPortal.sol";
 
 /**
  * @title NFT Portal
@@ -62,6 +63,7 @@ contract NFTPortal is AbstractPortal, ERC721 {
   function supportsInterface(bytes4 interfaceID) public pure virtual override(AbstractPortal, ERC721) returns (bool) {
     return
       interfaceID == type(AbstractPortal).interfaceId ||
+      interfaceID == type(IPortal).interfaceId ||
       interfaceID == type(IERC165).interfaceId ||
       interfaceID == type(IERC721).interfaceId;
   }


### PR DESCRIPTION
## What does this PR do?

### Related ticket

Fixes #310

### Type of change

- [ ] Chore
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update

## Check list

- [ ] Unit tests for any smart contract change
- [ ] Contracts and functions are documented
