### PR TITLE
chore(sdk): As a user, I want to use Linea Sepolia as a default network in examples

### DIFF
--- a/sdk/examples/attestation/index.ts
+++ b/sdk/examples/attestation/index.ts
@@ -17,6 +17,6 @@ let waitForConfirmation = false;
 if ((argv === "" && (process.argv[3] as string) === "wait") || waitForConfirmationArgv === "wait")
   waitForConfirmation = true;
 
-const veraxSdk = new VeraxSdk(VeraxSdk.DEFAULT_LINEA_TESTNET, undefined, privateKey);
+const veraxSdk = new VeraxSdk(VeraxSdk.DEFAULT_LINEA_SEPOLIA, undefined, privateKey);
 
 new AttestationExamples(veraxSdk).run(argv, process.argv[2], waitForConfirmation);

--- a/sdk/examples/module/index.ts
+++ b/sdk/examples/module/index.ts
@@ -17,6 +17,6 @@ let waitForConfirmation = false;
 if ((argv === "" && (process.argv[3] as string) === "wait") || waitForConfirmationArgv === "wait")
   waitForConfirmation = true;
 
-const veraxSdk = new VeraxSdk(VeraxSdk.DEFAULT_LINEA_TESTNET, undefined, privateKey);
+const veraxSdk = new VeraxSdk(VeraxSdk.DEFAULT_LINEA_SEPOLIA, undefined, privateKey);
 
 new ModuleExamples(veraxSdk).run(argv, process.argv[2], waitForConfirmation);

--- a/sdk/examples/portal/index.ts
+++ b/sdk/examples/portal/index.ts
@@ -17,6 +17,6 @@ let waitForConfirmation = false;
 if ((argv === "" && (process.argv[3] as string) === "wait") || waitForConfirmationArgv === "wait")
   waitForConfirmation = true;
 
-const veraxSdk = new VeraxSdk(VeraxSdk.DEFAULT_LINEA_TESTNET, undefined, privateKey);
+const veraxSdk = new VeraxSdk(VeraxSdk.DEFAULT_LINEA_SEPOLIA, undefined, privateKey);
 
 new PortalExamples(veraxSdk).run(argv, process.argv[2], waitForConfirmation);

--- a/sdk/examples/schema/index.ts
+++ b/sdk/examples/schema/index.ts
@@ -1,6 +1,6 @@
 import { Hex } from "viem";
 import { VeraxSdk } from "../../src/VeraxSdk";
-import PortalExamples from "./schemaExamples";
+import SchemaExamples from "./schemaExamples";
 import { config } from "dotenv";
 import * as path from "path";
 
@@ -17,6 +17,6 @@ let waitForConfirmation = false;
 if ((argv === "" && (process.argv[3] as string) === "wait") || waitForConfirmationArgv === "wait")
   waitForConfirmation = true;
 
-const veraxSdk = new VeraxSdk(VeraxSdk.DEFAULT_LINEA_TESTNET, undefined, privateKey);
+const veraxSdk = new VeraxSdk(VeraxSdk.DEFAULT_LINEA_SEPOLIA, undefined, privateKey);
 
-new PortalExamples(veraxSdk).run(argv, process.argv[2], waitForConfirmation);
+new SchemaExamples(veraxSdk).run(argv, process.argv[2], waitForConfirmation);

--- a/sdk/examples/utils/decode.ts
+++ b/sdk/examples/utils/decode.ts
@@ -1,6 +1,6 @@
 import { VeraxSdk } from "../../src/VeraxSdk";
 
