### PR TITLE
chore(contracts): Add a warning on the `withdraw` function not being implemented

### DIFF
--- a/contracts/src/abstracts/AbstractPortal.sol
+++ b/contracts/src/abstracts/AbstractPortal.sol
@@ -44,6 +44,7 @@ abstract contract AbstractPortal is IPortal {
    * @notice Optional method to withdraw funds from the Portal
    * @param to the address to send the funds to
    * @param amount the amount to withdraw
+   * @dev DISCLAIMER: by default, this method is not implemented and should be overridden if funds are to be withdrawn
    */
   function withdraw(address payable to, uint256 amount) external virtual;
 

--- a/contracts/src/examples/portals/EASPortal.sol
+++ b/contracts/src/examples/portals/EASPortal.sol
@@ -40,6 +40,12 @@ contract EASPortal is AbstractPortal {
   /// @notice Error thrown when trying to bulk revoke attestations
   error NoBulkRevocation();
 
+  /**
+   * @notice Contract constructor
+   * @param modules list of modules to use for the portal (can be empty)
+   * @param router Router's address
+   * @dev This sets the addresses for the AttestationRegistry, ModuleRegistry and PortalRegistry
+   */
   constructor(address[] memory modules, address router) AbstractPortal(modules, router) {}
 
   /// @inheritdoc AbstractPortal

--- a/contracts/src/examples/portals/NFTPortal.sol
+++ b/contracts/src/examples/portals/NFTPortal.sol
@@ -17,6 +17,12 @@ import { IPortal } from "../../interfaces/IPortal.sol";
 contract NFTPortal is AbstractPortal, ERC721 {
   mapping(bytes owner => uint256 numberOfAttestations) private numberOfAttestationsPerOwner;
 
+  /**
+   * @notice Contract constructor
+   * @param modules list of modules to use for the portal (can be empty)
+   * @param router Router's address
+   * @dev This sets the addresses for the AttestationRegistry, ModuleRegistry and PortalRegistry
+   */
   constructor(
     address[] memory modules,
     address router
@@ -43,8 +49,7 @@ contract NFTPortal is AbstractPortal, ERC721 {
   }
 
   /**
-   * @notice Method run before a payload is attested
-   * @param attestationPayload the attestation payload supposed to be attested
+   * @inheritdoc AbstractPortal
    */
   function _onAttest(
     AttestationPayload memory attestationPayload,
@@ -54,6 +59,7 @@ contract NFTPortal is AbstractPortal, ERC721 {
     numberOfAttestationsPerOwner[attestationPayload.subject]++;
   }
 
+  /// @inheritdoc AbstractPortal
   function withdraw(address payable to, uint256 amount) external override {}
 
   /**


### PR DESCRIPTION
## What does this PR do?

Adds a warning on the `AbstractPortal` and the example Portals to make sure the `withdraw` is implemented when needed.

This warning can also be found in [the documentation](https://docs.ver.ax/verax-documentation/developer-guides/for-attestation-issuers/create-a-portal).

### Related ticket

Fixes #639 

### Type of change

- [X] Chore
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update

## Check list

- [ ] Unit tests for any smart contract change
- [ ] Contracts and functions are documented
