### PR TITLE
fix(explorer): List of "Recent Attestations" for a Schema displays the oldest Attestations first

### DIFF
--- a/explorer/src/pages/Schema/components/RecentAttestations/index.tsx
+++ b/explorer/src/pages/Schema/components/RecentAttestations/index.tsx
@@ -17,7 +17,7 @@ export const RecentAttestations: React.FC<{ schemaId: string }> = ({ schemaId })
 
   const { data: attestations, isLoading } = useSWR(
     `${SWRKeys.GET_RECENT_ATTESTATION}/${schemaId}/${chain.id}`,
-    () => sdk.attestation.findBy(undefined, undefined, { schemaId }),
+    () => sdk.attestation.findBy(5, 0, { schemaId }, "attestedDate", "desc"),
     {
       shouldRetryOnError: false,
     },


### PR DESCRIPTION
## What does this PR do?

Puts the "recent Attestations" in descending order on the Schema page

### Related ticket

Fixes #628 

### Type of change

- [ ] Chore
- [X] Bug fix
- [ ] New feature
- [ ] Documentation update

## Check list

- [ ] Unit tests for any smart contract change
- [ ] Contracts and functions are documented
