### PR TITLE
feat: As a developer, I or portal owner should be able to revoke or replace the attestation

### DIFF
--- a/contracts/src/PortalRegistry.sol
+++ b/contracts/src/PortalRegistry.sol
@@ -214,6 +214,16 @@ contract PortalRegistry is OwnableUpgradeable {
   }
 
   /**
+   * @notice Get a Portal owner address by its address
+   * @param id The address of the Portal
+   * @return The Portal owner address
+   */
+  function getPortalOwnerAddress(address id) public view returns (address) {
+    if (!isRegistered(id)) revert PortalNotRegistered();
+    return portals[id].ownerAddress;
+  }
+
+  /**
    * @notice Check if a Portal is registered
    * @param id The address of the Portal
    * @return True if the Portal is registered, false otherwise

--- a/contracts/src/abstracts/AbstractPortal.sol
+++ b/contracts/src/abstracts/AbstractPortal.sol
@@ -23,9 +23,6 @@ abstract contract AbstractPortal is IPortal {
   AttestationRegistry public attestationRegistry;
   PortalRegistry public portalRegistry;
 
-  /// @notice Error thrown when someone else than the portal's owner is trying to revoke
-  error OnlyPortalOwner();
-
   /**
    * @notice Contract constructor
    * @param _modules list of modules to use for the portal (can be empty)
@@ -120,7 +117,7 @@ abstract contract AbstractPortal is IPortal {
   function revoke(bytes32 attestationId) public {
     _onRevoke(attestationId);
 
-    attestationRegistry.revoke(attestationId);
+    attestationRegistry.revoke(attestationId, getAttester());
   }
 
   /**
@@ -130,7 +127,7 @@ abstract contract AbstractPortal is IPortal {
   function bulkRevoke(bytes32[] memory attestationIds) public {
     _onBulkRevoke(attestationIds);
 
-    attestationRegistry.bulkRevoke(attestationIds);
+    attestationRegistry.bulkRevoke(attestationIds, getAttester());
   }
 
   /**
@@ -201,17 +198,11 @@ abstract contract AbstractPortal is IPortal {
 
   /**
    * @notice Optional method run when an attestation is revoked or replaced
-   * @dev    IMPORTANT NOTE: By default, revocation is only possible by the portal owner
    */
-  function _onRevoke(bytes32 /*attestationId*/) internal virtual {
-    if (msg.sender != portalRegistry.getPortalByAddress(address(this)).ownerAddress) revert OnlyPortalOwner();
-  }
+  function _onRevoke(bytes32 /*attestationId*/) internal virtual {}
 
   /**
    * @notice Optional method run when a batch of attestations are revoked or replaced
-   * @dev    IMPORTANT NOTE: By default, revocation is only possible by the portal owner
    */
-  function _onBulkRevoke(bytes32[] memory /*attestationIds*/) internal virtual {
-    if (msg.sender != portalRegistry.getPortalByAddress(address(this)).ownerAddress) revert OnlyPortalOwner();
-  }
+  function _onBulkRevoke(bytes32[] memory /*attestationIds*/) internal virtual {}
 }

--- a/contracts/test/DefaultPortal.t.sol
+++ b/contracts/test/DefaultPortal.t.sol
@@ -135,7 +135,7 @@ contract DefaultPortalTest is Test {
     defaultPortal.bulkReplace(attestationIds, payloadsToAttest, validationPayloads);
   }
 
