### PR TITLE
feat: As an Issuer, I want to use the subject field as an ETH address or an encoded ETH address

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
   "scripts": {
     "lint": "eslint .",
     "prepare": "husky install",
-    "prettier:check": "prettier --check \"**/*.{json,md,svg,yml,sol,ts,graphql}\"",
-    "prettier:write": "prettier --write \"**/*.{json,md,svg,yml,sol,ts,graphql}\""
+    "prettier:check": "prettier --check \"**/*.{json,md,svg,yml,sol,js,ts,graphql}\"",
+    "prettier:write": "prettier --write \"**/*.{json,md,svg,yml,sol,js,ts,graphql}\""
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^6.10.0",

--- a/sdk/test/integration/Attestation.integration.test.ts
+++ b/sdk/test/integration/Attestation.integration.test.ts
@@ -24,7 +24,7 @@ describe("AttestationDataMapper", () => {
       expect(result?.revocationDate).toEqual("0");
       expect(result?.version).toEqual("8");
       expect(result?.revoked).toBeFalsy();
-      expect(result?.subject).toEqual("0x000000000000000000000000cb859f99f84ab770a50380680be94ad9331bcec5");
+      expect(result?.subject).toEqual("0xcb859f99f84ab770a50380680be94ad9331bcec5");
       expect(result?.attestationData).toEqual("0x0000000000000000000000000000000000000000000000000000000000000004");
       expect(result?.schemaString).toEqual("uint8");
       expect(result?.decodedData).toEqual(["0x4"]);

--- a/subgraph/schema.graphql
+++ b/subgraph/schema.graphql
@@ -1,60 +1,61 @@
 type Attestation @entity {
-  id: ID!
-  schemaId: Bytes!
-  replacedBy: Bytes!
-  attester: Bytes!
-  portal: Bytes!
-  attestedDate: BigInt!
-  expirationDate: BigInt!
-  revocationDate: BigInt!
-  version: BigInt!
-  revoked: Boolean!
-  subject: Bytes!
-  attestationData: Bytes!
-  schemaString: String
-  decodedData: [String!]
+    id: ID!
+    schemaId: Bytes!
+    replacedBy: Bytes!
+    attester: Bytes!
+    portal: Bytes!
+    attestedDate: BigInt!
+    expirationDate: BigInt!
+    revocationDate: BigInt!
+    version: BigInt!
+    revoked: Boolean!
+    subject: Bytes!
+    encodedSubject: Bytes!
+    attestationData: Bytes!
+    schemaString: String
+    decodedData: [String!]
 }
 
 type Module @entity {
-  id: ID!
-  moduleAddress: Bytes!
-  name: String!
-  description: String!
+    id: ID!
+    moduleAddress: Bytes!
+    name: String!
+    description: String!
 }
 
 type Portal @entity {
-  id: ID!
-  ownerAddress: Bytes!
-  modules: [Bytes!]
-  isRevocable: Boolean!
-  name: String!
-  description: String!
-  ownerName: String!
-  attestationCounter: Int
+    id: ID!
+    ownerAddress: Bytes!
+    modules: [Bytes!]
+    isRevocable: Boolean!
+    name: String!
+    description: String!
+    ownerName: String!
+    attestationCounter: Int
 }
 
 type Schema @entity {
-  id: ID!
-  name: String!
-  description: String!
-  context: String!
-  schema: String!
+    id: ID!
+    name: String!
+    description: String!
+    context: String!
+    schema: String!
 }
 
 type Counter @entity {
-  id: ID!
-  attestations: Int
-  modules: Int
-  portals: Int
-  schemas: Int
+    id: ID!
+    attestations: Int
+    modules: Int
+    portals: Int
+    schemas: Int
 }
 
 type Issuer @entity {
-  id: ID!
+    id: ID!
 }
 
 type RegistryVersion @entity {
-  id: ID!
-  versionNumber: Int
-  timestamp: BigInt
+    id: ID!
+    versionNumber: Int
+    timestamp: BigInt
 }

--- a/subgraph/schema.graphql
+++ b/subgraph/schema.graphql
@@ -1,61 +1,61 @@
 type Attestation @entity {
-    id: ID!
-    schemaId: Bytes!
-    replacedBy: Bytes!
-    attester: Bytes!
-    portal: Bytes!
-    attestedDate: BigInt!
-    expirationDate: BigInt!
-    revocationDate: BigInt!
-    version: BigInt!
-    revoked: Boolean!
-    subject: Bytes!
-    encodedSubject: Bytes!
-    attestationData: Bytes!
-    schemaString: String
-    decodedData: [String!]
+  id: ID!
+  schemaId: Bytes!
+  replacedBy: Bytes!
+  attester: Bytes!
+  portal: Bytes!
+  attestedDate: BigInt!
+  expirationDate: BigInt!
+  revocationDate: BigInt!
+  version: BigInt!
+  revoked: Boolean!
+  subject: Bytes!
+  encodedSubject: Bytes!
+  attestationData: Bytes!
+  schemaString: String
+  decodedData: [String!]
 }
 
 type Module @entity {
-    id: ID!
-    moduleAddress: Bytes!
-    name: String!
-    description: String!
+  id: ID!
+  moduleAddress: Bytes!
+  name: String!
+  description: String!
 }
 
 type Portal @entity {
-    id: ID!
-    ownerAddress: Bytes!
-    modules: [Bytes!]
-    isRevocable: Boolean!
-    name: String!
-    description: String!
-    ownerName: String!
-    attestationCounter: Int
+  id: ID!
+  ownerAddress: Bytes!
+  modules: [Bytes!]
+  isRevocable: Boolean!
+  name: String!
+  description: String!
+  ownerName: String!
+  attestationCounter: Int
 }
 
 type Schema @entity {
-    id: ID!
-    name: String!
-    description: String!
-    context: String!
-    schema: String!
+  id: ID!
+  name: String!
+  description: String!
+  context: String!
+  schema: String!
 }
 
 type Counter @entity {
-    id: ID!
-    attestations: Int
-    modules: Int
-    portals: Int
-    schemas: Int
+  id: ID!
+  attestations: Int
+  modules: Int
+  portals: Int
+  schemas: Int
 }
 
 type Issuer @entity {
-    id: ID!
+  id: ID!
 }
 
 type RegistryVersion @entity {
-    id: ID!
-    versionNumber: Int
-    timestamp: BigInt
+  id: ID!
+  versionNumber: Int
+  timestamp: BigInt
 }

--- a/subgraph/src/attestation-registry.ts
+++ b/subgraph/src/attestation-registry.ts
@@ -24,8 +24,12 @@ export function handleAttestationRegistered(event: AttestationRegisteredEvent): 
   attestation.revocationDate = attestationData.revocationDate;
   attestation.version = BigInt.fromI32(attestationData.version);
   attestation.revoked = attestationData.revoked;
-  attestation.subject = attestationData.subject;
+  attestation.encodedSubject = attestationData.subject;
   attestation.attestationData = attestationData.attestationData;
+
+  // If the subject looks like an encoded address, decode it to an address
+  const tempSubject = ethereum.decode("address", attestationData.subject);
+  attestation.subject = tempSubject ? tempSubject.toAddress() : attestationData.subject;
 
   // Get matching Schema
   const schema = Schema.load(attestationData.schemaId.toHex());


### PR DESCRIPTION
## What does this PR do?

Decodes the attestation subject if it looks like an encoded address

### Related ticket

Fixes #312 

### Type of change

- [ ] Chore
- [ ] Bug fix
- [X] New feature
- [ ] Documentation update

## Check list

- [ ] Unit tests for any smart contract change
- [ ] Contracts and functions are documented
