### PR TITLE
fix: Use another Linea Testnet subgraph

### DIFF
--- a/sdk/src/VeraxSdk.ts
+++ b/sdk/src/VeraxSdk.ts
@@ -30,7 +30,8 @@ export class VeraxSdk {
   static DEFAULT_LINEA_TESTNET: Conf = {
     chain: lineaTestnet,
     mode: SDKMode.BACKEND,
-    subgraphUrl: "https://graph-query.goerli.linea.build/subgraphs/name/Consensys/linea-attestation-registry",
+    subgraphUrl:
+      "https://api.goldsky.com/api/public/project_clqghnrbp9nx201wtgylv8748/subgraphs/verax/subgraph-testnet/gn",
     portalRegistryAddress: "0x506f88a5Ca8D5F001f2909b029738A40042e42a6",
     moduleRegistryAddress: "0x1a20b2CFA134686306436D2c9f778D7eC6c43A43",
     schemaRegistryAddress: "0xB2c4Da1f8F08A0CA25862509E5431289BE2b598B",


### PR DESCRIPTION
## What does this PR do?

Fixes the issue with the missing Linea testnet subgraph by replacing it by a new one

### Type of change

- [ ] Chore
- [X] Bug fix
- [ ] New feature
- [ ] Documentation update

## Check list

- [ ] Unit tests for any smart contract change
- [ ] Contracts and functions are documented
