### PR TITLE
chore(contracts): Add a warning on the `bulkRunModules` being exposed to not incremented attestation ID

### DIFF
--- a/contracts/src/ModuleRegistry.sol
+++ b/contracts/src/ModuleRegistry.sol
@@ -188,6 +188,9 @@ contract ModuleRegistry is OwnableUpgradeable {
    * @param validationPayloads the payloads to check for each module
    * @dev NOTE: Currently the bulk run modules does not handle payable modules
    *            a default value of 0 is used.
+   * @dev DISCLAIMER: This method may have unexpected behavior if one of the checks is done on the attestation ID
+   *                  as this ID won't be incremented before the end of the transaction.
+   *                  If you need to check the attestation ID, please use the `attest` method.
    */
   function bulkRunModules(
     address[] memory modulesAddresses,
@@ -206,6 +209,9 @@ contract ModuleRegistry is OwnableUpgradeable {
    * @param validationPayloads the payloads to check for each module
    * @dev NOTE: Currently the bulk run modules does not handle payable modules
    *            a default value of 0 is used.
+   * @dev DISCLAIMER: This method may have unexpected behavior if one of the checks is done on the attestation ID
+   *                  as this ID won't be incremented before the end of the transaction.
+   *                  If you need to check the attestation ID, please use the `attestV2` method.
    */
   function bulkRunModulesV2(
     address[] memory modulesAddresses,

--- a/contracts/src/abstracts/AbstractPortal.sol
+++ b/contracts/src/abstracts/AbstractPortal.sol
@@ -79,6 +79,9 @@ abstract contract AbstractPortal is IPortal {
    * @notice Bulk attest the schema with payloads to attest and validation payloads
    * @param attestationsPayloads the payloads to attest
    * @param validationPayloads the payloads to validate via the modules to issue the attestations
+   * @dev DISCLAIMER: This method may have unexpected behavior if one of the Module checks is done on the attestation ID
+   *                  as this ID won't be incremented before the end of the transaction.
+   *                  If you need to check the attestation ID, please use the `attest` method.
    */
   function bulkAttest(AttestationPayload[] memory attestationsPayloads, bytes[][] memory validationPayloads) public {
     moduleRegistry.bulkRunModules(modules, attestationsPayloads, validationPayloads);
@@ -92,6 +95,9 @@ abstract contract AbstractPortal is IPortal {
    * @notice Bulk attest the schema with payloads to attest and validation payloads
    * @param attestationPayloads the payloads to attest
    * @param validationPayloads the payloads to validate via the modules to issue the attestations
+   * @dev DISCLAIMER: This method may have unexpected behavior if one of the Module checks is done on the attestation ID
+   *                  as this ID won't be incremented before the end of the transaction.
+   *                  If you need to check the attestation ID, please use the `attestV2` method.
    */
   function bulkAttestV2(AttestationPayload[] memory attestationPayloads, bytes[][] memory validationPayloads) public {
     moduleRegistry.bulkRunModulesV2(modules, attestationPayloads, validationPayloads, msg.sender, getAttester());
@@ -125,6 +131,9 @@ abstract contract AbstractPortal is IPortal {
    * @param attestationIds the list of IDs of the attestations to replace
    * @param attestationsPayloads the list of attestation payloads to create the new attestations and register them
    * @param validationPayloads the payloads to validate via the modules to issue the attestations
+   * @dev DISCLAIMER: This method may have unexpected behavior if one of the Module checks is done on the attestation ID
+   *                  as this ID won't be incremented before the end of the transaction.
+   *                  If you need to check the attestation ID, please use the `replace` method.
    */
   function bulkReplace(
     bytes32[] memory attestationIds,

--- a/contracts/src/examples/portals/EASPortal.sol
+++ b/contracts/src/examples/portals/EASPortal.sol
@@ -83,6 +83,9 @@ contract EASPortal is AbstractPortal {
   /**
    * @notice Issues Verax attestations in bulk, based on a list of EAS attestations
    * @param attestationsRequests the EAS payloads to attest
+   * @dev DISCLAIMER: This method may have unexpected behavior if one of the Module checks is done on the attestation ID
+   *                  as this ID won't be incremented before the end of the transaction.
+   *                  If you need to check the attestation ID, please use the `replace` method.
    */
   function bulkAttest(AttestationRequest[] memory attestationsRequests) external payable {
     for (uint256 i = 0; i < attestationsRequests.length; i = uncheckedInc256(i)) {


### PR DESCRIPTION
## What does this PR do?

Adds a warning on the `AbstractPortal`, the `ModuleRegistry` and the example Portals to warn about an edge case with the `bulkRunModules` function.

This warning can also be found in [the documentation](https://docs.ver.ax/verax-documentation/developer-guides/for-attestation-issuers/bulk-create-attestations).

### Related ticket

Fixes #640 

### Type of change

- [X] Chore
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update

## Check list

- [ ] Unit tests for any smart contract change
- [ ] Contracts and functions are documented
