### PR TITLE
fix: Reduce the number of RPC calls when fetching attestations

### DIFF
--- a/explorer/package.json
+++ b/explorer/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@radix-ui/react-dropdown-menu": "^2.0.6",
     "@tanstack/react-table": "^8.10.7",
-    "@verax-attestation-registry/verax-sdk": "1.1.1",
+    "@verax-attestation-registry/verax-sdk": "1.2.1",
     "@wagmi/core": "^1.4.7",
     "abitype": "^0.10.3",
     "class-variance-authority": "^0.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,14 +85,14 @@ importers:
         specifier: ^8.10.7
         version: 8.10.7(react-dom@18.2.0)(react@18.2.0)
       '@verax-attestation-registry/verax-sdk':
-        specifier: 1.1.1
-        version: 1.1.1(@babel/core@7.23.3)(@envelop/core@4.0.3)(@graphql-mesh/types@0.93.2)(@graphql-tools/delegate@10.0.3)(@graphql-tools/merge@9.0.0)(@graphql-tools/utils@9.2.1)(@graphql-tools/wrap@10.0.1)(@types/node@20.10.3)(graphql-tag@2.12.6)(react-dom@18.2.0)(react-native@0.72.6)(react@18.2.0)(tslib@2.6.2)(typescript@5.2.2)(zod@3.22.4)
+        specifier: 1.2.1
+        version: 1.2.1(@babel/core@7.23.3)(@envelop/core@4.0.3)(@graphql-mesh/types@0.93.2)(@graphql-tools/delegate@10.0.3)(@graphql-tools/merge@9.0.0)(@graphql-tools/utils@9.2.1)(@graphql-tools/wrap@10.0.1)(@types/node@20.10.3)(graphql-tag@2.12.6)(react-dom@18.2.0)(react-native@0.72.6)(react@18.2.0)(tslib@2.6.2)(typescript@5.2.2)
       '@wagmi/core':
         specifier: ^1.4.7
-        version: 1.4.7(@types/react@18.2.37)(react@18.2.0)(typescript@5.2.2)(viem@1.18.9)(zod@3.22.4)
+        version: 1.4.7(@types/react@18.2.37)(react@18.2.0)(typescript@5.2.2)(viem@1.18.9)
       abitype:
         specifier: ^0.10.3
-        version: 0.10.3(typescript@5.2.2)(zod@3.22.4)
+        version: 0.10.3(typescript@5.2.2)
       class-variance-authority:
         specifier: ^0.7.0
         version: 0.7.0
@@ -152,7 +152,7 @@ importers:
         version: 4.2.1(typescript@5.2.2)(vite@4.5.2)
       wagmi:
         specifier: ^1.4.6
-        version: 1.4.7(@types/react@18.2.37)(react-dom@18.2.0)(react-native@0.72.6)(react@18.2.0)(typescript@5.2.2)(viem@1.18.9)(zod@3.22.4)
+        version: 1.4.7(@types/react@18.2.37)(react-dom@18.2.0)(react-native@0.72.6)(react@18.2.0)(typescript@5.2.2)(viem@1.18.9)
     devDependencies:
       '@types/node':
         specifier: ^20.9.2
@@ -576,11 +576,11 @@ importers:
         specifier: ^2.1.0
         version: 2.1.0(react@18.2.0)
       '@verax-attestation-registry/verax-sdk':
-        specifier: 1.1.1
-        version: 1.1.1(@babel/core@7.23.3)(@envelop/core@4.0.3)(@graphql-mesh/types@0.93.2)(@graphql-tools/delegate@10.0.3)(@graphql-tools/merge@9.0.0)(@graphql-tools/utils@9.2.1)(@graphql-tools/wrap@10.0.1)(@types/node@20.10.3)(graphql-tag@2.12.6)(react-dom@18.2.0)(react-native@0.72.6)(react@18.2.0)(tslib@2.6.2)(typescript@5.2.2)(zod@3.22.4)
+        specifier: 1.2.1
+        version: 1.2.1(@babel/core@7.23.3)(@envelop/core@4.0.3)(@graphql-mesh/types@0.93.2)(@graphql-tools/delegate@10.0.3)(@graphql-tools/merge@9.0.0)(@graphql-tools/utils@9.2.1)(@graphql-tools/wrap@10.0.1)(@types/node@20.10.3)(graphql-tag@2.12.6)(react-dom@18.2.0)(react-native@0.72.6)(react@18.2.0)(tslib@2.6.2)(typescript@5.2.2)
       '@wagmi/core':
         specifier: ^1.4.7
