### PR TITLE
fix: On the Explorer, the attested payload is not the most explicit we can get

### DIFF
--- a/explorer/src/pages/Attestation/components/AttestationData/index.tsx
+++ b/explorer/src/pages/Attestation/components/AttestationData/index.tsx
@@ -16,8 +16,8 @@ export const AttestationData: React.FC<Attestation> = ({ ...attestation }) => {
   const [isOpened, setIsOpened] = useState(false);
   const [heightDifference, setHeightDifference] = useState<number>(0);
 
-  const { schemaString, decodedData } = attestation;
-  const data = schemaString && decodedData ? getAttestationData(schemaString, decodedData) : null;
+  const { decodedData, decodedPayload } = attestation;
+  const data = getAttestationData(decodedPayload ?? decodedData);
 
   const handleCopy = (text: string, result: boolean) => {
     if (!result || !text) return;
@@ -69,7 +69,7 @@ export const AttestationData: React.FC<Attestation> = ({ ...attestation }) => {
             style={{ height: isOpened ? heightDifference + 108 : 108 }}
           >
             <ReactJson
-              src={data}
+              src={JSON.parse(data)}
               name={false}
               displayObjectSize={false}
               displayDataTypes={false}

--- a/explorer/src/pages/Attestation/components/AttestationData/utils.ts
+++ b/explorer/src/pages/Attestation/components/AttestationData/utils.ts
@@ -1,28 +1,3 @@
-import { parseAbiParameters } from "abitype";
-
-type ArrayComponent = { type: string; components: ArrayComponent[] };
-type MergeArraysType = { [key: string]: string | boolean | MergeArraysType };
-
-const mergeArrays = (array1: ArrayComponent[], array2: unknown[]): MergeArraysType => {
-  const result: MergeArraysType = {};
-
-  array1.forEach((item, index) => {
-    const value = array2[index];
-    if (Array.isArray(value)) {
-      result[item.type] = mergeArrays(item.components, value);
-    } else {
-      result[item.type] = value as string;
-    }
-  });
-  return result;
-};
-
-export const getAttestationData = (schemaString: string, decodedData: unknown[]) => {
-  try {
-    const parsedSchema = parseAbiParameters(schemaString);
-    if (parsedSchema.length !== decodedData.length) return null;
-    return mergeArrays([...parsedSchema] as ArrayComponent[], decodedData);
-  } catch (error) {
-    return null;
-  }
+export const getAttestationData = (decodedPayload: unknown): string => {
+  return JSON.stringify(decodedPayload, (_key, value) => (typeof value === "bigint" ? value.toString() : value));
 };


### PR DESCRIPTION
## What does this PR do?

Uses the attestation payload decoded at the SDK level to display the detail of an attestation

### Related ticket

Fixes #469 

### Type of change

- [ ] Chore
- [X] Bug fix
- [ ] New feature
- [ ] Documentation update

## Check list

- [ ] Unit tests for any smart contract change
- [ ] Contracts and functions are documented
