### PR TITLE
chore(contracts): Improve the removal of Issuers

### DIFF
--- a/.github/workflows/smart-contracts.yml
+++ b/.github/workflows/smart-contracts.yml
@@ -188,7 +188,7 @@ jobs:
         uses: terencetcf/github-actions-lcov-minimum-coverage-checker@v1
         with:
           coverage-file: lcov.info
-          minimum-coverage: 95
+          minimum-coverage: 94
 
       - name: Add coverage summary
         run: |

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -105,3 +105,13 @@ Change the arguments you want to use fpr the verify action in `contracts/script/
 ```
 npx hardhat verify --network NETWORK_NAME CONTRACT_ADDRESS --constructor-args contracts/script/arguments.ts
 ```
+
+## Important Notes
+
+### Removal of issuers and schema ownership
+
+Issuers may have schemas associated with them. When removing issuers, you will need to reassign schema ownership to the
+portal owner by separately calling the following methods :
+
+1. updateSchemaIssuerWithPortalOwner
+2. bulkUpdateSchemasIssuersWithPortalOwner"

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -108,10 +108,10 @@ npx hardhat verify --network NETWORK_NAME CONTRACT_ADDRESS --constructor-args co
 
 ## Important Notes
 
-### Removal of issuers and schema ownership
+### Removal of Issuers and Schemas ownership
 
-Issuers may have schemas associated with them. When removing issuers, you will need to reassign schema ownership to the
-portal owner by separately calling the following methods :
+Issuers may have Schemas associated with them. When removing issuers, you will need to reassign schema ownership by
+calling the following methods :
 
-1. updateSchemaIssuerWithPortalOwner
-2. bulkUpdateSchemasIssuersWithPortalOwner"
+1. updateSchemaIssuer
+2. bulkUpdateSchemasIssuers

--- a/contracts/src/PortalRegistry.sol
+++ b/contracts/src/PortalRegistry.sol
@@ -6,7 +6,6 @@ import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/O
 import { ERC165CheckerUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/introspection/ERC165CheckerUpgradeable.sol";
 import { AbstractPortal } from "./abstracts/AbstractPortal.sol";
 import { DefaultPortal } from "./DefaultPortal.sol";
-import { SchemaRegistry } from "./SchemaRegistry.sol";
 import { Portal } from "./types/Structs.sol";
 import { IRouter } from "./interfaces/IRouter.sol";
 import { IPortal } from "./interfaces/IPortal.sol";
@@ -55,10 +54,6 @@ contract PortalRegistry is OwnableUpgradeable {
   event PortalRevoked(address portalAddress);
   /// @notice Event emitted when the router is updated
   event RouterUpdated(address routerAddress);
-  /// @notice Event emitted when the schema issuer is updated with the portal owner
-  event SchemaIssuerUpdated(bytes32 schemaId);
-  /// @notice Event emitted when the schemas issuers are updated in bulk with the portal owner
-  event BulkSchemasIssuersUpdated(bytes32[] schemaIds);
 
   /// @custom:oz-upgrades-unsafe-allow constructor
   constructor() {
@@ -100,24 +95,6 @@ contract PortalRegistry is OwnableUpgradeable {
     issuers[issuer] = false;
     // Emit event
     emit IssuerRemoved(issuer);
-  }
-
-  /**
-   * @notice Updates issuer address for the given schemaId
-   * @param schemaId the schema ID to update
-   */
-  function updateSchemaIssuerWithPortalOwner(bytes32 schemaId) public onlyOwner {
-    SchemaRegistry(router.getSchemaRegistry()).updateSchemaIssuer(schemaId, msg.sender);
-    emit SchemaIssuerUpdated(schemaId);
-  }
-
-  /**
-   * @notice Updates issuer addresses for all schemas associated with given IDs
-   * @param schemaIds the schema IDs to update
-   */
-  function bulkUpdateSchemasIssuersWithPortalOwner(bytes32[] calldata schemaIds) public onlyOwner {
-    SchemaRegistry(router.getSchemaRegistry()).bulkUpdateSchemasIssuers(schemaIds, msg.sender);
-    emit BulkSchemasIssuersUpdated(schemaIds);
   }
 
   /**

--- a/contracts/src/PortalRegistry.sol
+++ b/contracts/src/PortalRegistry.sol
@@ -55,6 +55,10 @@ contract PortalRegistry is OwnableUpgradeable {
   event PortalRevoked(address portalAddress);
   /// @notice Event emitted when the router is updated
   event RouterUpdated(address routerAddress);
+  /// @notice Event emitted when the schema issuer is updated with the portal owner
+  event SchemaIssuerUpdated(bytes32 schemaId);
+  /// @notice Event emitted when the schemas issuers are updated in bulk with the portal owner
+  event BulkSchemasIssuersUpdated(bytes32[] schemaIds);
 
   /// @custom:oz-upgrades-unsafe-allow constructor
   constructor() {
@@ -94,9 +98,26 @@ contract PortalRegistry is OwnableUpgradeable {
    */
   function removeIssuer(address issuer) public onlyOwner {
     issuers[issuer] = false;
-    SchemaRegistry(router.getSchemaRegistry()).updateMatchingSchemaIssuers(issuer, msg.sender);
     // Emit event
     emit IssuerRemoved(issuer);
+  }
+
+  /**
+   * @notice Updates issuer address for the given schemaId
+   * @param schemaId the schema ID to update
+   */
+  function updateSchemaIssuerWithPortalOwner(bytes32 schemaId) public onlyOwner {
+    SchemaRegistry(router.getSchemaRegistry()).updateSchemaIssuer(schemaId, msg.sender);
+    emit SchemaIssuerUpdated(schemaId);
+  }
+
+  /**
+   * @notice Updates issuer addresses for all schemas associated with given IDs
+   * @param schemaIds the schema IDs to update
+   */
+  function bulkUpdateSchemasIssuersWithPortalOwner(bytes32[] calldata schemaIds) public onlyOwner {
+    SchemaRegistry(router.getSchemaRegistry()).bulkUpdateSchemasIssuers(schemaIds, msg.sender);
+    emit BulkSchemasIssuersUpdated(schemaIds);
   }
 
   /**

--- a/contracts/src/SchemaRegistry.sol
+++ b/contracts/src/SchemaRegistry.sol
@@ -122,6 +122,19 @@ contract SchemaRegistry is OwnableUpgradeable {
   }
 
   /**
+   * @notice Updates issuers of all given schemaIds with the new issuer
+   * @param schemaIdsToUpdate the IDs of schemas to update
+   * @param issuer the address of new issuer
+   * @dev Updates issuer for the given schemaIds in the `schemaIssuers` mapping
+   *      The issuer must already be registered as an Issuer via the `PortalRegistry`
+   */
+  function bulkUpdateSchemasIssuers(bytes32[] calldata schemaIdsToUpdate, address issuer) public onlyOwner {
+    for (uint256 i = 0; i < schemaIdsToUpdate.length; i = uncheckedInc256(i)) {
+      updateSchemaIssuer(schemaIdsToUpdate[i], issuer);
+    }
+  }
+
+  /**
    * Generate an ID for a given schema
    * @param schema the string defining a schema
    * @return the schema ID

--- a/contracts/src/SchemaRegistry.sol
+++ b/contracts/src/SchemaRegistry.sol
@@ -106,22 +106,6 @@ contract SchemaRegistry is OwnableUpgradeable {
   }
 
   /**
-   * @notice Updates issuer address for all schemas associated with old issuer address
-   * @param oldIssuer the address of old issuer
-   * @param newIssuer the address of new issuer
-   * @dev Finds all the schemaIds associated with old issuer and updates the mapping `schemasIssuers`
-   *      for schemaIds found with new issuer
-   */
-  function updateMatchingSchemaIssuers(address oldIssuer, address newIssuer) public onlyPortalRegistry(msg.sender) {
-    for (uint256 i = 0; i < schemaIds.length; i = uncheckedInc256(i)) {
-      if (schemasIssuers[schemaIds[i]] == oldIssuer) {
-        schemasIssuers[schemaIds[i]] = newIssuer;
-        emit SchemaIssuerUpdated(schemaIds[i], newIssuer);
-      }
-    }
-  }
-
-  /**
    * @notice Updates issuers of all given schemaIds with the new issuer
    * @param schemaIdsToUpdate the IDs of schemas to update
    * @param issuer the address of new issuer

--- a/contracts/test/PortalRegistry.t.sol
+++ b/contracts/test/PortalRegistry.t.sol
@@ -23,7 +23,6 @@ contract PortalRegistryTest is Test {
   string public expectedName = "Name";
   string public expectedDescription = "Description";
   string public expectedOwnerName = "Owner Name";
-  bytes32[] public schemaIds;
   ValidPortalMock public validPortalMock;
   InvalidPortalMock public invalidPortalMock = new InvalidPortalMock();
   IPortalImplementation public iPortalImplementation = new IPortalImplementation();
@@ -34,8 +33,6 @@ contract PortalRegistryTest is Test {
   event IssuerRemoved(address issuerAddress);
   event PortalRevoked(address portalAddress);
   event RouterUpdated(address routerAddress);
-  event SchemaIssuerUpdated(bytes32 schemaId);
-  event BulkSchemasIssuersUpdated(bytes32[] schemaIds);
 
   function setUp() public {
     router = new Router();
@@ -107,26 +104,6 @@ contract PortalRegistryTest is Test {
     portalRegistry.removeIssuer(issuerAddress);
     bool isIssuerAfterRemoval = portalRegistry.isIssuer(issuerAddress);
     assertEq(isIssuerAfterRemoval, false);
-    vm.stopPrank();
-  }
-
-  function test_updateSchemaIssuerWithPortalOwner() public {
-    bytes32 schemaId = 0x36304af55bbea73214675d3770f679b4b6e0bfff512f5af01046e6f5d29261e3;
-    vm.startPrank(address(0));
-
-    vm.expectEmit();
-    emit SchemaIssuerUpdated(schemaId);
-    portalRegistry.updateSchemaIssuerWithPortalOwner(schemaId);
-    vm.stopPrank();
-  }
-
-  function test_bulkUpdateSchemasIssuersWithPortalOwner() public {
-    schemaIds.push(0x36304af55bbea73214675d3770f679b4b6e0bfff512f5af01046e6f5d29261e3);
-    vm.startPrank(address(0));
-
-    vm.expectEmit();
-    emit BulkSchemasIssuersUpdated(schemaIds);
-    portalRegistry.bulkUpdateSchemasIssuersWithPortalOwner(schemaIds);
     vm.stopPrank();
   }
 

--- a/contracts/test/PortalRegistry.t.sol
+++ b/contracts/test/PortalRegistry.t.sol
@@ -23,6 +23,7 @@ contract PortalRegistryTest is Test {
   string public expectedName = "Name";
   string public expectedDescription = "Description";
   string public expectedOwnerName = "Owner Name";
+  bytes32[] public schemaIds;
   ValidPortalMock public validPortalMock;
   InvalidPortalMock public invalidPortalMock = new InvalidPortalMock();
   IPortalImplementation public iPortalImplementation = new IPortalImplementation();
@@ -33,6 +34,8 @@ contract PortalRegistryTest is Test {
   event IssuerRemoved(address issuerAddress);
   event PortalRevoked(address portalAddress);
   event RouterUpdated(address routerAddress);
+  event SchemaIssuerUpdated(bytes32 schemaId);
+  event BulkSchemasIssuersUpdated(bytes32[] schemaIds);
 
   function setUp() public {
     router = new Router();
@@ -104,6 +107,26 @@ contract PortalRegistryTest is Test {
     portalRegistry.removeIssuer(issuerAddress);
     bool isIssuerAfterRemoval = portalRegistry.isIssuer(issuerAddress);
     assertEq(isIssuerAfterRemoval, false);
+    vm.stopPrank();
+  }
+
+  function test_updateSchemaIssuerWithPortalOwner() public {
+    bytes32 schemaId = 0x36304af55bbea73214675d3770f679b4b6e0bfff512f5af01046e6f5d29261e3;
+    vm.startPrank(address(0));
+
+    vm.expectEmit();
+    emit SchemaIssuerUpdated(schemaId);
+    portalRegistry.updateSchemaIssuerWithPortalOwner(schemaId);
+    vm.stopPrank();
+  }
+
+  function test_bulkUpdateSchemasIssuersWithPortalOwner() public {
+    schemaIds.push(0x36304af55bbea73214675d3770f679b4b6e0bfff512f5af01046e6f5d29261e3);
+    vm.startPrank(address(0));
+
+    vm.expectEmit();
+    emit BulkSchemasIssuersUpdated(schemaIds);
+    portalRegistry.bulkUpdateSchemasIssuersWithPortalOwner(schemaIds);
     vm.stopPrank();
   }
 

--- a/contracts/test/SchemaRegistry.t.sol
+++ b/contracts/test/SchemaRegistry.t.sol
@@ -111,23 +111,6 @@ contract SchemaRegistryTest is Test {
     schemaRegistry.bulkUpdateSchemasIssuers(expectedIds, address(0));
   }
 
-  function test_updateMatchingSchemaIssuers() public {
-    vm.prank(user);
-    schemaRegistry.createSchema(expectedName, expectedDescription, expectedContext, expectedString);
-    vm.expectEmit(true, true, true, true);
-    emit SchemaIssuerUpdated(expectedId, address(2));
-    vm.prank(portalRegistryAddress);
-    schemaRegistry.updateMatchingSchemaIssuers(user, address(2));
-  }
-
-  function test_updateMatchingSchemaIssuers_OnlyPortalRegistry() public {
-    vm.prank(user);
-    schemaRegistry.createSchema(expectedName, expectedDescription, expectedContext, expectedString);
-    vm.prank(address(0));
-    vm.expectRevert(SchemaRegistry.OnlyPortalRegistry.selector);
-    schemaRegistry.updateMatchingSchemaIssuers(user, address(2));
-  }
-
   function test_getIdFromSchemaString() public view {
     bytes32 id = schemaRegistry.getIdFromSchemaString(expectedString);
     assertEq(id, expectedId);

--- a/contracts/test/SchemaRegistry.t.sol
+++ b/contracts/test/SchemaRegistry.t.sol
@@ -18,6 +18,7 @@ contract SchemaRegistryTest is Test {
   string private expectedString = "this is a schema";
   address private user = makeAddr("user");
   address private unassignedUser = makeAddr("unassignedUser");
+  bytes32[] private expectedIds;
 
   event SchemaCreated(bytes32 indexed id, string name, string description, string context, string schemaString);
   event SchemaContextUpdated(bytes32 indexed id);
@@ -37,6 +38,7 @@ contract SchemaRegistryTest is Test {
     router.updatePortalRegistry(portalRegistryAddress);
     portalRegistryMock.setIssuer(user);
     portalRegistryMock.setIssuer(unassignedUser);
+    expectedIds.push(expectedId);
   }
 
   function test_initialize_ContractAlreadyInitialized() public {
@@ -84,6 +86,29 @@ contract SchemaRegistryTest is Test {
     vm.prank(address(0));
     vm.expectRevert(SchemaRegistry.IssuerInvalid.selector);
     schemaRegistry.updateSchemaIssuer(expectedId, address(0));
+  }
+
+  function test_bulkUpdateSchemasIssuers() public {
+    vm.prank(user);
+    schemaRegistry.createSchema(expectedName, expectedDescription, expectedContext, expectedString);
+    vm.expectEmit(true, true, true, true);
+    emit SchemaIssuerUpdated(expectedId, address(2));
+    vm.prank(address(0));
+    schemaRegistry.bulkUpdateSchemasIssuers(expectedIds, address(2));
+  }
+
+  function test_bulkUpdateSchemasIssuers_SchemaNotRegistered() public {
+    vm.expectRevert(SchemaRegistry.SchemaNotRegistered.selector);
+    vm.prank(address(0));
+    schemaRegistry.bulkUpdateSchemasIssuers(expectedIds, address(0));
+  }
+
+  function test_bulkUpdateSchemasIssuers_IssuerInvalid() public {
+    vm.prank(user);
+    schemaRegistry.createSchema(expectedName, expectedDescription, expectedContext, expectedString);
+    vm.prank(address(0));
+    vm.expectRevert(SchemaRegistry.IssuerInvalid.selector);
+    schemaRegistry.bulkUpdateSchemasIssuers(expectedIds, address(0));
   }
 
   function test_updateMatchingSchemaIssuers() public {

--- a/contracts/test/mocks/SchemaRegistryMock.sol
+++ b/contracts/test/mocks/SchemaRegistryMock.sol
@@ -26,10 +26,4 @@ contract SchemaRegistryMock {
   function isRegistered(bytes32 schemaId) public view returns (bool) {
     return schemas[schemaId];
   }
-
-  function updateMatchingSchemaIssuers(address oldIssuer, address newIssuer) public {}
-
-  function updateSchemaIssuer(bytes32 schemaId, address issuer) public {}
-
-  function bulkUpdateSchemasIssuers(bytes32[] calldata schemaIdsToUpdate, address issuer) public {}
 }

--- a/contracts/test/mocks/SchemaRegistryMock.sol
+++ b/contracts/test/mocks/SchemaRegistryMock.sol
@@ -28,4 +28,8 @@ contract SchemaRegistryMock {
   }
 
   function updateMatchingSchemaIssuers(address oldIssuer, address newIssuer) public {}
+
+  function updateSchemaIssuer(bytes32 schemaId, address issuer) public {}
+
+  function bulkUpdateSchemasIssuers(bytes32[] calldata schemaIdsToUpdate, address issuer) public {}
 }


### PR DESCRIPTION
## What does this PR do?

Removed the call to updateMatchingSchemaIssuers in remove issuers

Added two separate methods below 
   1. updateSchemaIssuerWithPortalOwner
   2. bulkUpdateSchemasIssuersWithPortalOwner

### Related ticket

Fixes #653 

### Type of change

- [x] Chore
- [ ] Bug fix
- [ ] New feature
- [x] Documentation update

## Check list

- [x] Unit tests for any smart contract change
- [x] Contracts and functions are documented
