### PR TITLE
chore: Add Hapi as codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,3 @@
 * @alainncls @fdemiramon @satyajeetkolhapure @orbmis @0xEillo
+/explorer/ @ars9 @Solniechniy
+/governance/ @DAOstrat


### PR DESCRIPTION
## What does this PR do?

Adds Hapi as codeowners of the explorer package

### Type of change

- [X] Chore
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update

## Check list

- [ ] Unit tests for any smart contract change
- [ ] Contracts and functions are documented