-        version: 1.4.7(@types/react@18.2.37)(react@18.2.0)(typescript@5.2.2)(viem@1.18.9)(zod@3.22.4)
+        version: 1.4.7(@types/react@18.2.37)(react@18.2.0)(typescript@5.2.2)(viem@1.18.9)
       '@web3modal/wagmi':
         specifier: ^3.5.0
         version: 3.5.4(@types/react@18.2.37)(@wagmi/core@1.4.7)(typescript@5.2.2)(viem@1.18.9)
@@ -604,7 +604,7 @@ importers:
         version: 1.18.9(typescript@5.2.2)(zod@3.22.4)
       wagmi:
         specifier: ^1.4.6
-        version: 1.4.7(@types/react@18.2.37)(react-dom@18.2.0)(react-native@0.72.6)(react@18.2.0)(typescript@5.2.2)(viem@1.18.9)(zod@3.22.4)
+        version: 1.4.7(@types/react@18.2.37)(react-dom@18.2.0)(react-native@0.72.6)(react@18.2.0)(typescript@5.2.2)(viem@1.18.9)
     devDependencies:
       '@types/react':
         specifier: ^18.2.37
@@ -8571,10 +8571,10 @@ packages:
       picomatch: 2.3.1
     dev: true
 
-  /@safe-global/safe-apps-provider@0.17.1(typescript@5.2.2)(zod@3.22.4):
+  /@safe-global/safe-apps-provider@0.17.1(typescript@5.2.2):
     resolution: {integrity: sha512-lYfRqrbbK1aKU1/UGkYWc/X7PgySYcumXKc5FB2uuwAs2Ghj8uETuW5BrwPqyjBknRxutFbTv+gth/JzjxAhdQ==}
     dependencies:
-      '@safe-global/safe-apps-sdk': 8.0.0(typescript@5.2.2)(zod@3.22.4)
+      '@safe-global/safe-apps-sdk': 8.0.0(typescript@5.2.2)
       events: 3.3.0
     transitivePeerDependencies:
       - bufferutil
@@ -8583,7 +8583,7 @@ packages:
       - zod
     dev: false
 
-  /@safe-global/safe-apps-sdk@8.0.0(typescript@5.2.2)(zod@3.22.4):
+  /@safe-global/safe-apps-sdk@8.0.0(typescript@5.2.2):
     resolution: {integrity: sha512-gYw0ki/EAuV1oSyMxpqandHjnthZjYYy+YWpTAzf8BqfXM3ItcZLpjxfg+3+mXW8HIO+3jw6T9iiqEXsqHaMMw==}
     dependencies:
       '@safe-global/safe-gateway-typescript-sdk': 3.13.2
@@ -8595,7 +8595,7 @@ packages:
       - zod
     dev: false
 
-  /@safe-global/safe-apps-sdk@8.1.0(typescript@5.2.2)(zod@3.22.4):
+  /@safe-global/safe-apps-sdk@8.1.0(typescript@5.2.2):
     resolution: {integrity: sha512-XJbEPuaVc7b9n23MqlF6c+ToYIS3f7P2Sel8f3cSBQ9WORE4xrSuvhMpK9fDSFqJ7by/brc+rmJR/5HViRr0/w==}
     dependencies:
       '@safe-global/safe-gateway-typescript-sdk': 3.13.2
@@ -10493,8 +10493,8 @@ packages:
       wonka: 6.3.4
     dev: false
 