-  function test_revoke_byPortalOwner() public {
+  function test_revoke() public {
     // Create attestation payload
     AttestationPayload memory attestationPayload = AttestationPayload(
       bytes32(uint256(1)),
@@ -154,33 +154,8 @@ contract DefaultPortalTest is Test {
     defaultPortal.attest(attestationPayload, validationPayload);
 
     // Revoke the attestation as portal owner
-    vm.prank(portalOwner);
     vm.expectEmit(true, true, true, true);
     emit AttestationRevoked(bytes32(abi.encode(1)));
-    defaultPortal.revoke(bytes32(abi.encode(1)));
-  }
-
-  function test_revokeFail_OnlyOwner() public {
-    // Create attestation payload
-    AttestationPayload memory attestationPayload = AttestationPayload(
-      bytes32(uint256(1)),
-      uint64(block.timestamp + 1 days),
-      bytes("subject"),
-      new bytes(1)
-    );
-
-    // Create validation payload
-    bytes[] memory validationPayload = new bytes[](2);
-
-    // Do register the attestation
-    vm.prank(makeAddr("attester"));
-    vm.expectEmit(true, true, true, true);
-    emit AttestationRegistered();
-    defaultPortal.attest(attestationPayload, validationPayload);
-
-    // Revoke the attestation as a random user
-    vm.prank(makeAddr("random"));
-    vm.expectRevert(AbstractPortal.OnlyPortalOwner.selector);
     defaultPortal.revoke(bytes32(abi.encode(1)));
   }
 

--- a/contracts/test/PortalRegistry.t.sol
+++ b/contracts/test/PortalRegistry.t.sol
@@ -265,6 +265,17 @@ contract PortalRegistryTest is Test {
     portalRegistry.getPortalByAddress(address(validPortalMock));
   }
 
+  function test_getPortalOwnerAddress() public {
+    vm.prank(user);
+    portalRegistry.register(address(validPortalMock), expectedName, expectedDescription, true, expectedOwnerName);
+    assertEq(portalRegistry.getPortalOwnerAddress(address(validPortalMock)), user);
+  }
+
+  function test_getPortalOwnerAddress_PortalNotRegistered() public {
+    vm.expectRevert(PortalRegistry.PortalNotRegistered.selector);
+    portalRegistry.getPortalOwnerAddress(address(validPortalMock));
+  }
+
   function test_isRegistered() public {
     assertEq(portalRegistry.isRegistered(address(validPortalMock)), false);
     vm.prank(user);

--- a/contracts/test/mocks/AttestationRegistryMock.sol
+++ b/contracts/test/mocks/AttestationRegistryMock.sol
@@ -45,7 +45,7 @@ contract AttestationRegistryMock {
   function replace(
     bytes32 /*attestationId*/,
     AttestationPayload calldata /*attestationPayload*/,
-    address /*attester*/
+    address /*replacer*/
   ) public {
     emit AttestationRegistered();
     emit AttestationReplaced();
@@ -54,14 +54,14 @@ contract AttestationRegistryMock {
   function bulkReplace(
     bytes32[] calldata /*attestationId*/,
     AttestationPayload[] calldata /*attestationPayload*/,
-    address /*attester*/
+    address /*replacer*/
   ) public {}
 
-  function revoke(bytes32 attestationId) public {
+  function revoke(bytes32 attestationId, address /*revoker*/) public {
     emit AttestationRevoked(attestationId);
   }
 
-  function bulkRevoke(bytes32[] memory attestationIds) public {
+  function bulkRevoke(bytes32[] memory attestationIds, address /*revoker*/) public {
     emit BulkAttestationsRevoked(attestationIds);
   }
 

--- a/contracts/test/mocks/PortalRegistryMock.sol
+++ b/contracts/test/mocks/PortalRegistryMock.sol
@@ -32,6 +32,10 @@ contract PortalRegistryMock {
     return portals[id];
   }
 
+  function getPortalOwnerAddress(address id) public view returns (address) {
+    return portals[id].ownerAddress;
+  }
+
   function setIssuer(address issuer) public {
     issuers[issuer] = true;
   }

--- a/sdk/doc/cli-examples.md
+++ b/sdk/doc/cli-examples.md
@@ -41,6 +41,8 @@
 
     pnpm portal getPortalByAddress '{\"portalAddress\":\"0x8b833796869b5debb9b06370d6d47016f0d7973b\"}'
 
+    pnpm portal getPortalOwnerAddress '{\"portalAddress\":\"0x8b833796869b5debb9b06370d6d47016f0d7973b\"}'
+
     pnpm portal isPortalRegistered '{\"portalAddress\":\"0x8b833796869b5debb9b06370d6d47016f0d7973b\"}'
 
     pnpm portal getPortalsCount

--- a/sdk/examples/portal/portalExamples.ts
+++ b/sdk/examples/portal/portalExamples.ts
@@ -365,6 +365,15 @@ export default class PortalExamples {
       console.log(await this.veraxSdk.portal.getPortalByAddress(portalAddress));
     }
 
+    if (methodName.toLowerCase() == "getPortalOwnerAddress".toLowerCase() || methodName == "") {
+      let params;
+      if (argv !== "") params = JSON.parse(argv);
+      const portalAddress = params?.portalAddress
+        ? (params.portalAddress as Address)
+        : "0x8b833796869b5debb9b06370d6d47016f0d7973b";
+      console.log(await this.veraxSdk.portal.getPortalOwnerAddress(portalAddress));
+    }
+
     if (methodName.toLowerCase() == "isPortalRegistered".toLowerCase() || methodName == "") {
       let params;
       if (argv !== "") params = JSON.parse(argv);

--- a/sdk/src/abi/AttestationRegistry.ts
+++ b/sdk/src/abi/AttestationRegistry.ts
@@ -41,6 +41,11 @@ export const abiAttestationRegistry = [
   },
   {
     inputs: [],
+    name: "OnlyAttestorOrPortalOwner",
+    type: "error",
+  },
+  {
+    inputs: [],
     name: "OnlyPortal",
     type: "error",
   },
@@ -308,7 +313,7 @@ export const abiAttestationRegistry = [
       },
       {
         internalType: "address",
-        name: "attester",
+        name: "replacer",
         type: "address",
       },
     ],
@@ -323,6 +328,11 @@ export const abiAttestationRegistry = [
         internalType: "bytes32[]",
         name: "attestationIds",
         type: "bytes32[]",
+      },
+      {
+        internalType: "address",
+        name: "revoker",
+        type: "address",
       },
     ],
     name: "bulkRevoke",
@@ -419,6 +429,19 @@ export const abiAttestationRegistry = [
         internalType: "uint32",
         name: "",
         type: "uint32",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "getChainPrefix",
+    outputs: [
+      {
+        internalType: "uint256",
+        name: "",
+        type: "uint256",
       },
     ],
     stateMutability: "view",
@@ -591,7 +614,7 @@ export const abiAttestationRegistry = [
       },
       {
         internalType: "address",
-        name: "attester",
+        name: "replacer",
         type: "address",
       },
     ],
@@ -606,6 +629,11 @@ export const abiAttestationRegistry = [
         internalType: "bytes32",
         name: "attestationId",
         type: "bytes32",
+      },
+      {
+        internalType: "address",
+        name: "revoker",
+        type: "address",
       },
     ],
     name: "revoke",
@@ -635,6 +663,19 @@ export const abiAttestationRegistry = [
       },
     ],
     name: "transferOwnership",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256",
+        name: "_chainPrefix",
+        type: "uint256",
+      },
+    ],
+    name: "updateChainPrefix",
     outputs: [],
     stateMutability: "nonpayable",
     type: "function",

--- a/sdk/src/abi/DefaultPortal.ts
+++ b/sdk/src/abi/DefaultPortal.ts
@@ -16,61 +16,6 @@ export const abiDefaultPortal = [
     type: "constructor",
   },
   {
-    inputs: [],
-    name: "OnlyPortalOwner",
-    type: "error",
-  },
-  {
-    inputs: [],
-    name: "AlreadyRevoked",
-    type: "error",
-  },
-  {
-    inputs: [],
-    name: "ArrayLengthMismatch",
-    type: "error",
-  },
-  {
-    inputs: [],
-    name: "AttestationDataFieldEmpty",
-    type: "error",
-  },
-  {
-    inputs: [],
-    name: "AttestationNotAttested",
-    type: "error",
-  },
-  {
-    inputs: [],
-    name: "AttestationNotRevocable",
-    type: "error",
-  },
-  {
-    inputs: [],
-    name: "AttestationSubjectFieldEmpty",
-    type: "error",
-  },
-  {
-    inputs: [],
-    name: "OnlyAttestingPortal",
-    type: "error",
-  },
-  {
-    inputs: [],
-    name: "OnlyPortal",
-    type: "error",
-  },
-  {
-    inputs: [],
-    name: "RouterInvalid",
-    type: "error",
-  },
-  {
-    inputs: [],
-    name: "SchemaNotRegistered",
-    type: "error",
-  },
-  {
     inputs: [
       {
         components: [

--- a/sdk/src/abi/PortalRegistry.ts
+++ b/sdk/src/abi/PortalRegistry.ts
@@ -66,6 +66,32 @@ export const abiPortalRegistry = [
     anonymous: false,
     inputs: [
       {
+        indexed: false,
+        internalType: "address",
+        name: "issuerAddress",
+        type: "address",
+      },
+    ],
+    name: "IssuerAdded",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: "address",
+        name: "issuerAddress",
+        type: "address",
+      },
+    ],
+    name: "IssuerRemoved",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
         indexed: true,
         internalType: "address",
         name: "previousOwner",
@@ -104,6 +130,19 @@ export const abiPortalRegistry = [
       },
     ],
     name: "PortalRegistered",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: "address",
+        name: "portalAddress",
+        type: "address",
+      },
+    ],
+    name: "PortalRevoked",
     type: "event",
   },
   {
@@ -190,6 +229,25 @@ export const abiPortalRegistry = [
         internalType: "struct Portal",
         name: "",
         type: "tuple",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "id",
+        type: "address",
+      },
+    ],
+    name: "getPortalOwnerAddress",
+    outputs: [
+      {
+        internalType: "address",
+        name: "",
+        type: "address",
       },
     ],
     stateMutability: "view",
@@ -315,6 +373,19 @@ export const abiPortalRegistry = [
   {
     inputs: [],
     name: "renounceOwnership",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "id",
+        type: "address",
+      },
+    ],
+    name: "revoke",
     outputs: [],
     stateMutability: "nonpayable",
     type: "function",

--- a/sdk/src/dataMapper/PortalDataMapper.ts
+++ b/sdk/src/dataMapper/PortalDataMapper.ts
@@ -215,6 +215,10 @@ export default class PortalDataMapper extends BaseDataMapper<Portal, Portal_filt
     return this.executePortalRegistryReadMethod("getPortalByAddress", [id]);
   }
 
+  async getPortalOwnerAddress(id: Address) {
+    return this.executePortalRegistryReadMethod("getPortalOwnerAddress", [id]);
+  }
+
   async isPortalRegistered(id: Address) {
     return this.executePortalRegistryReadMethod("isRegistered", [id]);
   }


### PR DESCRIPTION
## What does this PR do?

Along with the portal owner, an attester who attested the attestation should be able to revoke or replace his attestation too.

### Related ticket

Fixes #546 

### Type of change

- [ ] Chore
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update

## Check list

- [ ] Unit tests for any smart contract change
- [ ] Contracts and functions are documented
