### PR TITLE
chore: When the Explorer is deployed in production, remove the `HashRouter`

### DIFF
--- a/.github/workflows/explorer-deploy-preview.yml
+++ b/.github/workflows/explorer-deploy-preview.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Build
         if: steps.check-changes.outputs.changed == 'true'
-        run: pnpm run build
+        run: pnpm run build:netlify
         env:
           VITE_WALLETCONNECT_PROJECT_ID: ${{ secrets.VITE_WALLETCONNECT_PROJECT_ID }}
           VITE_INFURA_API_KEY: ${{ secrets.VITE_INFURA_API_KEY }}

--- a/.github/workflows/explorer-deploy-prod.yml
+++ b/.github/workflows/explorer-deploy-prod.yml
@@ -48,7 +48,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Build
-        run: pnpm run build
+        run: pnpm run build:netlify
         env:
           VITE_WALLETCONNECT_PROJECT_ID: ${{ secrets.VITE_WALLETCONNECT_PROJECT_ID }}
           VITE_INFURA_API_KEY: ${{ secrets.VITE_INFURA_API_KEY }}

--- a/explorer/package.json
+++ b/explorer/package.json
@@ -17,9 +17,11 @@
   "type": "module",
   "scripts": {
     "build": "tsc && vite build",
+    "build:netlify": "pnpm run build && pnpm run redirect",
     "dev": "vite",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "redirect": "touch dist/_redirects && echo '/*  /index.html  200' >> dist/_redirects"
   },
   "dependencies": {
     "@radix-ui/react-dropdown-menu": "^2.0.6",

--- a/explorer/src/routes/index.tsx
+++ b/explorer/src/routes/index.tsx
@@ -1,4 +1,4 @@
-import { Route, createHashRouter, createRoutesFromElements } from "react-router-dom";
+import { Route, createBrowserRouter, createRoutesFromElements } from "react-router-dom";
 
 import { Attestation } from "@/pages/Attestation";
 import { Attestations } from "@/pages/Attestations";
@@ -17,7 +17,7 @@ import { loaderNetworkProvider } from "@/providers/network-provider/loader";
 import { APP_ROUTES } from "./constants";
 import { NotFoundPage } from "./NotFoundPage";
 
-export const router = createHashRouter(
+export const router = createBrowserRouter(
   createRoutesFromElements(
     <Route element={<Providers />} loader={loaderNetworkProvider}>
       <Route path={APP_ROUTES.HOME} element={<Home />} />


### PR DESCRIPTION
## What does this PR do?

Switches the Explorer from `HashRouter` to `BrowserRouter` to have cleaner URLs

### Related ticket

Fixes #464 

### Type of change

- [X] Chore
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update

## Check list

- [ ] Unit tests for any smart contract change
- [ ] Contracts and functions are documented