-  /@verax-attestation-registry/verax-sdk@1.1.1(@babel/core@7.23.3)(@envelop/core@4.0.3)(@graphql-mesh/types@0.93.2)(@graphql-tools/delegate@10.0.3)(@graphql-tools/merge@9.0.0)(@graphql-tools/utils@9.2.1)(@graphql-tools/wrap@10.0.1)(@types/node@20.10.3)(graphql-tag@2.12.6)(react-dom@18.2.0)(react-native@0.72.6)(react@18.2.0)(tslib@2.6.2)(typescript@5.2.2)(zod@3.22.4):
-    resolution: {integrity: sha512-3SX2rSHh/UAdrzn7IAvIc0RxfClI0I3Yk6+WQN7FWtoYMww8SS4Zv4nm8eGQYXucK5PNJtMpBGBoR2SRHvha9A==}
+  /@verax-attestation-registry/verax-sdk@1.2.1(@babel/core@7.23.3)(@envelop/core@4.0.3)(@graphql-mesh/types@0.93.2)(@graphql-tools/delegate@10.0.3)(@graphql-tools/merge@9.0.0)(@graphql-tools/utils@9.2.1)(@graphql-tools/wrap@10.0.1)(@types/node@20.10.3)(graphql-tag@2.12.6)(react-dom@18.2.0)(react-native@0.72.6)(react@18.2.0)(tslib@2.6.2)(typescript@5.2.2):
+    resolution: {integrity: sha512-Me+JGGgOGLBsjBKtw+P/nXRy7thYRaMYkAn1ytP/sNQuUAL3w+hjnBdz/BWAZzB2ZrjNJuKe8TFmqhYjNLnisg==}
     dependencies:
       '@graphprotocol/client-cli': 3.0.0(@babel/core@7.23.3)(@envelop/core@4.0.3)(@graphql-mesh/cross-helpers@0.4.1)(@graphql-mesh/store@0.95.8)(@graphql-mesh/types@0.93.2)(@graphql-mesh/utils@0.95.8)(@graphql-tools/delegate@10.0.3)(@graphql-tools/merge@9.0.0)(@graphql-tools/utils@9.2.1)(@graphql-tools/wrap@10.0.1)(@types/node@20.10.3)(graphql-tag@2.12.6)(graphql@16.8.1)(react-native@0.72.6)
       '@graphql-mesh/cache-localforage': 0.95.8(@graphql-mesh/types@0.93.2)(@graphql-mesh/utils@0.95.8)(graphql@16.8.1)(tslib@2.6.2)
@@ -10642,7 +10642,7 @@ packages:
     requiresBuild: true
     dev: false
 
-  /@wagmi/connectors@3.1.5(@types/react@18.2.37)(react@18.2.0)(typescript@5.2.2)(viem@1.18.9)(zod@3.22.4):
+  /@wagmi/connectors@3.1.5(@types/react@18.2.37)(react@18.2.0)(typescript@5.2.2)(viem@1.18.9):
     resolution: {integrity: sha512-aE4rWZbivqWa9HqjiLDPtwROH2b1Az+lBVMeZ3o/aFxGNGNEkdrSAMOUG15/UFy3VnN6HqGOtTobOBZ10JhfNQ==}
     peerDependencies:
       typescript: '>=5.0.4'
@@ -10653,13 +10653,13 @@ packages:
     dependencies:
       '@coinbase/wallet-sdk': 3.7.2
       '@ledgerhq/connect-kit-loader': 1.1.2
-      '@safe-global/safe-apps-provider': 0.17.1(typescript@5.2.2)(zod@3.22.4)
-      '@safe-global/safe-apps-sdk': 8.1.0(typescript@5.2.2)(zod@3.22.4)
+      '@safe-global/safe-apps-provider': 0.17.1(typescript@5.2.2)
+      '@safe-global/safe-apps-sdk': 8.1.0(typescript@5.2.2)
       '@walletconnect/ethereum-provider': 2.10.2(@walletconnect/modal@2.6.2)
       '@walletconnect/legacy-provider': 2.0.0
       '@walletconnect/modal': 2.6.2(@types/react@18.2.37)(react@18.2.0)
       '@walletconnect/utils': 2.10.2
