### PR TITLE
chore(ci): Don't check contracts coverage when no change was done

### DIFF
--- a/.github/workflows/smart-contracts.yml
+++ b/.github/workflows/smart-contracts.yml
@@ -138,25 +138,38 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: recursive
+          fetch-depth: 0
+
+      - id: check-changes
+        run: |
+          if [ -n "$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} | grep '^contracts/')" ]; then
+            echo "::set-output name=changed::true"
+          else
+            echo "::set-output name=changed::false"
+          fi
 
       - name: Install Pnpm
+        if: steps.check-changes.outputs.changed == 'true'
         uses: pnpm/action-setup@v2
         with:
           version: 8
           run_install: false
 
       - name: Install Node.js
+        if: steps.check-changes.outputs.changed == 'true'
         uses: actions/setup-node@v3
         with:
           node-version: 18
           cache: pnpm
 
       - name: Get pnpm store directory
+        if: steps.check-changes.outputs.changed == 'true'
         shell: bash
         run: |
           echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
 
       - uses: actions/cache@v3
+        if: steps.check-changes.outputs.changed == 'true'
         name: Setup pnpm cache
         with:
           path: ${{ env.STORE_PATH }}
@@ -165,18 +178,23 @@ jobs:
             ${{ runner.os }}-pnpm-store-
 
       - name: Install dependencies
+        if: steps.check-changes.outputs.changed == 'true'
         run: pnpm install --frozen-lockfile
 
       - name: Install Foundry
+        if: steps.check-changes.outputs.changed == 'true'
         uses: foundry-rs/foundry-toolchain@v1
 
       - name: Generate the coverage report using the unit tests
+        if: steps.check-changes.outputs.changed == 'true'
         run: cd contracts && forge coverage --report lcov
 
       - name: Move the report at the root of the project
+        if: steps.check-changes.outputs.changed == 'true'
         run: mv contracts/lcov.info .
 
       - name: Upload coverage report to Codecov
+        if: steps.check-changes.outputs.changed == 'true'
         uses: codecov/codecov-action@v3
         with:
           files: ./lcov.info
@@ -185,15 +203,23 @@ jobs:
           verbose: true
 
       - name: Check test coverage
+        if: steps.check-changes.outputs.changed == 'true'
         uses: terencetcf/github-actions-lcov-minimum-coverage-checker@v1
         with:
           coverage-file: lcov.info
           minimum-coverage: 94
 
       - name: Add coverage summary
+        if: steps.check-changes.outputs.changed == 'true'
         run: |
           echo "## Coverage result" >> $GITHUB_STEP_SUMMARY
           echo "✅ Uploaded to Codecov" >> $GITHUB_STEP_SUMMARY
+
+      - name: Add coverage summary
+        if: steps.check-changes.outputs.changed == 'false'
+        run: |
+          echo "## Coverage result" >> $GITHUB_STEP_SUMMARY
+          echo "✅ No coverage report to upload" >> $GITHUB_STEP_SUMMARY
 
   upgradeability-contracts:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What does this PR do?

When no change was done on the contracts, stop checking their code coverage

### Related ticket

Fixes #675 

### Type of change

- [X] Chore
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update

## Check list

- [ ] Unit tests for any smart contract change
- [ ] Contracts and functions are documented
