### PR TITLE
fix: made portal and schema columns visible in schema's related attestations

### DIFF
--- a/explorer/src/pages/Schema/components/RecentAttestations/index.tsx
+++ b/explorer/src/pages/Schema/components/RecentAttestations/index.tsx
@@ -25,7 +25,7 @@ export const RecentAttestations: React.FC<{ schemaId: string }> = ({ schemaId })
   const columnsSkeletonRef = useRef(columnsSkeleton(columns({ sortByDate: false }), attestationColumnsOption));
   const data = isLoading
     ? { columns: columnsSkeletonRef.current, list: skeletonAttestations(5) }
-    : { columns: columns({ sortByDate: false }), list: attestations?.slice(-5).reverse() || [] };
+    : { columns: columns({ sortByDate: false, sdk }), list: attestations?.slice(-5).reverse() || [] };
 
   return (
     <div className="flex flex-col gap-6 w-full px-5 md:px-10">


### PR DESCRIPTION
## What does this PR do?
Portal's and schema's columns visibility in schema's related attestations table fixed