-      abitype: 0.8.7(typescript@5.2.2)(zod@3.22.4)
+      abitype: 0.8.7(typescript@5.2.2)
       eventemitter3: 4.0.7
       typescript: 5.2.2
       viem: 1.18.9(typescript@5.2.2)(zod@3.22.4)
@@ -10685,7 +10685,7 @@ packages:
       - zod
     dev: false
 
-  /@wagmi/core@1.4.7(@types/react@18.2.37)(react@18.2.0)(typescript@5.2.2)(viem@1.18.9)(zod@3.22.4):
+  /@wagmi/core@1.4.7(@types/react@18.2.37)(react@18.2.0)(typescript@5.2.2)(viem@1.18.9):
     resolution: {integrity: sha512-PiOIGni8ArQoPmuDylHX38zMt2nPnTYRIluIqiduKyGCM61X/tf10a0rafUMOOphDPudZu1TacNDhCSeoh/LEA==}
     peerDependencies:
       typescript: '>=5.0.4'
@@ -10694,8 +10694,8 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@wagmi/connectors': 3.1.5(@types/react@18.2.37)(react@18.2.0)(typescript@5.2.2)(viem@1.18.9)(zod@3.22.4)
-      abitype: 0.8.7(typescript@5.2.2)(zod@3.22.4)
+      '@wagmi/connectors': 3.1.5(@types/react@18.2.37)(react@18.2.0)(typescript@5.2.2)(viem@1.18.9)
+      abitype: 0.8.7(typescript@5.2.2)
       eventemitter3: 4.0.7
       typescript: 5.2.2
       viem: 1.18.9(typescript@5.2.2)(zod@3.22.4)
@@ -11357,7 +11357,7 @@ packages:
       vue:
         optional: true
     dependencies:
-      '@wagmi/core': 1.4.7(@types/react@18.2.37)(react@18.2.0)(typescript@5.2.2)(viem@1.18.9)(zod@3.22.4)
+      '@wagmi/core': 1.4.7(@types/react@18.2.37)(react@18.2.0)(typescript@5.2.2)(viem@1.18.9)
       '@web3modal/polyfills': 3.5.4
       '@web3modal/scaffold': 3.5.4(@types/react@18.2.37)(react@18.2.0)
       '@web3modal/scaffold-react': 3.5.4(@types/react@18.2.37)(react-dom@18.2.0)(react@18.2.0)
@@ -11623,7 +11623,7 @@ packages:
     resolution: {integrity: sha512-LEyx4aLEC3x6T0UguF6YILf+ntvmOaWsVfENmIW0E9H09vKlLDGelMjjSm0jkDHALj8A8quZ/HapKNigzwge+Q==}
     dev: true
 
-  /abitype@0.10.3(typescript@5.2.2)(zod@3.22.4):
+  /abitype@0.10.3(typescript@5.2.2):
     resolution: {integrity: sha512-tRN+7XIa7J9xugdbRzFv/95ka5ivR/sRe01eiWvM0HWWjHuigSZEACgKa0sj4wGuekTDtghCx+5Izk/cOi78pQ==}
     peerDependencies:
       typescript: '>=5.0.4'
@@ -11635,10 +11635,9 @@ packages:
         optional: true
     dependencies:
       typescript: 5.2.2
-      zod: 3.22.4
     dev: false
 
-  /abitype@0.8.7(typescript@5.2.2)(zod@3.22.4):
+  /abitype@0.8.7(typescript@5.2.2):
     resolution: {integrity: sha512-wQ7hV8Yg/yKmGyFpqrNZufCxbszDe5es4AZGYPBitocfSqXtjrTG9JMWFcc4N30ukl2ve48aBTwt7NJxVQdU3w==}
     peerDependencies:
       typescript: '>=5.0.4'
@@ -11648,7 +11647,6 @@ packages:
         optional: true
     dependencies:
       typescript: 5.2.2
