### PR TITLE
fix: Attestation IDs are rendered incorrectly on Verax Explorer on Base mainnet

### DIFF
--- a/explorer/src/components/NotFoundPage/index.tsx
+++ b/explorer/src/components/NotFoundPage/index.tsx
@@ -1,5 +1,6 @@
 import { t } from "i18next";
 import { ChevronLeft } from "lucide-react";
+import { Hex, hexToNumber } from "viem";
 
 import archive from "@/assets/icons/archive.svg";
 import { Link } from "@/components/Link";
@@ -10,7 +11,10 @@ import { getNotFoundPageData } from "./utils";
 
 export const NotFoundPage: React.FC<NotFoundPageProps> = ({ id, page }) => {
   const pageData = getNotFoundPageData(page, id);
-  const decodedId = typeof pageData.id === "string" ? pageData.id : displayAmountWithComma(pageData.id);
+  const decodedId =
+    typeof pageData.id === "string"
+      ? pageData.id
+      : displayAmountWithComma(hexToNumber(`0x${(id as Hex).substring(6)}`));
   return (
     <section className="container flex justify-center px-4">
       <div className="flex flex-col max-w-[1200px] w-full h-[644px] items-center justify-center gap-6 border border-solid mt-8 rounded-3xl">

--- a/explorer/src/constants/columns/attestation.tsx
+++ b/explorer/src/constants/columns/attestation.tsx
@@ -2,7 +2,7 @@ import { ColumnDef } from "@tanstack/react-table";
 import { Attestation, VeraxSdk } from "@verax-attestation-registry/verax-sdk";
 import { t } from "i18next";
 import moment from "moment";
-import { Address } from "viem";
+import { Hex } from "viem";
 import { hexToNumber } from "viem/utils";
 
 import { TdHandler } from "@/components/DataTable/components/TdHandler";
@@ -37,7 +37,7 @@ export const columns = ({ sortByDate = true, sdk, chainId }: Partial<ColumnsProp
       const id = row.getValue("id");
       return (
         <Link to={toAttestationById(id as string)} className="hover:underline" onClick={(e) => e.stopPropagation()}>
-          {displayAmountWithComma(hexToNumber(id as Address))}
+          {displayAmountWithComma(hexToNumber(`0x${(id as Hex).substring(6)}`))}
         </Link>
       );
     },

--- a/explorer/src/pages/Attestation/components/AttestationInfo/index.tsx
+++ b/explorer/src/pages/Attestation/components/AttestationInfo/index.tsx
@@ -46,7 +46,7 @@ export const AttestationInfo: React.FC<Attestation> = ({ ...attestation }) => {
   return (
     <div className="flex flex-col w-full items-start gap-6">
       <div className="font-semibold text-page-attestation dark:text-page-attestationDark text-2xl whitespace-nowrap md:text-3xl">
-        #{displayAmountWithComma(hexToNumber(id as Hex))}
+        #{displayAmountWithComma(hexToNumber(`0x${(id as Hex).substring(6)}`))}
       </div>
       <div className="gap-6 flex flex-col items-start w-full md:flex-wrap md:h-[170px] md:content-between xl:flex-nowrap xl:h-auto">
         {list.map((item) => (

--- a/explorer/src/pages/Attestation/components/RelatedAttestations/index.tsx
+++ b/explorer/src/pages/Attestation/components/RelatedAttestations/index.tsx
@@ -56,7 +56,7 @@ export const RelatedAttestations: React.FC<{ mutate: KeyedMutator<Attestation | 
               className="py-2 justify-start items-center gap-2 inline-flex flex-shrink-0 lg:flex-col lg:items-start lg:w-[115px]"
             >
               <div className="text-text-secondary text-lg font-semibold">
-                {displayAmountWithComma(hexToNumber(id as Hex))}
+                {displayAmountWithComma(hexToNumber(`0x${(id as Hex).substring(6)}`))}
               </div>
               <div className="text-text-tertiary text-sm font-normal">{title}</div>
             </Link>


### PR DESCRIPTION
## What does this PR do?

Attestation IDs were wrongly converted to a huge number on some networks

### Related ticket

Fixes #624 

### Type of change

- [ ] Chore
- [X] Bug fix
- [ ] New feature
- [ ] Documentation update

## Check list

- [ ] Unit tests for any smart contract change
- [ ] Contracts and functions are documented