-const veraxSdk = new VeraxSdk(VeraxSdk.DEFAULT_LINEA_TESTNET);
+const veraxSdk = new VeraxSdk(VeraxSdk.DEFAULT_LINEA_SEPOLIA);
 
 // This example relies on a complex Schema written by Clique
 console.log(

--- a/sdk/examples/utils/encode.ts
+++ b/sdk/examples/utils/encode.ts
@@ -1,6 +1,6 @@
 import { VeraxSdk } from "../../src/VeraxSdk";
 
-const veraxSdk = new VeraxSdk(VeraxSdk.DEFAULT_LINEA_TESTNET);
+const veraxSdk = new VeraxSdk(VeraxSdk.DEFAULT_LINEA_SEPOLIA);
 
 // This example relies on a complex Schema written by Clique
 console.log(

--- a/sdk/examples/utils/getAttestationIdCounter.ts
+++ b/sdk/examples/utils/getAttestationIdCounter.ts
@@ -1,5 +1,5 @@
 import { VeraxSdk } from "../../src/VeraxSdk";
 
-const veraxSdk = new VeraxSdk(VeraxSdk.DEFAULT_LINEA_TESTNET);
+const veraxSdk = new VeraxSdk(VeraxSdk.DEFAULT_LINEA_SEPOLIA);
 
 veraxSdk.utils.getAttestationIdCounter().then((res) => console.log(res));

--- a/sdk/examples/utils/getModulesNumber.ts
+++ b/sdk/examples/utils/getModulesNumber.ts
@@ -1,5 +1,5 @@
 import { VeraxSdk } from "../../src/VeraxSdk";
 
-const veraxSdk = new VeraxSdk(VeraxSdk.DEFAULT_LINEA_TESTNET);
+const veraxSdk = new VeraxSdk(VeraxSdk.DEFAULT_LINEA_SEPOLIA);
 
 veraxSdk.utils.getModulesNumber().then((res) => console.log(res));

--- a/sdk/examples/utils/getPortalsCount.ts
+++ b/sdk/examples/utils/getPortalsCount.ts
@@ -1,5 +1,5 @@
 import { VeraxSdk } from "../../src/VeraxSdk";
 
-const veraxSdk = new VeraxSdk(VeraxSdk.DEFAULT_LINEA_TESTNET);
+const veraxSdk = new VeraxSdk(VeraxSdk.DEFAULT_LINEA_SEPOLIA);
 
 veraxSdk.utils.getPortalsCount().then((res) => console.log(res));

--- a/sdk/examples/utils/getRelatedAttestation.ts
+++ b/sdk/examples/utils/getRelatedAttestation.ts
@@ -1,6 +1,6 @@
 import { VeraxSdk } from "../../src/VeraxSdk";
 
-const veraxSdk = new VeraxSdk(VeraxSdk.DEFAULT_LINEA_TESTNET);
+const veraxSdk = new VeraxSdk(VeraxSdk.DEFAULT_LINEA_SEPOLIA);
 
 veraxSdk.attestation
   .getRelatedAttestations("0x0000000000000000000000000000000000000000000000000000000000000001")

--- a/sdk/examples/utils/getSchemasNumber.ts
+++ b/sdk/examples/utils/getSchemasNumber.ts
@@ -1,5 +1,5 @@
 import { VeraxSdk } from "../../src/VeraxSdk";
 
-const veraxSdk = new VeraxSdk(VeraxSdk.DEFAULT_LINEA_TESTNET);
+const veraxSdk = new VeraxSdk(VeraxSdk.DEFAULT_LINEA_SEPOLIA);
 
 veraxSdk.utils.getSchemasNumber().then((res) => console.log(res));

--- a/sdk/examples/utils/getVersionNumber.ts
+++ b/sdk/examples/utils/getVersionNumber.ts
@@ -1,5 +1,5 @@
 import { VeraxSdk } from "../../src/VeraxSdk";
 
-const veraxSdk = new VeraxSdk(VeraxSdk.DEFAULT_LINEA_TESTNET);
+const veraxSdk = new VeraxSdk(VeraxSdk.DEFAULT_LINEA_SEPOLIA);
 
 veraxSdk.utils.getVersionNumber().then((res) => console.log(res));


### PR DESCRIPTION
## What does this PR do?

Updates the default network in SDK examples to Linea Sepolia
Also corrects the Schema examples class in schema index file

### Related ticket

Fixes #645 

### Type of change

- [x] Chore
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update

## Check list

- [ ] Unit tests for any smart contract change
- [ ] Contracts and functions are documented