-      zod: 3.22.4
     dev: false
 
   /abitype@0.9.8(typescript@5.2.2)(zod@3.22.4):
@@ -13912,7 +13910,7 @@ packages:
       resize-observer-polyfill: 1.5.1
       styled-components: 5.3.11(@babel/core@7.23.3)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
       viem: 1.18.9(typescript@5.2.2)(zod@3.22.4)
-      wagmi: 1.4.7(@types/react@18.2.37)(react-dom@18.2.0)(react-native@0.72.6)(react@18.2.0)(typescript@5.2.2)(viem@1.18.9)(zod@3.22.4)
+      wagmi: 1.4.7(@types/react@18.2.37)(react-dom@18.2.0)(react-native@0.72.6)(react@18.2.0)(typescript@5.2.2)(viem@1.18.9)
     transitivePeerDependencies:
       - '@babel/core'
       - react-is
@@ -27682,7 +27680,7 @@ packages:
     hasBin: true
     dev: true
 
-  /wagmi@1.4.7(@types/react@18.2.37)(react-dom@18.2.0)(react-native@0.72.6)(react@18.2.0)(typescript@5.2.2)(viem@1.18.9)(zod@3.22.4):
+  /wagmi@1.4.7(@types/react@18.2.37)(react-dom@18.2.0)(react-native@0.72.6)(react@18.2.0)(typescript@5.2.2)(viem@1.18.9):
     resolution: {integrity: sha512-/k8gA9S6RnwU6Qroxs630jAFvRIx+DSKpCP1owgAEGWc7D2bAJHljwRSCRTGENz48HyJ4V3R7KYV1yImxPvM3A==}
     peerDependencies:
       react: '>=17.0.0'
@@ -27695,8 +27693,8 @@ packages:
       '@tanstack/query-sync-storage-persister': 4.36.1
       '@tanstack/react-query': 4.36.1(react-dom@18.2.0)(react-native@0.72.6)(react@18.2.0)
       '@tanstack/react-query-persist-client': 4.36.1(@tanstack/react-query@4.36.1)
-      '@wagmi/core': 1.4.7(@types/react@18.2.37)(react@18.2.0)(typescript@5.2.2)(viem@1.18.9)(zod@3.22.4)
-      abitype: 0.8.7(typescript@5.2.2)(zod@3.22.4)
+      '@wagmi/core': 1.4.7(@types/react@18.2.37)(react@18.2.0)(typescript@5.2.2)(viem@1.18.9)
+      abitype: 0.8.7(typescript@5.2.2)
       react: 18.2.0
       typescript: 5.2.2
       use-sync-external-store: 1.2.0(react@18.2.0)

--- a/sdk/doc/cli-examples.md
+++ b/sdk/doc/cli-examples.md
@@ -76,8 +76,6 @@
 
     pnpm attestation getAttestation "0x0000000000000000000000000000000000000000000000000000000000000001"
 
-    pnpm attestation getAttestationWithDecodeObject "0x000000000000000000000000000000000000000000000000000000000000121f"
-
     pnpm attestation getVersionNumber
 
     pnpm attestation getAttestationIdCounter

--- a/sdk/examples/attestation/attestationExamples.ts
+++ b/sdk/examples/attestation/attestationExamples.ts
@@ -111,12 +111,6 @@ export default class AttestationExamples {
       console.log(await this.veraxSdk.attestation.getAttestation(attestationId));
     }
 
