### PR TITLE
fix: Fix the type of the date fields in Attestation at the SDK level

### DIFF
--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verax-attestation-registry/verax-sdk",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Verax Attestation Registry SDK to interact with the subgraph and the contracts",
   "keywords": [
     "linea-attestation-registry",

--- a/sdk/src/dataMapper/AttestationDataMapper.ts
+++ b/sdk/src/dataMapper/AttestationDataMapper.ts
@@ -60,6 +60,11 @@ export default class AttestationDataMapper extends BaseDataMapper<
   private async enrichAttestation(attestation: Attestation) {
     const schema = (await this.veraxSdk.schema.getSchema(attestation.schemaId)) as Schema;
     attestation.decodedPayload = decodeWithRetry(schema.schema, attestation.attestationData as `0x${string}`);
+
+    attestation.attestedDate = Number(attestation.attestedDate);
+    attestation.expirationDate = Number(attestation.expirationDate);
+    attestation.revocationDate = Number(attestation.revocationDate);
+
     // Check if data is stored offchain
     if (attestation.schemaId === Constants.OFFCHAIN_DATA_SCHEMA_ID) {
       attestation.offchainData = {

--- a/sdk/test/integration/Attestation.integration.test.ts
+++ b/sdk/test/integration/Attestation.integration.test.ts
@@ -19,9 +19,9 @@ describe("AttestationDataMapper", () => {
       expect(result?.replacedBy).toEqual("0x0000000000000000000000000000000000000000000000000000000000000000");
       expect(result?.attester).toEqual("0x809e815596abeb3764abf81be2dc39fbbacc9949");
       expect(result?.portal).toEqual("0xb3c0e57d560f36697f5d727c2c6db4e0c8f87bd8");
-      expect(result?.attestedDate).toEqual("1695398083");
-      expect(result?.expirationDate).toEqual("1793835110");
-      expect(result?.revocationDate).toEqual("0");
+      expect(result?.attestedDate).toEqual(1695398083);
+      expect(result?.expirationDate).toEqual(1793835110);
+      expect(result?.revocationDate).toEqual(0);
       expect(result?.version).toEqual("8");
       expect(result?.revoked).toBeFalsy();
       expect(result?.subject).toEqual("0xcb859f99f84ab770a50380680be94ad9331bcec5");


### PR DESCRIPTION
## What does this PR do?

Converts the dates fields back to `number` (instead of default `string`)

### Related ticket

Fixes #447 

### Type of change

- [ ] Chore
- [X] Bug fix
- [ ] New feature
- [ ] Documentation update

## Check list

- [ ] Unit tests for any smart contract change
- [ ] Contracts and functions are documented