-    if (methodName.toLowerCase() == "getAttestationWithDecodeObject".toLowerCase() || methodName == "") {
-      const attestationId: string =
-        argv === "" ? "0x000000000000000000000000000000000000000000000000000000000000121f" : argv;
-      console.log(await this.veraxSdk.attestation.getAttestationWithDecodeObject(attestationId));
-    }
-
     if (methodName.toLowerCase() == "getVersionNumber".toLowerCase() || methodName == "") {
       console.log(await this.veraxSdk.attestation.getVersionNumber());
     }

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verax-attestation-registry/verax-sdk",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Verax Attestation Registry SDK to interact with the subgraph and the contracts",
   "keywords": [
     "linea-attestation-registry",

--- a/sdk/src/dataMapper/AttestationDataMapper.ts
+++ b/sdk/src/dataMapper/AttestationDataMapper.ts
@@ -1,6 +1,6 @@
 import BaseDataMapper from "./BaseDataMapper";
 import { abiAttestationRegistry } from "../abi/AttestationRegistry";
-import { Attestation, AttestationPayload, AttestationWithDecodeObject, OffchainData, Schema } from "../types";
+import { Attestation, AttestationPayload, OffchainData, Schema } from "../types";
 import { Attestation_filter, Attestation_orderBy, OrderDirection } from "../../.graphclient";
 import { Constants } from "../utils/constants";
 import { handleSimulationError } from "../utils/simulationErrorHandler";
@@ -58,7 +58,7 @@ export default class AttestationDataMapper extends BaseDataMapper<
   }
 
   private async enrichAttestation(attestation: Attestation) {
-    const schema = (await this.veraxSdk.schema.getSchema(attestation.schemaId)) as Schema;
+    const schema = (await this.veraxSdk.schema.findOneById(attestation.schemaId)) as Schema;
     attestation.decodedPayload = decodeWithRetry(schema.schema, attestation.attestationData as `0x${string}`);
 
     attestation.attestedDate = Number(attestation.attestedDate);
@@ -79,7 +79,7 @@ export default class AttestationDataMapper extends BaseDataMapper<
           const ipfsHash = attestation.offchainData.uri.split("//")[1];
           const response = await getIPFSContent(ipfsHash);
           if (response.toString().startsWith("0x")) {
-            const offchainDataSchema = (await this.veraxSdk.schema.getSchema(
+            const offchainDataSchema = (await this.veraxSdk.schema.findOneById(
               attestation.offchainData.schemaId,
             )) as Schema;
             attestation.decodedPayload = decodeWithRetry(
@@ -167,21 +167,6 @@ export default class AttestationDataMapper extends BaseDataMapper<
 
   async getAttestation(attestationId: string) {
     return this.executeReadMethod("getAttestation", [attestationId]);
-  }
-
-  async getAttestationWithDecodeObject(attestationId: string) {
-    const attestation = await this.findOneById(attestationId);
-    if (!attestation) {
-      return null;
-    }
-    const attestationWithDecodeObject: AttestationWithDecodeObject = { ...attestation, decodeObject: {} };
-    const schema = (await this.veraxSdk.schema.getSchema(attestation.schemaId)) as Schema;
-    const splitSchema = schema.schema.split(",");
-    const schemaFields = splitSchema.map<string>((item) => item.trim().split(" ")[1]);
-    for (let i = 0; i < schemaFields.length; i++) {
-      attestationWithDecodeObject.decodeObject[schemaFields[i]] = attestation.decodedData[i];
-    }
-    return attestationWithDecodeObject;
   }
 
   async getVersionNumber() {

--- a/tutorial/package.json
+++ b/tutorial/package.json
@@ -29,7 +29,7 @@
     "@fortawesome/free-solid-svg-icons": "^6.4.2",
     "@fortawesome/react-fontawesome": "^0.2.0",
     "@lens-protocol/widgets-react": "^2.1.0",
-    "@verax-attestation-registry/verax-sdk": "1.1.1",
+    "@verax-attestation-registry/verax-sdk": "1.2.1",
     "@wagmi/core": "^1.4.7",
     "@web3modal/wagmi": "^3.5.0",
     "axios": "^1.6.1",


### PR DESCRIPTION
## What does this PR do?

When getting one or multiple attestation(s), the calls to fetch the Schema are now made to the subgraph instead of the chain. This reduces the number of RPC calls to 0 for such operations.

### Related ticket

Fixes #579 

### Type of change

- [ ] Chore
- [X] Bug fix
- [ ] New feature
- [ ] Documentation update

## Check list

- [ ] Unit tests for any smart contract change
- [ ] Contracts and functions are documented
