### PR TITLE
feat(sdk): As a developer, I want to access the Attestation count on Portals and Schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,8 +266,8 @@ Here are the addresses on those networks:
 ## Subgraphs URLs
 
 - [Linea Sepolia](https://api.studio.thegraph.com/query/67521/verax-v1-linea-sepolia/v0.0.12)
-- [Linea Mainnet](https://graph-query.linea.build/subgraphs/name/Consensys/linea-attestation-registry/graphql)
-- [Linea Mainnet (Backup)](https://api.studio.thegraph.com/query/67521/verax-v1-linea/v0.0.1)
+- [Linea Mainnet](https://api.studio.thegraph.com/query/67521/verax-v1-linea/v0.0.1)
+- [Linea Mainnet (Backup)](https://graph-query.linea.build/subgraphs/name/Consensys/linea-attestation-registry/graphql)
 - [Arbitrum Sepolia](https://api.studio.thegraph.com/query/67521/verax-v1-arbitrum-sepolia/v0.0.2)
 - [Arbitrum Mainnet](https://api.studio.thegraph.com/query/67521/verax-v1-arbitrum/v0.0.1)
 - [Arbitrum Nova](https://api.goldsky.com/api/public/project_clwsa54350ydv01wjbq5r17v1/subgraphs/verax-v1-arbitrum-nova/0.0.4/gn)

--- a/explorer/package.json
+++ b/explorer/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@radix-ui/react-dropdown-menu": "^2.0.6",
     "@tanstack/react-table": "^8.10.7",
-    "@verax-attestation-registry/verax-sdk": "1.10.0",
+    "@verax-attestation-registry/verax-sdk": "1.11.0",
     "@wagmi/core": "^1.4.7",
     "abitype": "^0.10.3",
     "class-variance-authority": "^0.7.0",

--- a/explorer/src/constants/columns/attestation.tsx
+++ b/explorer/src/constants/columns/attestation.tsx
@@ -129,6 +129,7 @@ export const skeletonAttestations = (itemPerPage = ITEMS_PER_PAGE_DEFAULT): Arra
       version: 0,
       revoked: false,
       subject: EMPTY_STRING,
+      encodedSubject: EMPTY_STRING,
       attestationData: EMPTY_STRING,
     })),
   );

--- a/explorer/src/constants/columns/schema.tsx
+++ b/explorer/src/constants/columns/schema.tsx
@@ -65,6 +65,7 @@ export const skeletonSchemas = (itemPerPage = ITEMS_PER_PAGE_DEFAULT): Array<Sch
       description: EMPTY_STRING,
       context: EMPTY_STRING,
       schema: EMPTY_STRING,
+      attestationCounter: 0,
     })),
   );
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,8 +90,8 @@ importers:
         specifier: ^8.10.7
         version: 8.17.3(react-dom@18.3.1)(react@18.3.1)
       '@verax-attestation-registry/verax-sdk':
-        specifier: 1.10.0
-        version: 1.10.0(@envelop/core@5.0.1)(@graphql-mesh/types@0.95.8)(@graphql-tools/delegate@10.0.10)(@graphql-tools/merge@9.0.4)(@graphql-tools/utils@10.2.0)(@graphql-tools/wrap@10.0.5)(@types/node@20.12.12)(@types/react@18.3.2)(graphql-tag@2.12.6)(graphql-yoga@5.3.1)(react-dom@18.3.1)(react@18.3.1)(tslib@2.6.2)(typescript@5.2.2)
+        specifier: 1.11.0
+        version: 1.11.0(@graphql-mesh/types@0.95.8)(@graphql-tools/utils@10.2.0)(@types/node@20.12.12)(@types/react@18.3.2)(react-dom@18.3.1)(react@18.3.1)(tslib@2.6.2)(typescript@5.2.2)
       '@wagmi/core':
         specifier: ^1.4.7
         version: 1.4.13(@types/react@18.3.2)(react@18.3.1)(typescript@5.2.2)(viem@1.18.9)
@@ -280,9 +280,6 @@ importers:
 
   sdk:
     dependencies:
-      '@graphprotocol/client-cli':
-        specifier: ^3.0.0
-        version: 3.0.3(@envelop/core@5.0.1)(@graphql-mesh/cross-helpers@0.4.2)(@graphql-mesh/store@0.95.8)(@graphql-mesh/types@0.98.4)(@graphql-mesh/utils@0.95.8)(@graphql-tools/delegate@10.0.10)(@graphql-tools/merge@9.0.4)(@graphql-tools/utils@10.2.0)(@graphql-tools/wrap@10.0.5)(@types/node@20.12.12)(graphql-tag@2.12.6)(graphql-yoga@5.3.1)(graphql@16.8.1)
       '@graphql-mesh/cache-localforage':
         specifier: ^0.95.8
         version: 0.95.8(@graphql-mesh/types@0.98.4)(@graphql-mesh/utils@0.95.8)(graphql@16.8.1)(tslib@2.6.2)
@@ -332,6 +329,9 @@ importers:
       '@babel/preset-typescript':
         specifier: ^7.23.3
         version: 7.24.1(@babel/core@7.24.5)
+      '@graphprotocol/client-cli':
+        specifier: ^3.0.0
+        version: 3.0.3(@envelop/core@5.0.1)(@graphql-mesh/cross-helpers@0.4.2)(@graphql-mesh/store@0.95.8)(@graphql-mesh/types@0.98.4)(@graphql-mesh/utils@0.95.8)(@graphql-tools/delegate@10.0.10)(@graphql-tools/merge@9.0.4)(@graphql-tools/utils@10.2.0)(@graphql-tools/wrap@10.0.5)(@types/node@20.12.12)(graphql-tag@2.12.6)(graphql-yoga@5.3.1)(graphql@16.8.1)
       '@types/jest':
         specifier: ^29.5.8
         version: 29.5.12
@@ -642,7 +642,6 @@ packages:
       zen-observable-ts: 1.2.5
     transitivePeerDependencies:
       - '@types/react'
-    dev: false
     optional: true
 
   /@ardatan/relay-compiler@12.0.0(graphql@16.8.1):
@@ -672,6 +671,7 @@ packages:
     transitivePeerDependencies:
       - encoding
       - supports-color
+    dev: true
 
   /@ardatan/sync-fetch@0.0.1:
     resolution: {integrity: sha512-xhlTqH0m31mnsG0tIP4ETgfSB6gXDaYYsUWTrlUV93fFQPI9dd8hE0Ot6MHLCtqgB32hwJAC3YZMWlXZw7AleA==}
@@ -680,7 +680,6 @@ packages:
       node-fetch: 2.7.0
     transitivePeerDependencies:
       - encoding
-    dev: false
 
   /@aws-crypto/sha256-js@1.2.2:
     resolution: {integrity: sha512-Nr1QJIbW/afYYGzYvrF70LtaHrIRtd4TNAglX8BvlfxJLZ45SAmueIKYl5tWoNBPzp65ymXGFK0Bb1vZUpuc9g==}
@@ -813,6 +812,7 @@ packages:
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
       '@babel/helper-split-export-declaration': 7.24.5
       semver: 6.3.1
+    dev: true
 
   /@babel/helper-create-regexp-features-plugin@7.22.15(@babel/core@7.24.5):
     resolution: {integrity: sha512-29FkPLFjn4TPEa3RE7GpW+qbE8tlsu3jntNYNfcGsc49LphF1PQIiD+vMZ1z1xVOKt+93khA9tc2JBs3kBjA7w==}
@@ -863,6 +863,7 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.24.5
+    dev: true
 
   /@babel/helper-module-imports@7.24.3:
     resolution: {integrity: sha512-viKb0F9f2s0BCS22QSF308z/+1YWKV/76mwt61NBzS5izMzDPwdq1pTrzf+Li3npBWX9KdQbkeCt1jSAM7lZqg==}
@@ -888,6 +889,7 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.24.5
+    dev: true
 
   /@babel/helper-plugin-utils@7.24.5:
     resolution: {integrity: sha512-xjNLDopRzW2o6ba0gKbkZq5YWEBaK3PCyTOY1K2P/O07LGMhMqlMXPxwN4S5/RhWuCobT8z0jrlKGlYmeR1OhQ==}
@@ -915,6 +917,7 @@ packages:
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-member-expression-to-functions': 7.24.5
       '@babel/helper-optimise-call-expression': 7.22.5
+    dev: true
 
   /@babel/helper-simple-access@7.24.5:
     resolution: {integrity: sha512-uH3Hmf5q5n7n8mz7arjUlDOCbttY/DW4DYhE6FUsjKJ/oYC1kQQUvwEQWxRwUpX9qQKRXeqLwWxrqilMrf32sQ==}
@@ -927,6 +930,7 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.24.5
+    dev: true
 
   /@babel/helper-split-export-declaration@7.24.5:
     resolution: {integrity: sha512-5CHncttXohrHk8GWOFCcCl4oRD9fKosWlIRgWm4ql9VYioKm52Mk2xsmoohvm7f3JoiLSM5ZgJuRaf5QZZYd3Q==}
@@ -1035,6 +1039,7 @@ packages:
       '@babel/core': 7.24.5
       '@babel/helper-create-class-features-plugin': 7.24.5(@babel/core@7.24.5)
       '@babel/helper-plugin-utils': 7.24.5
+    dev: true
 
   /@babel/plugin-proposal-nullish-coalescing-operator@7.18.6(@babel/core@7.24.5):
     resolution: {integrity: sha512-wQxQzxYeJqHcfppzBDnm1yAY0jSRkUXR2z8RePZYrKwMKgMlE8+Z6LUno+bd6LvbGh8Gltvy74+9pIYkr+XkKA==}
@@ -1073,6 +1078,7 @@ packages:
       '@babel/helper-plugin-utils': 7.24.5
       '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.24.5)
       '@babel/plugin-transform-parameters': 7.24.5(@babel/core@7.24.5)
+    dev: true
 
   /@babel/plugin-proposal-optional-chaining@7.21.0(@babel/core@7.24.5):
     resolution: {integrity: sha512-p4zeefM72gpmEe2fkUr/OnOXpWEf8nAgk7ZYVqqfFiyIG7oFfVZcCrU64hWn5xp4tQ9LkV4bTIa5rD0KANpKNA==}
@@ -1121,6 +1127,7 @@ packages:
     dependencies:
       '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.24.5
+    dev: true
 
   /@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.24.5):
     resolution: {integrity: sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==}
@@ -1158,6 +1165,7 @@ packages:
     dependencies:
       '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.24.5
+    dev: true
 
   /@babel/plugin-syntax-import-assertions@7.24.1(@babel/core@7.24.5):
     resolution: {integrity: sha512-IuwnI5XnuF189t91XbxmXeCDz3qs6iDRO7GJ++wcfgeXNs/8FmIlKcpDSXNVyuLQxlwvskmI3Ct73wUODkJBlQ==}
@@ -1167,6 +1175,7 @@ packages:
     dependencies:
       '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.24.5
+    dev: true
 
   /@babel/plugin-syntax-import-attributes@7.24.1(@babel/core@7.24.5):
     resolution: {integrity: sha512-zhQTMH0X2nVLnb04tz+s7AMuasX8U0FnpE+nHTOhSOINjWMnopoZTxtIKsd45n4GQ/HIZLyfIpoul8e2m0DnRA==}
@@ -1239,6 +1248,7 @@ packages:
     dependencies:
       '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.24.5
+    dev: true
 
   /@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.24.5):
     resolution: {integrity: sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==}
@@ -1307,6 +1317,7 @@ packages:
     dependencies:
       '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.24.5
+    dev: true
 
   /@babel/plugin-transform-async-generator-functions@7.24.3(@babel/core@7.24.5):
     resolution: {integrity: sha512-Qe26CMYVjpQxJ8zxM1340JFNjZaF+ISWpr1Kt/jGo+ZTUzKkfw/pphEWbRCb+lmSM6k/TOgfYLvmbHkUQ0asIg==}
@@ -1341,6 +1352,7 @@ packages:
     dependencies:
       '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.24.5
+    dev: true
 
   /@babel/plugin-transform-block-scoping@7.24.5(@babel/core@7.24.5):
     resolution: {integrity: sha512-sMfBc3OxghjC95BkYrYocHL3NaOplrcaunblzwXhGmlPwpmfsxr4vK+mBBt49r+S240vahmv+kUxkeKgs+haCw==}
@@ -1350,6 +1362,7 @@ packages:
     dependencies:
       '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.24.5
+    dev: true
 
   /@babel/plugin-transform-class-properties@7.24.1(@babel/core@7.24.5):
     resolution: {integrity: sha512-OMLCXi0NqvJfORTaPQBwqLXHhb93wkBKZ4aNwMl6WtehO7ar+cmp+89iPEQPqxAnxsOKTaMcs3POz3rKayJ72g==}
@@ -1389,6 +1402,7 @@ packages:
       '@babel/helper-replace-supers': 7.24.1(@babel/core@7.24.5)
       '@babel/helper-split-export-declaration': 7.24.5
       globals: 11.12.0
+    dev: true
 
   /@babel/plugin-transform-computed-properties@7.24.1(@babel/core@7.24.5):
     resolution: {integrity: sha512-5pJGVIUfJpOS+pAqBQd+QMaTD2vCL/HcePooON6pDpHgRp4gNRmzyHTPIkXntwKsq3ayUFVfJaIKPw2pOkOcTw==}
@@ -1399,6 +1413,7 @@ packages:
       '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.24.5
       '@babel/template': 7.24.0
+    dev: true
 
   /@babel/plugin-transform-destructuring@7.24.5(@babel/core@7.24.5):
     resolution: {integrity: sha512-SZuuLyfxvsm+Ah57I/i1HVjveBENYK9ue8MJ7qkc7ndoNjqquJiElzA7f5yaAXjyW2hKojosOTAQQRX50bPSVg==}
@@ -1408,6 +1423,7 @@ packages:
     dependencies:
       '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.24.5
+    dev: true
 
   /@babel/plugin-transform-dotall-regex@7.24.1(@babel/core@7.24.5):
     resolution: {integrity: sha512-p7uUxgSoZwZ2lPNMzUkqCts3xlp8n+o05ikjy7gbtFJSt9gdU88jAmtfmOxHM14noQXBxfgzf2yRWECiNVhTCw==}
@@ -1472,6 +1488,7 @@ packages:
       '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.24.5
       '@babel/plugin-syntax-flow': 7.24.1(@babel/core@7.24.5)
+    dev: true
 
   /@babel/plugin-transform-for-of@7.24.1(@babel/core@7.24.5):
     resolution: {integrity: sha512-OxBdcnF04bpdQdR3i4giHZNZQn7cm8RQKcSwA17wAAqEELo1ZOwp5FFgeptWUQXFyT9kwHo10aqqauYkRZPCAg==}
@@ -1482,6 +1499,7 @@ packages:
       '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.24.5
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
+    dev: true
 
   /@babel/plugin-transform-function-name@7.24.1(@babel/core@7.24.5):
     resolution: {integrity: sha512-BXmDZpPlh7jwicKArQASrj8n22/w6iymRnvHYYd2zO30DbE277JO20/7yXJT3QxDPtiQiOxQBbZH4TpivNXIxA==}
@@ -1493,6 +1511,7 @@ packages:
       '@babel/helper-compilation-targets': 7.23.6
       '@babel/helper-function-name': 7.23.0
       '@babel/helper-plugin-utils': 7.24.5
+    dev: true
 
   /@babel/plugin-transform-json-strings@7.24.1(@babel/core@7.24.5):
     resolution: {integrity: sha512-U7RMFmRvoasscrIFy5xA4gIp8iWnWubnKkKuUGJjsuOH7GfbMkB+XZzeslx2kLdEGdOJDamEmCqOks6e8nv8DQ==}
@@ -1513,6 +1532,7 @@ packages:
     dependencies:
       '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.24.5
+    dev: true
 
   /@babel/plugin-transform-logical-assignment-operators@7.24.1(@babel/core@7.24.5):
     resolution: {integrity: sha512-OhN6J4Bpz+hIBqItTeWJujDOfNP+unqv/NJgyhlpSqgBTPm37KkMmZV6SYcOj+pnDbdcl1qRGV/ZiIjX9Iy34w==}
@@ -1533,6 +1553,7 @@ packages:
     dependencies:
       '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.24.5
+    dev: true
 
   /@babel/plugin-transform-modules-amd@7.24.1(@babel/core@7.24.5):
     resolution: {integrity: sha512-lAxNHi4HVtjnHd5Rxg3D5t99Xm6H7b04hUS7EHIXcUl2EV4yl1gWdqZrNzXnSrHveL9qMdbODlLF55mvgjAfaQ==}
@@ -1555,6 +1576,7 @@ packages:
       '@babel/helper-module-transforms': 7.24.5(@babel/core@7.24.5)
       '@babel/helper-plugin-utils': 7.24.5
       '@babel/helper-simple-access': 7.24.5
+    dev: true
 
   /@babel/plugin-transform-modules-systemjs@7.24.1(@babel/core@7.24.5):
     resolution: {integrity: sha512-mqQ3Zh9vFO1Tpmlt8QPnbwGHzNz3lpNEMxQb1kAemn/erstyqw1r9KeOlOfo3y6xAnFEcOv2tSyrXfmMk+/YZA==}
@@ -1645,6 +1667,7 @@ packages:
       '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.24.5
       '@babel/helper-replace-supers': 7.24.1(@babel/core@7.24.5)
+    dev: true
 
   /@babel/plugin-transform-optional-catch-binding@7.24.1(@babel/core@7.24.5):
     resolution: {integrity: sha512-oBTH7oURV4Y+3EUrf6cWn1OHio3qG/PVwO5J03iSJmBg6m2EhKjkAu/xuaXaYwWW9miYtvbWv4LNf0AmR43LUA==}
@@ -1677,6 +1700,7 @@ packages:
     dependencies:
       '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.24.5
+    dev: true
 
   /@babel/plugin-transform-private-methods@7.24.1(@babel/core@7.24.5):
     resolution: {integrity: sha512-tGvisebwBO5em4PaYNqt4fkw56K2VALsAbAakY0FjTYqJp7gfdrgr7YX76Or8/cpik0W6+tj3rZ0uHU9Oil4tw==}
@@ -1710,6 +1734,7 @@ packages:
     dependencies:
       '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.24.5
+    dev: true
 
   /@babel/plugin-transform-react-constant-elements@7.24.1(@babel/core@7.24.5):
     resolution: {integrity: sha512-QXp1U9x0R7tkiGB0FOk8o74jhnap0FlZ5gNkRIWdG3eP+SvMFg118e1zaWewDzgABb106QSKpVsD3Wgd8t6ifA==}
@@ -1729,6 +1754,7 @@ packages:
     dependencies:
       '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.24.5
+    dev: true
 
   /@babel/plugin-transform-react-jsx-development@7.22.5(@babel/core@7.24.5):
     resolution: {integrity: sha512-bDhuzwWMuInwCYeDeMzyi7TaBgRQei6DqxhbyniL7/VG4RSS7HtSL2QbY4eESy1KJqlWt8g3xeEBGPuo+XqC8A==}
@@ -1772,6 +1798,7 @@ packages:
       '@babel/helper-plugin-utils': 7.24.5
       '@babel/plugin-syntax-jsx': 7.24.1(@babel/core@7.24.5)
       '@babel/types': 7.24.5
+    dev: true
 
   /@babel/plugin-transform-react-pure-annotations@7.24.1(@babel/core@7.24.5):
     resolution: {integrity: sha512-+pWEAaDJvSm9aFvJNpLiM2+ktl2Sn2U5DdyiWdZBxmLc6+xGt88dvFqsHiAiDS+8WqUwbDfkKz9jRxK3M0k+kA==}
@@ -1830,6 +1857,7 @@ packages:
     dependencies:
       '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.24.5
+    dev: true
 
   /@babel/plugin-transform-spread@7.24.1(@babel/core@7.24.5):
     resolution: {integrity: sha512-KjmcIM+fxgY+KxPVbjelJC6hrH1CgtPmTvdXAfn3/a9CnWGSTY7nH4zm5+cjmWJybdcPSsD0++QssDsjcpe47g==}
@@ -1840,6 +1868,7 @@ packages:
       '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.24.5
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
+    dev: true
 
   /@babel/plugin-transform-sticky-regex@7.24.1(@babel/core@7.24.5):
     resolution: {integrity: sha512-9v0f1bRXgPVcPrngOQvLXeGNNVLc8UjMVfebo9ka0WF3/7+aVUHmaJVT3sa0XCzEFioPfPHZiOcYG9qOsH63cw==}
@@ -1859,6 +1888,7 @@ packages:
     dependencies:
       '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.24.5
+    dev: true
 
   /@babel/plugin-transform-typeof-symbol@7.24.5(@babel/core@7.24.5):
     resolution: {integrity: sha512-UTGnhYVZtTAjdwOTzT+sCyXmTn8AhaxOS/MjG9REclZ6ULHWF9KoCZur0HSGU7hk8PdBFKKbYe6+gqdXWz84Jg==}
@@ -2131,6 +2161,7 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
+    dev: true
 
   /@emotion/is-prop-valid@0.8.8:
     resolution: {integrity: sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==}
@@ -2166,7 +2197,6 @@ packages:
     dependencies:
       '@envelop/types': 5.0.0
       tslib: 2.6.2
-    dev: false
 
   /@envelop/extended-validation@4.0.0(@envelop/core@5.0.1)(graphql@16.8.1):
     resolution: {integrity: sha512-pvJ/OL+C+lpNiiCXezHT+vP3PTq37MQicoOB1l5MdgOOZZWRAp0NDOgvEKcXUY7AWNpvNHgSE0QFSRfGwsfwFQ==}
@@ -2179,7 +2209,6 @@ packages:
       '@graphql-tools/utils': 10.2.0(graphql@16.8.1)
       graphql: 16.8.1
       tslib: 2.6.2
-    dev: false
 
   /@envelop/graphql-jit@8.0.3(@envelop/core@5.0.1)(graphql@16.8.1):
     resolution: {integrity: sha512-IZnKc7dVOQV9jEi5s5RkG8fVKqc6Ss/mBN9PRt2iYFa9o6XkL/haPLJRfWFsS/CSJfFOQuzLyxYuALA8DaoOYw==}
@@ -2193,14 +2222,12 @@ packages:
       graphql-jit: 0.8.6(graphql@16.8.1)
       tslib: 2.6.2
       value-or-promise: 1.0.12
-    dev: false
 
   /@envelop/types@5.0.0:
     resolution: {integrity: sha512-IPjmgSc4KpQRlO4qbEDnBEixvtb06WDmjKfi/7fkZaryh5HuOmTtixe1EupQI5XfXO8joc3d27uUZ0QdC++euA==}
     engines: {node: '>=18.0.0'}
     dependencies:
       tslib: 2.6.2
-    dev: false
 
   /@es-joy/jsdoccomment@0.37.1:
     resolution: {integrity: sha512-5vxWJ1gEkEF0yRd0O+uK6dHJf7adrxwQSX8PuRiPfFSAbNLnY0ZJfXaZucoz14Jj2N11xn2DnlEPwWRpYpvRjg==}
@@ -2827,7 +2854,6 @@ packages:
     resolution: {integrity: sha512-fERDVz7topgNjtXsJTTW1JKLy0rhuLRcquYqNR9rF7OcVpCa2OVW49ZPDIhaRRCaUuvVxI+N416xUoF76HNSXA==}
     dependencies:
       fast-deep-equal: 3.1.3
-    dev: false
 
   /@float-capital/float-subgraph-uncrashable@0.0.0-internal-testing.5:
     resolution: {integrity: sha512-yZ0H5e3EpAYKokX/AbtplzlvSxEJY7ZfpvQyDzyODkks0hakAAlDG6fQu1SlDJMWorY7bbq1j7fCiFeTWci6TA==}
@@ -2899,25 +2925,6 @@ packages:
       strip-ansi: 6.0.1
     dev: true
 
-  /@graphprotocol/client-add-source-name@2.0.3(@graphql-mesh/types@0.95.8)(@graphql-tools/delegate@10.0.10)(@graphql-tools/utils@10.2.0)(@graphql-tools/wrap@10.0.5)(graphql@16.8.1):
-    resolution: {integrity: sha512-30VxjW8yEytySAJ7S+6pC3SII8BGyzQbLTIDr7FPEdj5FHvVKq3WQxDNHwWPEoEYYEEWDlapw3+e7leDwW9MCQ==}
-    engines: {node: '>=16.0.0'}
-    peerDependencies:
-      '@graphql-mesh/types': ^0.78.0 || ^0.79.0 || ^0.80.0 || ^0.81.0 || ^0.82.0 || ^0.83.0 || ^0.84.0 || ^0.85.0 || ^0.89.0 || ^0.90.0 || ^0.91.0 || ^0.93.0 || ^0.94.0 || ^0.97.0 || ^0.98.0
-      '@graphql-tools/delegate': ^9.0.32 || ^10.0.0
-      '@graphql-tools/utils': ^9.2.1 || ^10.0.0
-      '@graphql-tools/wrap': ^9.4.2 || ^10.0.0
-      graphql: ^15.2.0 || ^16.0.0
-    dependencies:
-      '@graphql-mesh/types': 0.95.8(@graphql-mesh/store@0.95.8)(@graphql-tools/utils@10.2.0)(graphql@16.8.1)(tslib@2.6.2)
-      '@graphql-tools/delegate': 10.0.10(graphql@16.8.1)
-      '@graphql-tools/utils': 10.2.0(graphql@16.8.1)
-      '@graphql-tools/wrap': 10.0.5(graphql@16.8.1)
-      graphql: 16.8.1
-      lodash: 4.17.21
-      tslib: 2.6.2
-    dev: false
-
   /@graphprotocol/client-add-source-name@2.0.3(@graphql-mesh/types@0.98.4)(@graphql-tools/delegate@10.0.10)(@graphql-tools/utils@10.2.0)(@graphql-tools/wrap@10.0.5)(graphql@16.8.1):
     resolution: {integrity: sha512-30VxjW8yEytySAJ7S+6pC3SII8BGyzQbLTIDr7FPEdj5FHvVKq3WQxDNHwWPEoEYYEEWDlapw3+e7leDwW9MCQ==}
     engines: {node: '>=16.0.0'}
@@ -2935,26 +2942,7 @@ packages:
       graphql: 16.8.1
       lodash: 4.17.21
       tslib: 2.6.2
-    dev: false
-
-  /@graphprotocol/client-auto-pagination@2.0.3(@graphql-mesh/types@0.95.8)(@graphql-tools/delegate@10.0.10)(@graphql-tools/utils@10.2.0)(@graphql-tools/wrap@10.0.5)(graphql@16.8.1):
-    resolution: {integrity: sha512-ZYMO4/tQ5ndSYeaZ+uucJYFNVc1DYSC6jK5AfJYElEfRMRZrj7jXL6RViBNmsSYuOXR2EIyEqPBOAdy2oDLWdw==}
-    engines: {node: '>=16.0.0'}
-    peerDependencies:
-      '@graphql-mesh/types': ^0.78.0 || ^0.79.0 || ^0.80.0 || ^0.81.0 || ^0.82.0 || ^0.83.0 || ^0.84.0 || ^0.85.0 || ^0.89.0 || ^0.90.0 || ^0.91.0 || ^0.93.0 || ^0.94.0 || ^0.97.0 || ^0.98.0
-      '@graphql-tools/delegate': ^9.0.32 || ^10.0.0
-      '@graphql-tools/utils': ^9.2.1 || ^10.0.0
-      '@graphql-tools/wrap': ^9.4.2 || ^10.0.0
-      graphql: ^15.2.0 || ^16.0.0
-    dependencies:
-      '@graphql-mesh/types': 0.95.8(@graphql-mesh/store@0.95.8)(@graphql-tools/utils@10.2.0)(graphql@16.8.1)(tslib@2.6.2)
-      '@graphql-tools/delegate': 10.0.10(graphql@16.8.1)
-      '@graphql-tools/utils': 10.2.0(graphql@16.8.1)
-      '@graphql-tools/wrap': 10.0.5(graphql@16.8.1)
-      graphql: 16.8.1
-      lodash: 4.17.21
-      tslib: 2.6.2
-    dev: false
+    dev: true
 
   /@graphprotocol/client-auto-pagination@2.0.3(@graphql-mesh/types@0.98.4)(@graphql-tools/delegate@10.0.10)(@graphql-tools/utils@10.2.0)(@graphql-tools/wrap@10.0.5)(graphql@16.8.1):
     resolution: {integrity: sha512-ZYMO4/tQ5ndSYeaZ+uucJYFNVc1DYSC6jK5AfJYElEfRMRZrj7jXL6RViBNmsSYuOXR2EIyEqPBOAdy2oDLWdw==}
@@ -2973,24 +2961,7 @@ packages:
       graphql: 16.8.1
       lodash: 4.17.21
       tslib: 2.6.2
-    dev: false
-
-  /@graphprotocol/client-auto-type-merging@2.0.3(@graphql-mesh/types@0.95.8)(@graphql-mesh/utils@0.95.8)(@graphql-tools/delegate@10.0.10)(graphql@16.8.1):
-    resolution: {integrity: sha512-vJVzvxk3FRwHc4w9+GP4QBrQ3oxNbveH1k3bEGokSo5DbGMQ2HIYFrGRZ+hICUQBIcqgK+beWa35BZtEMnBWaw==}
-    engines: {node: '>=16.0.0'}
-    peerDependencies:
-      '@graphql-mesh/types': ^0.78.0 || ^0.79.0 || ^0.80.0 || ^0.81.0 || ^0.82.0 || ^0.83.0 || ^0.84.0 || ^0.85.0 || ^0.89.0 || ^0.90.0 || ^0.91.0 || ^0.93.0 || ^0.94.0 || ^0.97.0 || ^0.98.0
-      '@graphql-tools/delegate': ^9.0.32 || ^10.0.0
-      graphql: ^15.2.0 || ^16.0.0
-    dependencies:
-      '@graphql-mesh/transform-type-merging': 0.98.4(@graphql-mesh/types@0.95.8)(@graphql-mesh/utils@0.95.8)(graphql@16.8.1)(tslib@2.6.2)
-      '@graphql-mesh/types': 0.95.8(@graphql-mesh/store@0.95.8)(@graphql-tools/utils@10.2.0)(graphql@16.8.1)(tslib@2.6.2)
-      '@graphql-tools/delegate': 10.0.10(graphql@16.8.1)
-      graphql: 16.8.1
-      tslib: 2.6.2
-    transitivePeerDependencies:
-      - '@graphql-mesh/utils'
-    dev: false
+    dev: true
 
   /@graphprotocol/client-auto-type-merging@2.0.3(@graphql-mesh/types@0.98.4)(@graphql-mesh/utils@0.95.8)(@graphql-tools/delegate@10.0.10)(graphql@16.8.1):
     resolution: {integrity: sha512-vJVzvxk3FRwHc4w9+GP4QBrQ3oxNbveH1k3bEGokSo5DbGMQ2HIYFrGRZ+hICUQBIcqgK+beWa35BZtEMnBWaw==}
@@ -3007,7 +2978,7 @@ packages:
       tslib: 2.6.2
     transitivePeerDependencies:
       - '@graphql-mesh/utils'
-    dev: false
+    dev: true
 
   /@graphprotocol/client-block-tracking@2.0.2(@graphql-mesh/cross-helpers@0.4.2)(@graphql-mesh/store@0.95.8)(@graphql-tools/delegate@10.0.10)(graphql@16.8.1):
     resolution: {integrity: sha512-gVOUq77kxniXk3kQ+Bl2GHB5HvYYDChV/e2YMxHieVgCVEmQ/CzRRDdSfBf898ZAyqeY3QNsdbR/EpcEyM4bFw==}
@@ -3024,49 +2995,7 @@ packages:
     transitivePeerDependencies:
       - '@graphql-mesh/cross-helpers'
       - '@graphql-mesh/store'
-    dev: false
-
-  /@graphprotocol/client-cli@3.0.3(@envelop/core@5.0.1)(@graphql-mesh/cross-helpers@0.4.2)(@graphql-mesh/store@0.95.8)(@graphql-mesh/types@0.95.8)(@graphql-mesh/utils@0.95.8)(@graphql-tools/delegate@10.0.10)(@graphql-tools/merge@9.0.4)(@graphql-tools/utils@10.2.0)(@graphql-tools/wrap@10.0.5)(@types/node@20.12.12)(@types/react@18.3.2)(graphql-tag@2.12.6)(graphql-yoga@5.3.1)(graphql@16.8.1)(react-dom@18.3.1)(react@18.3.1):
-    resolution: {integrity: sha512-cFukNLDqkPLEtZYfz8xDOLbX8/Wslv30QOL8RHsqodnlpMCJYB52VSj8qzNE+KM8/AWCDMZk+7+tgmThraVbPA==}
-    engines: {node: '>=16.0.0'}
-    hasBin: true
-    peerDependencies:
-      graphql: ^15.2.0 || ^16.0.0
-    dependencies:
-      '@graphprotocol/client-add-source-name': 2.0.3(@graphql-mesh/types@0.95.8)(@graphql-tools/delegate@10.0.10)(@graphql-tools/utils@10.2.0)(@graphql-tools/wrap@10.0.5)(graphql@16.8.1)
-      '@graphprotocol/client-auto-pagination': 2.0.3(@graphql-mesh/types@0.95.8)(@graphql-tools/delegate@10.0.10)(@graphql-tools/utils@10.2.0)(@graphql-tools/wrap@10.0.5)(graphql@16.8.1)
-      '@graphprotocol/client-auto-type-merging': 2.0.3(@graphql-mesh/types@0.95.8)(@graphql-mesh/utils@0.95.8)(@graphql-tools/delegate@10.0.10)(graphql@16.8.1)
-      '@graphprotocol/client-block-tracking': 2.0.2(@graphql-mesh/cross-helpers@0.4.2)(@graphql-mesh/store@0.95.8)(@graphql-tools/delegate@10.0.10)(graphql@16.8.1)
-      '@graphprotocol/client-polling-live': 2.0.1(@envelop/core@5.0.1)(@graphql-tools/merge@9.0.4)(graphql@16.8.1)
-      '@graphql-mesh/cli': 0.90.5(@types/node@20.12.12)(graphql-tag@2.12.6)(graphql-yoga@5.3.1)(graphql@16.8.1)
-      '@graphql-mesh/graphql': 0.98.4(@graphql-mesh/cross-helpers@0.4.2)(@graphql-mesh/store@0.95.8)(@graphql-mesh/types@0.95.8)(@graphql-mesh/utils@0.95.8)(@graphql-tools/utils@10.2.0)(@types/node@20.12.12)(@types/react@18.3.2)(graphql@16.8.1)(react-dom@18.3.1)(react@18.3.1)(tslib@2.6.2)
-      graphql: 16.8.1
-      tslib: 2.6.2
-    transitivePeerDependencies:
-      - '@envelop/core'
-      - '@graphql-mesh/cross-helpers'
-      - '@graphql-mesh/store'
-      - '@graphql-mesh/types'
-      - '@graphql-mesh/utils'
-      - '@graphql-tools/delegate'
-      - '@graphql-tools/merge'
-      - '@graphql-tools/utils'
-      - '@graphql-tools/wrap'
-      - '@swc/core'
-      - '@swc/wasm'
-      - '@types/node'
-      - '@types/react'
-      - bufferutil
-      - encoding
-      - graphql-tag
-      - graphql-ws
-      - graphql-yoga
-      - react
-      - react-dom
-      - subscriptions-transport-ws
-      - supports-color
-      - utf-8-validate
-    dev: false
+    dev: true
 
   /@graphprotocol/client-cli@3.0.3(@envelop/core@5.0.1)(@graphql-mesh/cross-helpers@0.4.2)(@graphql-mesh/store@0.95.8)(@graphql-mesh/types@0.98.4)(@graphql-mesh/utils@0.95.8)(@graphql-tools/delegate@10.0.10)(@graphql-tools/merge@9.0.4)(@graphql-tools/utils@10.2.0)(@graphql-tools/wrap@10.0.5)(@types/node@20.12.12)(graphql-tag@2.12.6)(graphql-yoga@5.3.1)(graphql@16.8.1):
     resolution: {integrity: sha512-cFukNLDqkPLEtZYfz8xDOLbX8/Wslv30QOL8RHsqodnlpMCJYB52VSj8qzNE+KM8/AWCDMZk+7+tgmThraVbPA==}
@@ -3108,7 +3037,7 @@ packages:
       - subscriptions-transport-ws
       - supports-color
       - utf-8-validate
-    dev: false
+    dev: true
 
   /@graphprotocol/client-polling-live@2.0.1(@envelop/core@5.0.1)(@graphql-tools/merge@9.0.4)(graphql@16.8.1):
     resolution: {integrity: sha512-jE+9cOM5gAC18uMA7nC7w5X/ru4U4ZrZxWqh3N+gxoLIPpnNYerwzRfFJskPyzl0QQjMiUMua9agqKCyxNBlOA==}
@@ -3123,7 +3052,7 @@ packages:
       '@repeaterjs/repeater': 3.0.6
       graphql: 16.8.1
       tslib: 2.6.2
-    dev: false
+    dev: true
 
   /@graphprotocol/graph-cli@0.73.0(@types/node@20.12.12)(node-fetch@2.7.0)(typescript@4.9.5):
     resolution: {integrity: sha512-g+EapDRvxhRjMccnUJE8gBRGDIF6mXqtv8g0tzzixVClw/BezBni8QXtXMHs4Gg0G2UnerJJLp5ZQgZqtHWnmg==}
@@ -3208,7 +3137,7 @@ packages:
       '@graphql-tools/utils': 10.2.0(graphql@16.8.1)
       graphql: 16.8.1
       tslib: 2.6.2
-    dev: false
+    dev: true
 
   /@graphql-codegen/plugin-helpers@2.7.2(graphql@16.8.1):
     resolution: {integrity: sha512-kln2AZ12uii6U59OQXdjLk5nOlh1pHis1R98cDZGFnfaiAbX9V3fxcZ1MMJkB7qFUymTALzyjZoXXdyVmPMfRg==}
@@ -3222,6 +3151,7 @@ packages:
       import-from: 4.0.0
       lodash: 4.17.21
       tslib: 2.4.1
+    dev: true
 
   /@graphql-codegen/plugin-helpers@3.1.2(graphql@16.8.1):
     resolution: {integrity: sha512-emOQiHyIliVOIjKVKdsI5MXj312zmRDwmHpyUTZMjfpvxq/UVAHUJIVdVf+lnjjrI+LXBTgMlTWTgHQfmICxjg==}
@@ -3235,6 +3165,7 @@ packages:
       import-from: 4.0.0
       lodash: 4.17.21
       tslib: 2.4.1
+    dev: true
 
   /@graphql-codegen/plugin-helpers@5.0.3(graphql@16.8.1):
     resolution: {integrity: sha512-yZ1rpULIWKBZqCDlvGIJRSyj1B2utkEdGmXZTBT/GVayP4hyRYlkd36AJV/LfEsVD8dnsKL5rLz2VTYmRNlJ5Q==}
@@ -3248,7 +3179,7 @@ packages:
       import-from: 4.0.0
       lodash: 4.17.21
       tslib: 2.6.2
-    dev: false
+    dev: true
 
   /@graphql-codegen/schema-ast@2.6.1(graphql@16.8.1):
     resolution: {integrity: sha512-5TNW3b1IHJjCh07D2yQNGDQzUpUl2AD+GVe1Dzjqyx/d2Fn0TPMxLsHsKPS4Plg4saO8FK/QO70wLsP7fdbQ1w==}
@@ -3270,7 +3201,7 @@ packages:
       '@graphql-tools/utils': 10.2.0(graphql@16.8.1)
       graphql: 16.8.1
       tslib: 2.6.2
-    dev: false
+    dev: true
 
   /@graphql-codegen/typed-document-node@5.0.6(graphql@16.8.1):
     resolution: {integrity: sha512-US0J95hOE2/W/h42w4oiY+DFKG7IetEN1mQMgXXeat1w6FAR5PlIz4JrRrEkiVfVetZ1g7K78SOwBD8/IJnDiA==}
@@ -3286,7 +3217,7 @@ packages:
     transitivePeerDependencies:
       - encoding
       - supports-color
-    dev: false
+    dev: true
 
   /@graphql-codegen/typescript-generic-sdk@3.1.0(graphql-tag@2.12.6)(graphql@16.8.1):
     resolution: {integrity: sha512-nQZi/YGRI1+qCZZsh0V5nz6+hCHSN4OU9tKyOTDsEPyDFnGEukDuRdCH2IZasGn22a3Iu5TUDkgp5w9wEQwGmg==}
@@ -3303,7 +3234,7 @@ packages:
     transitivePeerDependencies:
       - encoding
       - supports-color
-    dev: false
+    dev: true
 
   /@graphql-codegen/typescript-operations@2.5.13(graphql@16.8.1):
     resolution: {integrity: sha512-3vfR6Rx6iZU0JRt29GBkFlrSNTM6t+MSLF86ChvL4d/Jfo/JYAGuB3zNzPhirHYzJPCvLOAx2gy9ID1ltrpYiw==}
@@ -3335,7 +3266,7 @@ packages:
     transitivePeerDependencies:
       - encoding
       - supports-color
-    dev: false
+    dev: true
 
   /@graphql-codegen/typescript-resolvers@4.0.6(graphql@16.8.1):
     resolution: {integrity: sha512-7OBFzZ2xSkYgMgcc1A3xNqbBHHSQXBesLrG86Sh+Jj0PQQB3Om8j1HSFs64PD/l5Kri2dXgm3oim/89l3Rl3lw==}
@@ -3352,7 +3283,7 @@ packages:
     transitivePeerDependencies:
       - encoding
       - supports-color
-    dev: false
+    dev: true
 
   /@graphql-codegen/typescript@2.8.8(graphql@16.8.1):
     resolution: {integrity: sha512-A0oUi3Oy6+DormOlrTC4orxT9OBZkIglhbJBcDmk34jAKKUgesukXRd4yOhmTrnbchpXz2T8IAOFB3FWIaK4Rw==}
@@ -3384,7 +3315,7 @@ packages:
     transitivePeerDependencies:
       - encoding
       - supports-color
-    dev: false
+    dev: true
 
   /@graphql-codegen/visitor-plugin-common@2.13.1(graphql@16.8.1):
     resolution: {integrity: sha512-mD9ufZhDGhyrSaWQGrU1Q1c5f01TeWtSWy/cDwXYjJcHIj1Y/DG2x0tOflEfCvh5WcnmHNIw4lzDsg1W7iFJEg==}
@@ -3405,7 +3336,7 @@ packages:
     transitivePeerDependencies:
       - encoding
       - supports-color
-    dev: false
+    dev: true
 
   /@graphql-codegen/visitor-plugin-common@2.13.8(graphql@16.8.1):
     resolution: {integrity: sha512-IQWu99YV4wt8hGxIbBQPtqRuaWZhkQRG2IZKbMoSvh0vGeWb3dB0n0hSgKaOOxDY+tljtOf9MTcUYvJslQucMQ==}
@@ -3447,7 +3378,7 @@ packages:
     transitivePeerDependencies:
       - encoding
       - supports-color
-    dev: false
+    dev: true
 
   /@graphql-inspector/core@5.0.1(graphql@16.8.1):
     resolution: {integrity: sha512-1CWfFYucnRdULGiN1NDSinlNlpucBT+0x4i4AIthKe5n5jD9RIVyJtkA8zBbujUFrP++YE3l+TQifwbN1yTQsw==}
@@ -3459,7 +3390,6 @@ packages:
       graphql: 16.8.1
       object-inspect: 1.12.3
       tslib: 2.6.0
-    dev: false
 
   /@graphql-inspector/core@5.0.2(graphql@16.8.1):
     resolution: {integrity: sha512-pXHPCggwLmgi5NACPPV4qyf2xW/sQONnu6ZqCAid3k/S2APmVYN4Z3OvxvLA12NFhzby5Sz5K4fRsId43cK8ww==}
@@ -3471,7 +3401,7 @@ packages:
       graphql: 16.8.1
       object-inspect: 1.12.3
       tslib: 2.6.2
-    dev: false
+    dev: true
 
   /@graphql-mesh/cache-localforage@0.95.8(@graphql-mesh/types@0.95.8)(@graphql-mesh/utils@0.95.8)(graphql@16.8.1)(tslib@2.6.2):
     resolution: {integrity: sha512-PgCTHh1dLwjmusWEWAMQkglL7gR8VyyT9pzTcYBVFhGYNXysepCrl85QtaqtEMnR/YijgpCWaKGIYK+bosQZsg==}
@@ -3519,7 +3449,7 @@ packages:
       graphql: 16.8.1
       localforage: 1.10.0
       tslib: 2.6.2
-    dev: false
+    dev: true
 
   /@graphql-mesh/cli@0.90.5(@types/node@20.12.12)(graphql-tag@2.12.6)(graphql-yoga@5.3.1)(graphql@16.8.1):
     resolution: {integrity: sha512-qXjr4XQBqXMkwv1KkGBogLheU2BfUHjT/5GDmT2uTzC8iDr9EHQoXEScxOBz9RFWEXll+PxMe2p7E5mNUz8fFQ==}
@@ -3559,7 +3489,7 @@ packages:
       tsconfig-paths: 4.2.0
       tslib: 2.6.2
       typescript: 5.4.5
-      uWebSockets.js: github.com/uNetworking/uWebSockets.js/8fa05571bf6ea95be8966ad313d9d39453e381ae
+      uWebSockets.js: github.com/uNetworking/uWebSockets.js/6f4b450fc642abba540535f0755c990b42a16026
       yargs: 17.7.2
     optionalDependencies:
       node-libcurl: 4.0.0
@@ -3571,7 +3501,7 @@ packages:
       - graphql-tag
       - graphql-yoga
       - supports-color
-    dev: false
+    dev: true
 
   /@graphql-mesh/config@0.100.5(@graphql-mesh/cross-helpers@0.4.2)(@graphql-mesh/runtime@0.99.5)(@graphql-mesh/store@0.98.4)(@graphql-mesh/types@0.98.4)(@graphql-mesh/utils@0.98.4)(@graphql-tools/utils@10.2.0)(graphql-yoga@5.3.1)(graphql@16.8.1)(tslib@2.6.2):
     resolution: {integrity: sha512-9H2EW8+PqQ1N+YOJ4GWJxmvEKeEjy7oNs/VBayAOUw7lVSVE/97IoeOs9SORaJplvNwSVPwdF0zM/RVMm1GwyA==}
@@ -3609,7 +3539,7 @@ packages:
     transitivePeerDependencies:
       - graphql-yoga
       - supports-color
-    dev: false
+    dev: true
 
   /@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0)(graphql@16.8.1):
     resolution: {integrity: sha512-rx/fWJ6Cgdp6w+dnxm6uVMrtJamjZT2SbNprEJnaSgThbm6EzLYSVGZzfALlXNCr3dUT5fOtnTu+JFWvWZxjcg==}
@@ -3621,7 +3551,6 @@ packages:
       '@graphql-tools/utils': 10.2.0(graphql@16.8.1)
       graphql: 16.8.1
       path-browserify: 1.0.1
-    dev: false
 
   /@graphql-mesh/fusion-runtime@0.3.5(@graphql-mesh/cross-helpers@0.4.2)(@graphql-mesh/store@0.95.8)(graphql@16.8.1):
     resolution: {integrity: sha512-gMtK5gGeEssF6KUkCDv5FmLxxae76jyReUPomH+lPRnS5GIY/tbs6aaL7YRkcrNOI6nYV3Yglolnh12t5kKl2w==}
@@ -3644,7 +3573,7 @@ packages:
     transitivePeerDependencies:
       - '@graphql-mesh/cross-helpers'
       - '@graphql-mesh/store'
-    dev: false
+    dev: true
 
   /@graphql-mesh/graphql@0.95.8(@graphql-mesh/cross-helpers@0.4.2)(@graphql-mesh/store@0.95.8)(@graphql-mesh/types@0.95.8)(@graphql-mesh/utils@0.95.8)(@graphql-tools/utils@10.2.0)(@types/node@20.12.12)(@types/react@18.3.2)(graphql@16.8.1)(react-dom@18.3.1)(react@18.3.1)(tslib@2.6.2):
     resolution: {integrity: sha512-mEbz2XYSgRTdNidUBWB7FT3QzLliJwxJIoqipSbZNputJqSbUZZ6QD/oI1IrdPXqVl/ELE2CuLiogkOSO24C1Q==}
@@ -3718,42 +3647,6 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@graphql-mesh/graphql@0.98.4(@graphql-mesh/cross-helpers@0.4.2)(@graphql-mesh/store@0.95.8)(@graphql-mesh/types@0.95.8)(@graphql-mesh/utils@0.95.8)(@graphql-tools/utils@10.2.0)(@types/node@20.12.12)(@types/react@18.3.2)(graphql@16.8.1)(react-dom@18.3.1)(react@18.3.1)(tslib@2.6.2):
-    resolution: {integrity: sha512-gt3/rDylShniGsdAzq3xkULUWY4s3j8uRoxOn3C8F7Bmi7kVqH0FAfgel53MWB24qxjJe3KrxmhhDURet9t0KA==}
-    engines: {node: '>=16.0.0'}
-    peerDependencies:
-      '@graphql-mesh/cross-helpers': ^0.4.2
-      '@graphql-mesh/store': ^0.98.4
-      '@graphql-mesh/types': ^0.98.4
-      '@graphql-mesh/utils': ^0.98.4
-      '@graphql-tools/utils': ^10.2.0
-      graphql: '*'
-      tslib: ^2.4.0
-    dependencies:
-      '@graphql-mesh/cross-helpers': 0.4.2(@graphql-tools/utils@10.2.0)(graphql@16.8.1)
-      '@graphql-mesh/store': 0.95.8(@graphql-mesh/cross-helpers@0.4.2)(@graphql-mesh/types@0.95.8)(@graphql-mesh/utils@0.95.8)(@graphql-tools/utils@10.2.0)(graphql@16.8.1)(tslib@2.6.2)
-      '@graphql-mesh/string-interpolation': 0.5.4(graphql@16.8.1)(tslib@2.6.2)
-      '@graphql-mesh/types': 0.95.8(@graphql-mesh/store@0.95.8)(@graphql-tools/utils@10.2.0)(graphql@16.8.1)(tslib@2.6.2)
-      '@graphql-mesh/utils': 0.95.8(@graphql-mesh/cross-helpers@0.4.2)(@graphql-mesh/types@0.95.8)(@graphql-tools/utils@10.2.0)(graphql@16.8.1)(tslib@2.6.2)
-      '@graphql-tools/delegate': 10.0.10(graphql@16.8.1)
-      '@graphql-tools/federation': 1.1.35(@types/node@20.12.12)(@types/react@18.3.2)(graphql@16.8.1)(react-dom@18.3.1)(react@18.3.1)
-      '@graphql-tools/url-loader': 8.0.2(@types/node@20.12.12)(graphql@16.8.1)
-      '@graphql-tools/utils': 10.2.0(graphql@16.8.1)
-      graphql: 16.8.1
-      lodash.get: 4.4.2
-      tslib: 2.6.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - '@types/react'
-      - bufferutil
-      - encoding
-      - graphql-ws
-      - react
-      - react-dom
-      - subscriptions-transport-ws
-      - utf-8-validate
-    dev: false
-
   /@graphql-mesh/graphql@0.98.4(@graphql-mesh/cross-helpers@0.4.2)(@graphql-mesh/store@0.95.8)(@graphql-mesh/types@0.98.4)(@graphql-mesh/utils@0.95.8)(@graphql-tools/utils@10.2.0)(@types/node@20.12.12)(graphql@16.8.1)(tslib@2.6.2):
     resolution: {integrity: sha512-gt3/rDylShniGsdAzq3xkULUWY4s3j8uRoxOn3C8F7Bmi7kVqH0FAfgel53MWB24qxjJe3KrxmhhDURet9t0KA==}
     engines: {node: '>=16.0.0'}
@@ -3788,7 +3681,7 @@ packages:
       - react-dom
       - subscriptions-transport-ws
       - utf-8-validate
-    dev: false
+    dev: true
 
   /@graphql-mesh/http@0.96.14(@graphql-mesh/cross-helpers@0.4.2)(@graphql-mesh/runtime@0.96.13)(@graphql-mesh/types@0.95.8)(@graphql-mesh/utils@0.95.8)(graphql@16.8.1)(tslib@2.6.2):
     resolution: {integrity: sha512-38Mxw2K2RABBBO0IiXKZDu2o+jlM4vcUSEg+9h2Dz67oOJZHpKeId6z1PFb7uYMzAs29yoMcqXIEnews+HVhrQ==}
@@ -3853,7 +3746,7 @@ packages:
       graphql: 16.8.1
       graphql-yoga: 5.3.1(graphql@16.8.1)
       tslib: 2.6.2
-    dev: false
+    dev: true
 
   /@graphql-mesh/merger-bare@0.95.8(@graphql-mesh/store@0.95.8)(@graphql-mesh/types@0.95.8)(@graphql-mesh/utils@0.95.8)(@graphql-tools/utils@10.2.0)(graphql@16.8.1)(tslib@2.6.2):
     resolution: {integrity: sha512-E5R8Sv5Dkp+eswYKEDHgu8puwSeolPX1j9IHwBVe1npRRCXc3CjMsQJ9+kcTln453vbSBcM1a3fQspIaKA1Tcg==}
@@ -3916,7 +3809,7 @@ packages:
       tslib: 2.6.2
     transitivePeerDependencies:
       - '@graphql-mesh/store'
-    dev: false
+    dev: true
 
   /@graphql-mesh/merger-stitching@0.95.8(@graphql-mesh/store@0.95.8)(@graphql-mesh/types@0.95.8)(@graphql-mesh/utils@0.95.8)(@graphql-tools/utils@10.2.0)(graphql@16.8.1)(tslib@2.6.2):
     resolution: {integrity: sha512-eAukU8AsjK8jIT3vFhalGoERh98xZgzKkTCQL7w2wPpFXveSDMn+9fVvCJ1EBKTsLa7SkNXqzAFkfYp21hW0ng==}
@@ -3982,7 +3875,7 @@ packages:
       '@graphql-tools/utils': 10.2.0(graphql@16.8.1)
       graphql: 16.8.1
       tslib: 2.6.2
-    dev: false
+    dev: true
 
   /@graphql-mesh/runtime@0.96.13(@graphql-mesh/cross-helpers@0.4.2)(@graphql-mesh/types@0.95.8)(@graphql-mesh/utils@0.95.8)(@graphql-tools/utils@10.2.0)(graphql@16.8.1)(tslib@2.6.2):
     resolution: {integrity: sha512-eZIW/gdEVLvCLEEae8e3lny7d89CFfDyu0Z0xu4yVEdYeVpG9Ki2mDYFHztusIIkZikecvdsoM9MZX6LYcPOkg==}
@@ -4069,7 +3962,7 @@ packages:
       graphql: 16.8.1
       graphql-jit: 0.8.2(graphql@16.8.1)
       tslib: 2.6.2
-    dev: false
+    dev: true
 
   /@graphql-mesh/store@0.95.8(@graphql-mesh/cross-helpers@0.4.2)(@graphql-mesh/types@0.95.8)(@graphql-mesh/utils@0.95.8)(@graphql-tools/utils@10.2.0)(graphql@16.8.1)(tslib@2.6.2):
     resolution: {integrity: sha512-29lpMcvqS1DM9alUOCyj6he2V7ZzG/DZxkerRefT8Mo5FexwJZI3LeI0YHNSY9Cq0x8KzRoH1TWcTTN/1PDRRw==}
@@ -4109,7 +4002,6 @@ packages:
       '@graphql-tools/utils': 10.2.0(graphql@16.8.1)
       graphql: 16.8.1
       tslib: 2.6.2
-    dev: false
 
   /@graphql-mesh/store@0.98.4(@graphql-mesh/cross-helpers@0.4.2)(@graphql-mesh/types@0.98.4)(@graphql-mesh/utils@0.98.4)(@graphql-tools/utils@10.2.0)(graphql@16.8.1)(tslib@2.6.2):
     resolution: {integrity: sha512-aitkzzNyx+49jCWaiCzTZlsGbnEl2yuf6jMrTy5hgYB5kAKuS+gXiW8rDGvFTnTlsdu0BWUh14XnCWfuqR+r2Q==}
@@ -4129,7 +4021,7 @@ packages:
       '@graphql-tools/utils': 10.2.0(graphql@16.8.1)
       graphql: 16.8.1
       tslib: 2.6.2
-    dev: false
+    dev: true
 
   /@graphql-mesh/string-interpolation@0.5.4(graphql@16.8.1)(tslib@2.6.2):
     resolution: {integrity: sha512-Luw/AFPcvTBBNr3KC7d9REyAEC8ZS6HUZiGMKOGYp+uviHUjX30loEVMOkLdrVNPN4Qf35k6yt4NpapTXqcl/Q==}
@@ -4143,24 +4035,6 @@ packages:
       json-pointer: 0.6.2
       lodash.get: 4.4.2
       tslib: 2.6.2
-    dev: false
-
-  /@graphql-mesh/transform-type-merging@0.98.4(@graphql-mesh/types@0.95.8)(@graphql-mesh/utils@0.95.8)(graphql@16.8.1)(tslib@2.6.2):
-    resolution: {integrity: sha512-inQVZ/QjkBpuWMytLNSkimYDCKlPFwa1emQJmpq/Tp8FL/fHpsk3pNeVMtQ3hs7cV9D3qMCxA8XcyDiwt82l4w==}
-    engines: {node: '>=16.0.0'}
-    peerDependencies:
-      '@graphql-mesh/types': ^0.98.4
-      '@graphql-mesh/utils': ^0.98.4
-      graphql: '*'
-      tslib: ^2.4.0
-    dependencies:
-      '@graphql-mesh/types': 0.95.8(@graphql-mesh/store@0.95.8)(@graphql-tools/utils@10.2.0)(graphql@16.8.1)(tslib@2.6.2)
-      '@graphql-mesh/utils': 0.95.8(@graphql-mesh/cross-helpers@0.4.2)(@graphql-mesh/types@0.95.8)(@graphql-tools/utils@10.2.0)(graphql@16.8.1)(tslib@2.6.2)
-      '@graphql-tools/delegate': 10.0.10(graphql@16.8.1)
-      '@graphql-tools/stitching-directives': 3.0.2(graphql@16.8.1)
-      graphql: 16.8.1
-      tslib: 2.6.2
-    dev: false
 
   /@graphql-mesh/transform-type-merging@0.98.4(@graphql-mesh/types@0.98.4)(@graphql-mesh/utils@0.95.8)(graphql@16.8.1)(tslib@2.6.2):
     resolution: {integrity: sha512-inQVZ/QjkBpuWMytLNSkimYDCKlPFwa1emQJmpq/Tp8FL/fHpsk3pNeVMtQ3hs7cV9D3qMCxA8XcyDiwt82l4w==}
@@ -4177,7 +4051,7 @@ packages:
       '@graphql-tools/stitching-directives': 3.0.2(graphql@16.8.1)
       graphql: 16.8.1
       tslib: 2.6.2
-    dev: false
+    dev: true
 
   /@graphql-mesh/transport-common@0.2.4(@graphql-mesh/types@0.98.4)(graphql@16.8.1)(tslib@2.6.2):
     resolution: {integrity: sha512-AhqYa0xVmMptw4Dy+ZuBQLSF08wh39gOwQmWu4NkH492gV49aEmw6gr81uL8YNIVo0bTmD6UMdlie7tY/Ll2GQ==}
@@ -4192,7 +4066,7 @@ packages:
       '@graphql-tools/utils': 10.2.0(graphql@16.8.1)
       graphql: 16.8.1
       tslib: 2.6.2
-    dev: false
+    dev: true
 
   /@graphql-mesh/types@0.95.8(@graphql-mesh/store@0.95.8)(@graphql-tools/utils@10.2.0)(graphql@16.8.1)(tslib@2.6.2):
     resolution: {integrity: sha512-H2xh5KGc3+Ly3VdAPnRdKTibZpW9zEFgUzsozL9MQhCs6WLX+/kOADb0uIDqYFKX5c/2axmcy87BFNOausXYig==}
@@ -4228,7 +4102,6 @@ packages:
       '@graphql-typed-document-node/core': 3.2.0(graphql@16.8.1)
       graphql: 16.8.1
       tslib: 2.6.2
-    dev: false
 
   /@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.98.4)(@graphql-tools/utils@10.2.0)(graphql@16.8.1)(tslib@2.6.2):
     resolution: {integrity: sha512-9H5HGtT+jP2SHOR2+yde6iqB+nlj4UHg1hE4anEc6/dpnbEOdg4QY4VIPsz6OyRgPByYUBJHm7hwkfr6j2XIDA==}
@@ -4246,7 +4119,7 @@ packages:
       '@graphql-typed-document-node/core': 3.2.0(graphql@16.8.1)
       graphql: 16.8.1
       tslib: 2.6.2
-    dev: false
+    dev: true
 
   /@graphql-mesh/utils@0.95.8(@graphql-mesh/cross-helpers@0.4.2)(@graphql-mesh/types@0.95.8)(@graphql-tools/utils@10.2.0)(graphql@16.8.1)(tslib@2.6.2):
     resolution: {integrity: sha512-gH2/kXvxMHVWMX8DppIIZpFfSUaoKDJ6eQHFoAAsdabGE+vLtVk0OEYqMGVGtD/8ZDFa/P6CmwXc6hBzoLY6Kg==}
@@ -4296,7 +4169,6 @@ packages:
       lodash.topath: 4.5.2
       tiny-lru: 11.2.6
       tslib: 2.6.2
-    dev: false
 
   /@graphql-mesh/utils@0.98.4(@graphql-mesh/cross-helpers@0.4.2)(@graphql-mesh/types@0.98.4)(@graphql-tools/utils@10.2.0)(graphql@16.8.1)(tslib@2.6.2):
     resolution: {integrity: sha512-vmbNTr19Pc1YMi5wjivCWMLei4h2FB/MfZBRSId5KV5LUAmhK/hXCBKpLlS+vUIIn2LXFH4h7IZnadfZ0h1xLQ==}
@@ -4321,7 +4193,7 @@ packages:
       lodash.topath: 4.5.2
       tiny-lru: 11.2.6
       tslib: 2.6.2
-    dev: false
+    dev: true
 
   /@graphql-tools/batch-delegate@9.0.2(graphql@16.8.1):
     resolution: {integrity: sha512-LMnHPO5vYSYGo0uFfkwJ91F9VWIRRMQGBt/Ff6E/YFnrHhE49711t0uyPlar511EytwpXxq3rGavXxX6bKy31A==}
@@ -4335,7 +4207,6 @@ packages:
       graphql: 16.8.1
       tslib: 2.6.2
       value-or-promise: 1.0.12
-    dev: false
 
   /@graphql-tools/batch-execute@9.0.4(graphql@16.8.1):
     resolution: {integrity: sha512-kkebDLXgDrep5Y0gK1RN3DMUlLqNhg60OAz0lTCqrYeja6DshxLtLkj+zV4mVbBA4mQOEoBmw6g1LZs3dA84/w==}
@@ -4348,7 +4219,6 @@ packages:
       graphql: 16.8.1
       tslib: 2.6.2
       value-or-promise: 1.0.12
-    dev: false
 
   /@graphql-tools/code-file-loader@7.3.23(@babel/core@7.24.5)(graphql@16.8.1):
     resolution: {integrity: sha512-8Wt1rTtyTEs0p47uzsPJ1vAtfAx0jmxPifiNdmo9EOCuUPyQGEbMaik/YkqZ7QUFIEYEQu+Vgfo8tElwOPtx5Q==}
@@ -4380,7 +4250,7 @@ packages:
       unixify: 1.0.0
     transitivePeerDependencies:
       - supports-color
-    dev: false
+    dev: true
 
   /@graphql-tools/delegate@10.0.10(graphql@16.8.1):
     resolution: {integrity: sha512-OOqsPRfGatQG0qMKG3sxtxHiRg7cA6OWMTuETDvwZCoOuxqCc17K+nt8GvaqptNJi2/wBgeH7pi7wA5QzgiG1g==}
@@ -4395,7 +4265,6 @@ packages:
       dataloader: 2.2.2
       graphql: 16.8.1
       tslib: 2.6.2
-    dev: false
 
   /@graphql-tools/executor-graphql-ws@1.1.2(graphql@16.8.1):
     resolution: {integrity: sha512-+9ZK0rychTH1LUv4iZqJ4ESbmULJMTsv3XlFooPUngpxZkk00q6LqHKJRrsLErmQrVaC7cwQCaRBJa0teK17Lg==}
@@ -4413,7 +4282,6 @@ packages:
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
-    dev: false
 
   /@graphql-tools/executor-http@1.0.9(@types/node@20.12.12)(graphql@16.8.1):
     resolution: {integrity: sha512-+NXaZd2MWbbrWHqU4EhXcrDbogeiCDmEbrAN+rMn4Nu2okDjn2MTFDbTIab87oEubQCH4Te1wDkWPKrzXup7+Q==}
@@ -4431,7 +4299,6 @@ packages:
       value-or-promise: 1.0.12
     transitivePeerDependencies:
       - '@types/node'
-    dev: false
 
   /@graphql-tools/executor-legacy-ws@1.0.6(graphql@16.8.1):
     resolution: {integrity: sha512-lDSxz9VyyquOrvSuCCnld3256Hmd+QI2lkmkEv7d4mdzkxkK4ddAWW1geQiWrQvWmdsmcnGGlZ7gDGbhEExwqg==}
@@ -4448,7 +4315,6 @@ packages:
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
-    dev: false
 
   /@graphql-tools/executor@1.2.6(graphql@16.8.1):
     resolution: {integrity: sha512-+1kjfqzM5T2R+dCw7F4vdJ3CqG+fY/LYJyhNiWEFtq0ToLwYzR/KKyD8YuzTirEjSxWTVlcBh7endkx5n5F6ew==}
@@ -4462,7 +4328,6 @@ packages:
       graphql: 16.8.1
       tslib: 2.6.2
       value-or-promise: 1.0.12
-    dev: false
 
   /@graphql-tools/federation@1.1.35(@types/node@20.12.12)(@types/react@18.3.2)(graphql@16.8.1)(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-40qvVaYI7Wf/pdv1GhznyXBW/3BS7ogJBPLbLaaz7mqmaHzSGCGpW3buOxUwnbvG3r0eMz/sOiCyw3JpP8BisQ==}
@@ -4489,7 +4354,6 @@ packages:
       - react
       - react-dom
       - subscriptions-transport-ws
-    dev: false
 
   /@graphql-tools/graphql-file-loader@8.0.1(graphql@16.8.1):
     resolution: {integrity: sha512-7gswMqWBabTSmqbaNyWSmRRpStWlcCkBc73E6NZNlh4YNuiyKOwbvSkOUYFOqFMfEL+cFsXgAvr87Vz4XrYSbA==}
@@ -4503,7 +4367,7 @@ packages:
       graphql: 16.8.1
       tslib: 2.6.2
       unixify: 1.0.0
-    dev: false
+    dev: true
 
   /@graphql-tools/graphql-tag-pluck@7.5.2(@babel/core@7.24.5)(graphql@16.8.1):
     resolution: {integrity: sha512-RW+H8FqOOLQw0BPXaahYepVSRjuOHw+7IL8Opaa5G5uYGOBxoXR7DceyQ7BcpMgktAOOmpDNQ2WtcboChOJSRA==}
@@ -4538,7 +4402,7 @@ packages:
       tslib: 2.6.2
     transitivePeerDependencies:
       - supports-color
-    dev: false
+    dev: true
 
   /@graphql-tools/import@7.0.1(graphql@16.8.1):
     resolution: {integrity: sha512-935uAjAS8UAeXThqHfYVr4HEAp6nHJ2sximZKO1RzUTq5WoALMAhhGARl0+ecm6X+cqNUwIChJbjtaa6P/ML0w==}
@@ -4550,7 +4414,7 @@ packages:
       graphql: 16.8.1
       resolve-from: 5.0.0
       tslib: 2.6.2
-    dev: false
+    dev: true
 
   /@graphql-tools/load@7.8.14(graphql@16.8.1):
     resolution: {integrity: sha512-ASQvP+snHMYm+FhIaLxxFgVdRaM0vrN9wW2BKInQpktwWTXVyk+yP5nQUCEGmn0RTdlPKrffBaigxepkEAJPrg==}
@@ -4575,7 +4439,7 @@ packages:
       graphql: 16.8.1
       p-limit: 3.1.0
       tslib: 2.6.2
-    dev: false
+    dev: true
 
   /@graphql-tools/merge@8.4.2(graphql@16.8.1):
     resolution: {integrity: sha512-XbrHAaj8yDuINph+sAfuq3QCZ/tKblrTLOpirK0+CAgNlZUCHs0Fa+xtMUURgwCVThLle1AF7svJCxFizygLsw==}
@@ -4596,7 +4460,6 @@ packages:
       '@graphql-tools/utils': 10.2.0(graphql@16.8.1)
       graphql: 16.8.1
       tslib: 2.6.2
-    dev: false
 
   /@graphql-tools/optimize@1.4.0(graphql@16.8.1):
     resolution: {integrity: sha512-dJs/2XvZp+wgHH8T5J2TqptT9/6uVzIYvA6uFACha+ufvdMBedkfR4b4GbT8jAKLRARiqRTxy3dctnwkTM2tdw==}
@@ -4605,6 +4468,7 @@ packages:
     dependencies:
       graphql: 16.8.1
       tslib: 2.6.2
+    dev: true
 
   /@graphql-tools/optimize@2.0.0(graphql@16.8.1):
     resolution: {integrity: sha512-nhdT+CRGDZ+bk68ic+Jw1OZ99YCDIKYA5AlVAnBHJvMawSx9YQqQAIj4refNc1/LRieGiuWvhbG3jvPVYho0Dg==}
@@ -4614,7 +4478,7 @@ packages:
     dependencies:
       graphql: 16.8.1
       tslib: 2.6.2
-    dev: false
+    dev: true
 
   /@graphql-tools/relay-operation-optimizer@6.5.18(graphql@16.8.1):
     resolution: {integrity: sha512-mc5VPyTeV+LwiM+DNvoDQfPqwQYhPV/cl5jOBjTgSniyaq8/86aODfMkrE2OduhQ5E00hqrkuL2Fdrgk0w1QJg==}
@@ -4628,6 +4492,7 @@ packages:
     transitivePeerDependencies:
       - encoding
       - supports-color
+    dev: true
 
   /@graphql-tools/relay-operation-optimizer@7.0.1(graphql@16.8.1):
     resolution: {integrity: sha512-y0ZrQ/iyqWZlsS/xrJfSir3TbVYJTYmMOu4TaSz6F4FRDTQ3ie43BlKkhf04rC28pnUOS4BO9pDcAo1D30l5+A==}
@@ -4642,7 +4507,7 @@ packages:
     transitivePeerDependencies:
       - encoding
       - supports-color
-    dev: false
+    dev: true
 
   /@graphql-tools/schema@10.0.0(graphql@16.8.1):
     resolution: {integrity: sha512-kf3qOXMFcMs2f/S8Y3A8fm/2w+GaHAkfr3Gnhh2LOug/JgpY/ywgFVxO3jOeSpSEdoYcDKLcXVjMigNbY4AdQg==}
@@ -4668,7 +4533,6 @@ packages:
       graphql: 16.8.1
       tslib: 2.6.2
       value-or-promise: 1.0.12
-    dev: false
 
   /@graphql-tools/schema@9.0.19(graphql@16.8.1):
     resolution: {integrity: sha512-oBRPoNBtCkk0zbUsyP4GaIzCt8C0aCI4ycIRUL67KK5pOHljKLBBtGT+Jr6hkzA74C8Gco8bpZPe7aWFjiaK2w==}
@@ -4698,7 +4562,6 @@ packages:
       graphql: 16.8.1
       tslib: 2.6.2
       value-or-promise: 1.0.12
-    dev: false
 
   /@graphql-tools/stitching-directives@3.0.2(graphql@16.8.1):
     resolution: {integrity: sha512-xZ/gU+p3YKm/asvxiseuyDIS6NL1+LKMhoafqSadxxweDsskSpPrWZfOWGlblVq/w7iikxQhRF2b8+VVgF6Myg==}
@@ -4710,7 +4573,7 @@ packages:
       '@graphql-tools/utils': 10.2.0(graphql@16.8.1)
       graphql: 16.8.1
       tslib: 2.6.2
-    dev: false
+    dev: true
 
   /@graphql-tools/url-loader@8.0.2(@types/node@20.12.12)(graphql@16.8.1):
     resolution: {integrity: sha512-1dKp2K8UuFn7DFo1qX5c1cyazQv2h2ICwA9esHblEqCYrgf69Nk8N7SODmsfWg94OEaI74IqMoM12t7eIGwFzQ==}
@@ -4737,7 +4600,6 @@ packages:
       - bufferutil
       - encoding
       - utf-8-validate
-    dev: false
 
   /@graphql-tools/utils@10.2.0(graphql@16.8.1):
     resolution: {integrity: sha512-HYV7dO6pNA2nGKawygaBpk8y+vXOUjjzzO43W/Kb7EPRmXUEQKjHxPYRvQbiF72u1N3XxwGK5jnnFk9WVhUwYw==}
@@ -4750,7 +4612,6 @@ packages:
       dset: 3.1.3
       graphql: 16.8.1
       tslib: 2.6.2
-    dev: false
 
   /@graphql-tools/utils@8.13.1(graphql@16.8.1):
     resolution: {integrity: sha512-qIh9yYpdUFmctVqovwMdheVNJqFh+DQNWIhX87FJStfXYnmweBUDATok9fWPleKeFwxnW8IapKmY8m8toJEkAw==}
@@ -4759,6 +4620,7 @@ packages:
     dependencies:
       graphql: 16.8.1
       tslib: 2.6.2
+    dev: true
 
   /@graphql-tools/utils@9.2.1(graphql@16.8.1):
     resolution: {integrity: sha512-WUw506Ql6xzmOORlriNrD6Ugx+HjVgYxt9KCXD9mHAak+eaXSwuGGPyE60hy9xaDEoXKBsG7SkG69ybitaVl6A==}
@@ -4768,6 +4630,7 @@ packages:
       '@graphql-typed-document-node/core': 3.2.0(graphql@16.8.1)
       graphql: 16.8.1
       tslib: 2.6.2
+    dev: true
 
   /@graphql-tools/wrap@10.0.5(graphql@16.8.1):
     resolution: {integrity: sha512-Cbr5aYjr3HkwdPvetZp1cpDWTGdD1Owgsb3z/ClzhmrboiK86EnQDxDvOJiQkDCPWE9lNBwj8Y4HfxroY0D9DQ==}
@@ -4781,7 +4644,6 @@ packages:
       graphql: 16.8.1
       tslib: 2.6.2
       value-or-promise: 1.0.12
-    dev: false
 
   /@graphql-typed-document-node/core@3.2.0(graphql@16.8.1):
     resolution: {integrity: sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==}
@@ -4795,7 +4657,6 @@ packages:
     engines: {node: '>=18.0.0'}
     dependencies:
       tslib: 2.6.2
-    dev: false
 
   /@graphql-yoga/plugin-persisted-operations@3.3.1(@graphql-tools/utils@10.2.0)(graphql-yoga@5.3.1)(graphql@16.8.1):
     resolution: {integrity: sha512-2FteUIepgAZL5q2JSPbTFozba4T6v34skb6I7FiqZp7XwNnp8Da9Jf5BpcwUb4buP51FzbO5WJW1UMyNptxuOA==}
@@ -4808,7 +4669,7 @@ packages:
       '@graphql-tools/utils': 10.2.0(graphql@16.8.1)
       graphql: 16.8.1
       graphql-yoga: 5.3.1(graphql@16.8.1)
-    dev: false
+    dev: true
 
   /@graphql-yoga/subscription@5.0.0:
     resolution: {integrity: sha512-Ri7sK8hmxd/kwaEa0YT8uqQUb2wOLsmBMxI90QDyf96lzOMJRgBuNYoEkU1pSgsgmW2glceZ96sRYfaXqwVxUw==}
@@ -4818,7 +4679,6 @@ packages:
       '@repeaterjs/repeater': 3.0.6
       '@whatwg-node/events': 0.1.1
       tslib: 2.6.2
-    dev: false
 
   /@graphql-yoga/typed-event-target@3.0.0:
     resolution: {integrity: sha512-w+liuBySifrstuHbFrHoHAEyVnDFVib+073q8AeAJ/qqJfvFvAwUPLLtNohR/WDVRgSasfXtl3dcNuVJWN+rjg==}
@@ -4826,7 +4686,6 @@ packages:
     dependencies:
       '@repeaterjs/repeater': 3.0.6
       tslib: 2.6.2
-    dev: false
 
   /@hapi/hoek@9.3.0:
     resolution: {integrity: sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==}
@@ -5171,6 +5030,7 @@ packages:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.4.15
+    dev: true
 
   /@jsonjoy.com/base64@1.1.2(tslib@2.6.2):
     resolution: {integrity: sha512-q6XAnWQDIMA3+FTiOYajoYqySkO+JSat0ytXGSuRdq9uXE7o92gzuQwQM14xaCRlBLGq3v5miDGC4vkVTn54xA==}
@@ -5205,7 +5065,6 @@ packages:
 
   /@kamilkisiela/fast-url-parser@1.1.4:
     resolution: {integrity: sha512-gbkePEBupNydxCelHCESvFSFM8XPh1Zs/OAVRW/rKpEqPAl5PbOM90Si8mv9bvnR53uPD2s/FiRxdvSejpRJew==}
-    dev: false
 
   /@ledgerhq/connect-kit-loader@1.1.8:
     resolution: {integrity: sha512-mDJsOucVW8m3Lk2fdQst+P74SgiKebvq1iBk4sXLbADQOwhL9bWGaArvO+tW7jPJZwEfSPWBdHcHoYi11XAwZw==}
@@ -5344,7 +5203,7 @@ packages:
     transitivePeerDependencies:
       - encoding
       - supports-color
-    dev: false
+    dev: true
     optional: true
 
   /@metamask/abi-utils@2.0.2:
@@ -6665,7 +6524,7 @@ packages:
       socks-proxy-agent: 8.0.3
     transitivePeerDependencies:
       - supports-color
-    dev: false
+    dev: true
     optional: true
 
   /@npmcli/fs@3.1.1:
@@ -6674,7 +6533,7 @@ packages:
     requiresBuild: true
     dependencies:
       semver: 7.6.2
-    dev: false
+    dev: true
     optional: true
 
   /@oclif/core@2.16.0(@types/node@20.12.12)(typescript@4.9.5):
@@ -8080,7 +7939,6 @@ packages:
 
   /@repeaterjs/repeater@3.0.6:
     resolution: {integrity: sha512-Javneu5lsuhwNCryN+pXH93VPQ8g0dBX7wItHFgYiwQmzE1sVdg5tWHiOgHywzL2W21XQopa7IwIEnNbmeUJYA==}
-    dev: false
 
   /@rescript/std@9.0.0:
     resolution: {integrity: sha512-zGzFsgtZ44mgL4Xef2gOy1hrRVdrs9mcxCOOKZrIPsmbZW14yTkaF591GXxpQvjXiHtgZ/iA9qLyWH6oSReIxQ==}
@@ -9025,15 +8883,19 @@ packages:
 
   /@tsconfig/node10@1.0.11:
     resolution: {integrity: sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==}
+    dev: true
 
   /@tsconfig/node12@1.0.11:
     resolution: {integrity: sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==}
+    dev: true
 
   /@tsconfig/node14@1.0.3:
     resolution: {integrity: sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==}
+    dev: true
 
   /@tsconfig/node16@1.0.4:
     resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
+    dev: true
 
   /@turist/fetch@7.2.0(node-fetch@2.7.0):
     resolution: {integrity: sha512-2x7EGw+6OJ29phunsbGvtxlNmSfcuPcyYudkMbi8gARCP9eJ1CtuMvnVUHL//O9Ixi9SJiug8wNt6lj86pN8XQ==}
@@ -9509,7 +9371,6 @@ packages:
     resolution: {integrity: sha512-vmQSUcfalpIq0R9q7uTo2lXs6eGIpt9wtnLdMv9LVpIjCA/+ufZRozlVoVelIYixx1ugCBKDhn89vnsEGOCx9A==}
     dependencies:
       '@types/node': 20.12.12
-    dev: false
 
   /@types/yargs-parser@21.0.3:
     resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
@@ -9879,10 +9740,9 @@ packages:
     resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
     dev: true
 
-  /@verax-attestation-registry/verax-sdk@1.10.0(@envelop/core@5.0.1)(@graphql-mesh/types@0.95.8)(@graphql-tools/delegate@10.0.10)(@graphql-tools/merge@9.0.4)(@graphql-tools/utils@10.2.0)(@graphql-tools/wrap@10.0.5)(@types/node@20.12.12)(@types/react@18.3.2)(graphql-tag@2.12.6)(graphql-yoga@5.3.1)(react-dom@18.3.1)(react@18.3.1)(tslib@2.6.2)(typescript@5.2.2):
-    resolution: {integrity: sha512-tzy7Gaw3Q18mA0inkT9UESvMTPVR6wKzV50D1CAqyvsshLPG+1pVKV3bRhS4WFhoIHLnoLKSpko0aHmk3xa4gg==}
+  /@verax-attestation-registry/verax-sdk@1.11.0(@graphql-mesh/types@0.95.8)(@graphql-tools/utils@10.2.0)(@types/node@20.12.12)(@types/react@18.3.2)(react-dom@18.3.1)(react@18.3.1)(tslib@2.6.2)(typescript@5.2.2):
+    resolution: {integrity: sha512-rewR7ZvBLeKkGOAXUCfQpIKSMa7XTQPbGmy0DbA2xJs0qIf39I3BfP6GKNeire+KrNRiTGpP6E8C8JU3SrSa3w==}
     dependencies:
-      '@graphprotocol/client-cli': 3.0.3(@envelop/core@5.0.1)(@graphql-mesh/cross-helpers@0.4.2)(@graphql-mesh/store@0.95.8)(@graphql-mesh/types@0.95.8)(@graphql-mesh/utils@0.95.8)(@graphql-tools/delegate@10.0.10)(@graphql-tools/merge@9.0.4)(@graphql-tools/utils@10.2.0)(@graphql-tools/wrap@10.0.5)(@types/node@20.12.12)(@types/react@18.3.2)(graphql-tag@2.12.6)(graphql-yoga@5.3.1)(graphql@16.8.1)(react-dom@18.3.1)(react@18.3.1)
       '@graphql-mesh/cache-localforage': 0.95.8(@graphql-mesh/types@0.95.8)(@graphql-mesh/utils@0.95.8)(graphql@16.8.1)(tslib@2.6.2)
       '@graphql-mesh/cross-helpers': 0.4.2(@graphql-tools/utils@10.2.0)(graphql@16.8.1)
       '@graphql-mesh/graphql': 0.95.8(@graphql-mesh/cross-helpers@0.4.2)(@graphql-mesh/store@0.95.8)(@graphql-mesh/types@0.95.8)(@graphql-mesh/utils@0.95.8)(@graphql-tools/utils@10.2.0)(@types/node@20.12.12)(@types/react@18.3.2)(graphql@16.8.1)(react-dom@18.3.1)(react@18.3.1)(tslib@2.6.2)
@@ -9897,26 +9757,17 @@ packages:
       graphql: 16.8.1
       viem: 2.10.8(typescript@5.2.2)
     transitivePeerDependencies:
-      - '@envelop/core'
       - '@graphql-mesh/types'
-      - '@graphql-tools/delegate'
-      - '@graphql-tools/merge'
       - '@graphql-tools/utils'
-      - '@graphql-tools/wrap'
-      - '@swc/core'
-      - '@swc/wasm'
       - '@types/node'
       - '@types/react'
       - bufferutil
       - debug
       - encoding
-      - graphql-tag
       - graphql-ws
-      - graphql-yoga
       - react
       - react-dom
       - subscriptions-transport-ws
-      - supports-color
       - tslib
       - typescript
       - utf-8-validate
@@ -10912,7 +10763,6 @@ packages:
   /@whatwg-node/events@0.1.1:
     resolution: {integrity: sha512-AyQEn5hIPV7Ze+xFoXVU3QTHXVbWPrzaOkxtENMPMuNL6VVHrp4hHfDt9nrQpjO7BgvuM95dMtkycX5M/DZR3w==}
     engines: {node: '>=16.0.0'}
-    dev: false
 
   /@whatwg-node/fetch@0.8.8:
     resolution: {integrity: sha512-CdcjGC2vdKhc13KKxgsc6/616BQ7ooDIgPeTuAiE8qfCnS0mGzcfCOoZXypQSz73nxI+GWc7ZReIAVhxoE1KCg==}
@@ -10930,7 +10780,6 @@ packages:
     dependencies:
       '@whatwg-node/node-fetch': 0.5.11
       urlpattern-polyfill: 10.0.0
-    dev: false
 
   /@whatwg-node/node-fetch@0.3.6:
     resolution: {integrity: sha512-w9wKgDO4C95qnXZRwZTfCmLWqyRnooGjcIwG0wADWjw9/HN0p7dtvtgSvItZtUyNteEvgTrd8QojNEqV6DAGTA==}
@@ -10951,7 +10800,6 @@ packages:
       busboy: 1.6.0
       fast-querystring: 1.1.2
       tslib: 2.6.2
-    dev: false
 
   /@whatwg-node/server@0.9.34:
     resolution: {integrity: sha512-1sHRjqUtZIyTR2m2dS/dJpzS5OcNDpPuUSVDa2PoEgzYVKr4GsqJaYtRaEXXFohvvyh6PkouYCc1rE7jMDWVCA==}
@@ -10959,7 +10807,6 @@ packages:
     dependencies:
       '@whatwg-node/fetch': 0.9.17
       tslib: 2.6.2
-    dev: false
 
   /@wry/caches@1.0.1:
     resolution: {integrity: sha512-bXuaUNLVVkD20wcGBWRyo7j9N3TxePEWFZj2Y+r9OoUzfqmavM84+mFykRicNsBqatba5JLay1t48wxaXaWnlA==}
@@ -10967,7 +10814,6 @@ packages:
     requiresBuild: true
     dependencies:
       tslib: 2.6.2
-    dev: false
     optional: true
 
   /@wry/context@0.7.4:
@@ -10976,7 +10822,6 @@ packages:
     requiresBuild: true
     dependencies:
       tslib: 2.6.2
-    dev: false
     optional: true
 
   /@wry/equality@0.5.7:
@@ -10985,7 +10830,6 @@ packages:
     requiresBuild: true
     dependencies:
       tslib: 2.6.2
-    dev: false
     optional: true
 
   /@wry/trie@0.4.3:
@@ -10994,7 +10838,6 @@ packages:
     requiresBuild: true
     dependencies:
       tslib: 2.6.2
-    dev: false
     optional: true
 
   /@wry/trie@0.5.0:
@@ -11003,7 +10846,6 @@ packages:
     requiresBuild: true
     dependencies:
       tslib: 2.6.2
-    dev: false
     optional: true
 
   /@xstate/fsm@2.1.0:
@@ -11040,12 +10882,13 @@ packages:
 
   /abbrev@1.1.1:
     resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
+    dev: true
 
   /abbrev@2.0.0:
     resolution: {integrity: sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
     requiresBuild: true
-    dev: false
+    dev: true
     optional: true
 
   /abitype@0.10.3(typescript@5.2.2):
@@ -11182,6 +11025,7 @@ packages:
   /acorn-walk@8.3.2:
     resolution: {integrity: sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==}
     engines: {node: '>=0.4.0'}
+    dev: true
 
   /acorn@6.4.2:
     resolution: {integrity: sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==}
@@ -11229,6 +11073,7 @@ packages:
       debug: 4.3.4(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /agent-base@7.1.1:
     resolution: {integrity: sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==}
@@ -11238,7 +11083,7 @@ packages:
       debug: 4.3.4(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
-    dev: false
+    dev: true
     optional: true
 
   /aggregate-error@3.1.0:
@@ -11247,6 +11092,7 @@ packages:
     dependencies:
       clean-stack: 2.2.0
       indent-string: 4.0.0
+    dev: true
 
   /ajv-formats@2.1.1(ajv@8.13.0):
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
@@ -11268,7 +11114,6 @@ packages:
         optional: true
     dependencies:
       ajv: 8.13.0
-    dev: false
 
   /ajv-keywords@3.5.2(ajv@6.12.6):
     resolution: {integrity: sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==}
@@ -11460,7 +11305,7 @@ packages:
   /aproba@2.0.0:
     resolution: {integrity: sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==}
     requiresBuild: true
-    dev: false
+    dev: true
     optional: true
 
   /are-docs-informative@0.0.2:
@@ -11475,18 +11320,19 @@ packages:
     dependencies:
       delegates: 1.0.0
       readable-stream: 3.6.2
-    dev: false
+    dev: true
     optional: true
 
   /are-we-there-yet@4.0.2:
     resolution: {integrity: sha512-ncSWAawFhKMJDTdoAeOV+jyW1VCMj5QIAwULIBV0SSR7B/RLPPEQiknKcg/RIIZlUQrxELpsxMiTUoAQ4sIUyg==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
     requiresBuild: true
-    dev: false
+    dev: true
     optional: true
 
   /arg@4.1.3:
     resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
+    dev: true
 
   /arg@5.0.2:
     resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
@@ -11556,6 +11402,7 @@ packages:
   /array-union@2.1.0:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
     engines: {node: '>=8'}
+    dev: true
 
   /array-uniq@1.0.3:
     resolution: {integrity: sha512-MNha4BWQ6JbwhFhj03YK552f7cb3AzoE8SzeljgChvL1dl3IcvggXVz1DilzySZkCja+CXuZbdW7yATchWn8/Q==}
@@ -11751,6 +11598,7 @@ packages:
   /auto-bind@4.0.0:
     resolution: {integrity: sha512-Hdw8qdNiqdJ8LqT0iK0sVzkFbzg6fhnQqqfWhBDxcHZvU75+B+ayzTy8x+k5Ix0Y92XOhOUlx74ps+bA6BeYMQ==}
     engines: {node: '>=8'}
+    dev: true
 
   /autoprefixer@10.4.19(postcss@8.4.38):
     resolution: {integrity: sha512-BaENR2+zBZ8xXhM4pUaKUxlVdxZ0EZhjvbopwnXmxRUfqDmwSpC2lAi/QXvx7NRdPCo1WKEcEF6mV64si1z4Ew==}
@@ -11977,6 +11825,7 @@ packages:
 
   /babel-plugin-syntax-trailing-function-commas@7.0.0-beta.0:
     resolution: {integrity: sha512-Xj9XuRuz3nTSbaTXWv3itLOcxyF4oPD8douBBmj7U9BBC6nEBYfyOJYQMf/8PJAFotC62UY5dFfIGEPr7WswzQ==}
+    dev: true
 
   /babel-plugin-transform-import-meta@2.2.1(@babel/core@7.24.5):
     resolution: {integrity: sha512-AxNh27Pcg8Kt112RGa3Vod2QS2YXKKJ6+nSvRtv7qQTJAdx0MZa4UHZ4lnxHUWA2MNbLuZQv5FVab4P1CoLOWw==}
@@ -12045,6 +11894,7 @@ packages:
       '@babel/plugin-transform-spread': 7.24.1(@babel/core@7.24.5)
       '@babel/plugin-transform-template-literals': 7.24.1(@babel/core@7.24.5)
       babel-plugin-syntax-trailing-function-commas: 7.0.0-beta.0
+    dev: true
 
   /babel-preset-gatsby@3.13.2(@babel/core@7.24.5)(core-js@3.37.1):
     resolution: {integrity: sha512-1zZ3Fpt9jD63inJXWUF2hA6U2cBAMYFDSC5hKqnSSVbNUzKlHUcY0Vbx8azBSaHg27TVp9BitR10zvq5AHP/OQ==}
@@ -12296,6 +12146,7 @@ packages:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
+    dev: true
 
   /brace-expansion@2.0.1:
     resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
@@ -12485,6 +12336,7 @@ packages:
     resolution: {integrity: sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==}
     dependencies:
       node-int64: 0.4.0
+    dev: true
 
   /buffer-alloc-unsafe@1.1.0:
     resolution: {integrity: sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==}
@@ -12580,7 +12432,7 @@ packages:
       ssri: 10.0.6
       tar: 6.2.1
       unique-filename: 3.0.0
-    dev: false
+    dev: true
     optional: true
 
   /cache-manager@2.11.1:
@@ -12645,12 +12497,14 @@ packages:
   /callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
+    dev: true
 
   /camel-case@4.1.2:
     resolution: {integrity: sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==}
     dependencies:
       pascal-case: 3.1.2
       tslib: 2.6.2
+    dev: true
 
   /camelcase-css@2.0.1:
     resolution: {integrity: sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==}
@@ -12686,6 +12540,7 @@ packages:
       no-case: 3.0.4
       tslib: 2.6.2
       upper-case-first: 2.0.2
+    dev: true
 
   /cardinal@2.1.1:
     resolution: {integrity: sha512-JSr5eOgoEymtYHBjNWyjrMqet9Am2miJhlfKNdqLp6zoeAh0KN5dRAcxlecj5mAJrmQomgiOBj35xHLrFjqBpw==}
@@ -12762,6 +12617,7 @@ packages:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
+    dev: true
 
   /change-case-all@1.0.14:
     resolution: {integrity: sha512-CWVm2uT7dmSHdO/z1CXT/n47mWonyypzBbuCy5tN7uMg22BsfkhwT6oHmFCAk+gL1LOOxhdbB9SZz3J1KTY3gA==}
@@ -12776,6 +12632,7 @@ packages:
       title-case: 3.0.3
       upper-case: 2.0.2
       upper-case-first: 2.0.2
+    dev: true
 
   /change-case-all@1.0.15:
     resolution: {integrity: sha512-3+GIFhk3sNuvFAJKU46o26OdzudQlPNBCu1ZQi3cMeMHhty1bhDxu2WrEilVNYaGvqUtR1VSigFcJOiS13dRhQ==}
@@ -12790,6 +12647,7 @@ packages:
       title-case: 3.0.3
       upper-case: 2.0.2
       upper-case-first: 2.0.2
+    dev: true
 
   /change-case@4.1.2:
     resolution: {integrity: sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==}
@@ -12806,6 +12664,7 @@ packages:
       sentence-case: 3.0.4
       snake-case: 3.0.4
       tslib: 2.6.2
+    dev: true
 
   /char-regex@1.0.2:
     resolution: {integrity: sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==}
@@ -12862,6 +12721,7 @@ packages:
   /chownr@2.0.0:
     resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
     engines: {node: '>=10'}
+    dev: true
 
   /chrome-trace-event@1.0.3:
     resolution: {integrity: sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==}
@@ -12903,6 +12763,7 @@ packages:
   /clean-stack@2.2.0:
     resolution: {integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==}
     engines: {node: '>=6'}
+    dev: true
 
   /clean-stack@3.0.1:
     resolution: {integrity: sha512-lR9wNiMRcVQjSB3a7xXGLuz4cr4wJuuXlaAEbRutGowQTmlp7R72/DOgN21e8jdwblMWl9UOJMJXarX94pzKdg==}
@@ -12994,6 +12855,7 @@ packages:
       string-width: 4.2.3
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
+    dev: true
 
   /clone-deep@4.0.1:
     resolution: {integrity: sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==}
@@ -13072,7 +12934,7 @@ packages:
     resolution: {integrity: sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==}
     hasBin: true
     requiresBuild: true
-    dev: false
+    dev: true
     optional: true
 
   /color@4.2.3:
@@ -13165,6 +13027,7 @@ packages:
   /common-tags@1.8.2:
     resolution: {integrity: sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==}
     engines: {node: '>=4.0.0'}
+    dev: true
 
   /commondir@1.0.1:
     resolution: {integrity: sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==}
@@ -13198,6 +13061,7 @@ packages:
 
   /concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+    dev: true
 
   /concat-stream@1.6.2:
     resolution: {integrity: sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==}
@@ -13284,7 +13148,7 @@ packages:
   /console-control-strings@1.1.0:
     resolution: {integrity: sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==}
     requiresBuild: true
-    dev: false
+    dev: true
     optional: true
 
   /constant-case@3.0.4:
@@ -13293,6 +13157,7 @@ packages:
       no-case: 3.0.4
       tslib: 2.6.2
       upper-case: 2.0.2
+    dev: true
 
   /constants-browserify@1.0.0:
     resolution: {integrity: sha512-xFxOwqIzR/e1k1gLiWEophSCMqXcwVHIH7akf7b/vxcUeGunlj3hvZaaqxwHsTgn+IndtkQJgSztIDWeumWJDQ==}
@@ -13469,7 +13334,7 @@ packages:
       js-yaml: 4.1.0
       parse-json: 5.2.0
       typescript: 5.4.5
-    dev: false
+    dev: true
 
   /crc-32@1.2.2:
     resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
@@ -13532,6 +13397,7 @@ packages:
 
   /create-require@1.1.1:
     resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
+    dev: true
 
   /cron-parser@4.9.0:
     resolution: {integrity: sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==}
@@ -13552,7 +13418,6 @@ packages:
     engines: {node: '>=16.0.0'}
     dependencies:
       tslib: 2.6.2
-    dev: false
 
   /cross-spawn@7.0.3:
     resolution: {integrity: sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==}
@@ -13804,7 +13669,6 @@ packages:
 
   /dataloader@2.2.2:
     resolution: {integrity: sha512-8YnDaaf7N3k/q5HnTJVuzSyLETjoZjVmHc4AeKAzOvKHEFQKcn64OKBfzHYtE9zGjctNM7V9I0MfnUVLpi7M5g==}
-    dev: false
 
   /date-fns@2.30.0:
     resolution: {integrity: sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==}
@@ -13815,7 +13679,6 @@ packages:
 
   /dayjs@1.11.11:
     resolution: {integrity: sha512-okzr3f11N6WuqYtZSvm+F776mB41wRZMhKP+hc34YdW+KmtYYK9iqvHSwo2k9FEH3fhGXvOPV6yz2IcSrfRUDg==}
-    dev: false
 
   /death@1.1.0:
     resolution: {integrity: sha512-vsV6S4KVHvTGxbEcij7hkWRv0It+sGGWVOM67dQde/o5Xjnr+KmLjxWJii2uEObIrt1CcM9w0Yaovx+iOlIL+w==}
@@ -14003,7 +13866,7 @@ packages:
   /delegates@1.0.0:
     resolution: {integrity: sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==}
     requiresBuild: true
-    dev: false
+    dev: true
     optional: true
 
   /depd@2.0.0:
@@ -14062,6 +13925,7 @@ packages:
   /detect-libc@2.0.3:
     resolution: {integrity: sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==}
     engines: {node: '>=8'}
+    dev: true
 
   /detect-newline@3.1.0:
     resolution: {integrity: sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==}
@@ -14155,6 +14019,7 @@ packages:
   /diff@4.0.2:
     resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
     engines: {node: '>=0.3.1'}
+    dev: true
 
   /diff@5.0.0:
     resolution: {integrity: sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==}
@@ -14189,6 +14054,7 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       path-type: 4.0.0
+    dev: true
 
   /dlv@1.1.3:
     resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
@@ -14323,6 +14189,7 @@ packages:
     dependencies:
       no-case: 3.0.4
       tslib: 2.6.2
+    dev: true
 
   /dot-prop@5.3.0:
     resolution: {integrity: sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==}
@@ -14352,7 +14219,6 @@ packages:
   /dset@3.1.3:
     resolution: {integrity: sha512-20TuZZHCEZ2O71q9/+8BwKwZ0QtD9D8ObhrihJPr+vLLYlSuAU3/zL4cSlgbfeoGHTjCSJBa7NGcrF9/Bx/WJQ==}
     engines: {node: '>=4'}
-    dev: false
 
   /duplexer2@0.1.4:
     resolution: {integrity: sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==}
@@ -14459,6 +14325,7 @@ packages:
     resolution: {integrity: sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==}
     dependencies:
       iconv-lite: 0.6.3
+    dev: true
 
   /end-of-stream@1.4.4:
     resolution: {integrity: sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==}
@@ -14540,12 +14407,13 @@ packages:
     resolution: {integrity: sha512-6u0VYSCo/OW6IoD5WCLLy9JUGARbamfSavcNXry/eu8aHVFei6CD3Sw+VGX5alea1i9pgPHW0mbu6Xj0uBh7gA==}
     engines: {node: '>=6'}
     requiresBuild: true
-    dev: false
+    dev: true
     optional: true
 
   /env-paths@2.2.1:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
     engines: {node: '>=6'}
+    dev: true
 
   /envinfo@7.13.0:
     resolution: {integrity: sha512-cvcaMr7KqXVh4nyzGTVqTum+gAiL265x5jUWQIDLq//zOGbW+gSW/C+OWLleY/rs9Qole6AZLMXPbtIFQbqu+Q==}
@@ -14560,7 +14428,7 @@ packages:
   /err-code@2.0.3:
     resolution: {integrity: sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==}
     requiresBuild: true
-    dev: false
+    dev: true
     optional: true
 
   /err-code@3.0.1:
@@ -14571,6 +14439,7 @@ packages:
     resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}
     dependencies:
       is-arrayish: 0.2.1
+    dev: true
 
   /error-stack-parser@2.1.4:
     resolution: {integrity: sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==}
@@ -15867,7 +15736,7 @@ packages:
   /exponential-backoff@3.1.1:
     resolution: {integrity: sha512-dX7e/LHVJ6W3DE1MHWi9S1EYzDESENfLrYohG2G++ovZrYOkm4Knwa0mc1cn84xJOR4KEU0WSchhLbd0UklbHw==}
     requiresBuild: true
-    dev: false
+    dev: true
     optional: true
 
   /express-http-proxy@1.6.3:
@@ -15945,7 +15814,6 @@ packages:
   /extract-files@11.0.0:
     resolution: {integrity: sha512-FuoE1qtbJ4bBVvv94CC7s0oTnKUGvQs+Rjf1L2SJFfS+HTVVjhPFtehPdQ0JiGPqVNfSSZvL5yzHHQq2Z4WNhQ==}
     engines: {node: ^12.20 || >= 14.13}
-    dev: false
 
   /eyes@0.1.8:
     resolution: {integrity: sha512-GipyPsXO1anza0AOZdy69Im7hGFCNB7Y/NGjDlZGJ3GJJLtwNSb2vrzYrTYJRrRloVx7pl+bhUaTB8yiccPvFQ==}
@@ -15989,7 +15857,6 @@ packages:
       ajv: 6.12.6
       deepmerge: 4.3.1
       string-similarity: 4.0.4
-    dev: false
 
   /fast-json-stringify@5.15.1:
     resolution: {integrity: sha512-JopGtkvvguRqrS4gHXSSA2jf4pDgOZkeBAkLO1LbzOpiOMo7/kugoR+KiWifpLpluaVeYDkAuxCJOj4Gyc6L9A==}
@@ -16001,7 +15868,6 @@ packages:
       fast-uri: 2.3.0
       json-schema-ref-resolver: 1.0.1
       rfdc: 1.3.1
-    dev: false
 
   /fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
@@ -16028,7 +15894,6 @@ packages:
 
   /fast-uri@2.3.0:
     resolution: {integrity: sha512-eel5UKGn369gGEWOqBShmFJWfq/xSJvsgDzgLYC845GneayWvXBf0lJCBn5qTABfewy1ZDPoaR5OZCP+kssfuw==}
-    dev: false
 
   /fast-url-parser@1.1.3:
     resolution: {integrity: sha512-5jOCVXADYNuRkKFzNJ0dCCewsZiYo0dz8QNYljkOpFC6r2U4OBmKtvm/Tsuh4w1YYdDqDb31a8TVhBJ2OJKdqQ==}
@@ -16056,6 +15921,7 @@ packages:
     resolution: {integrity: sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==}
     dependencies:
       bser: 2.1.1
+    dev: true
 
   /fbemitter@3.0.0:
     resolution: {integrity: sha512-KWKaceCwKQU0+HPoop6gn4eOHk50bBv/VxjJtGMfwmJt3D29JpN4H4eisCtIPA+a8GVBam+ldMMpMjJUvpDyHw==}
@@ -16245,7 +16111,6 @@ packages:
 
   /foreach@2.0.6:
     resolution: {integrity: sha512-k6GAGDyqLe9JaebCsFCoudPPWfihKu8pylYXRlqP1J7ms39iPoTtk2fviNglIeQEwdh0bQeKJ01ZPyuyQvKzwg==}
-    dev: false
 
   /foreground-child@3.1.1:
     resolution: {integrity: sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==}
@@ -16444,6 +16309,7 @@ packages:
     engines: {node: '>= 8'}
     dependencies:
       minipass: 3.3.6
+    dev: true
 
   /fs-minipass@3.0.3:
     resolution: {integrity: sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==}
@@ -16451,7 +16317,7 @@ packages:
     requiresBuild: true
     dependencies:
       minipass: 7.1.1
-    dev: false
+    dev: true
     optional: true
 
   /fs-monkey@1.0.6:
@@ -16464,6 +16330,7 @@ packages:
 
   /fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
+    dev: true
 
   /fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -17025,7 +16892,7 @@ packages:
       string-width: 4.2.3
       strip-ansi: 6.0.1
       wide-align: 1.1.5
-    dev: false
+    dev: true
     optional: true
 
   /gauge@5.0.2:
@@ -17041,14 +16908,13 @@ packages:
       string-width: 4.2.3
       strip-ansi: 6.0.1
       wide-align: 1.1.5
-    dev: false
+    dev: true
     optional: true
 
   /generate-function@2.3.1:
     resolution: {integrity: sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==}
     dependencies:
       is-property: 1.0.2
-    dev: false
 
   /gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
@@ -17234,6 +17100,7 @@ packages:
       minimatch: 3.1.2
       once: 1.4.0
       path-is-absolute: 1.0.1
+    dev: true
 
   /glob@8.1.0:
     resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
@@ -17315,6 +17182,7 @@ packages:
       ignore: 5.3.1
       merge2: 1.4.1
       slash: 3.0.0
+    dev: true
 
   /globby@13.2.2:
     resolution: {integrity: sha512-Y1zNGV+pzQdh7H39l9zgB4PJqjRNqydvdYCDG4HFXM4XuvSaQQlEc91IU1yALL8gUTDomgBAfz3XJdmUS+oo0w==}
@@ -17415,6 +17283,7 @@ packages:
 
   /graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+    dev: true
 
   /graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
@@ -17444,6 +17313,7 @@ packages:
       graphql: '*'
     dependencies:
       graphql: 16.8.1
+    dev: true
 
   /graphql-jit@0.8.2(graphql@16.8.1):
     resolution: {integrity: sha512-P9KtM/UY4JTtHVRqRlZzFXPmDEtps1Bd27Mvj/naQIa5d0j83zPxAx4jewq1wueF3UEZu1JFZwX1XVBBkoo1Mg==}
@@ -17458,7 +17328,6 @@ packages:
       lodash.memoize: 4.1.2
       lodash.merge: 4.6.2
       lodash.mergewith: 4.6.2
-    dev: false
 
   /graphql-jit@0.8.6(graphql@16.8.1):
     resolution: {integrity: sha512-oVJteh/uYDpIA/M4UHrI+DmzPnX1zTD0a7Je++JA8q8P68L/KbuepimDyrT5FhL4HAq3filUxaFvfsL6/A4msw==}
@@ -17472,7 +17341,6 @@ packages:
       lodash.memoize: 4.1.2
       lodash.merge: 4.6.2
       lodash.mergewith: 4.6.2
-    dev: false
 
   /graphql-tag@2.12.6(graphql@16.8.1):
     resolution: {integrity: sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==}
@@ -17498,7 +17366,6 @@ packages:
       graphql: '>=0.11 <=16'
     dependencies:
       graphql: 16.8.1
-    dev: false
 
   /graphql-yoga@5.3.1(graphql@16.8.1):
     resolution: {integrity: sha512-n918QV6TF7xTjb9ASnozgsr4ydMc08c+x4eRAWKxxWVwSnzdP2xeN2zw1ljIzRD0ccSCNoBajGDKwcZkJDitPA==}
@@ -17518,7 +17385,6 @@ packages:
       graphql: 16.8.1
       lru-cache: 10.2.2
       tslib: 2.6.2
-    dev: false
 
   /graphql@15.5.0:
     resolution: {integrity: sha512-OmaM7y0kaK31NKG31q4YbD2beNYa6jBBKtMFT6gLYJljHLJr42IqJ8KX08u3Li/0ifzTU5HjmoOOrwa5BRLeDA==}
@@ -17662,6 +17528,7 @@ packages:
   /has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
+    dev: true
 
   /has-property-descriptors@1.0.2:
     resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
@@ -17689,7 +17556,7 @@ packages:
   /has-unicode@2.0.1:
     resolution: {integrity: sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==}
     requiresBuild: true
-    dev: false
+    dev: true
     optional: true
 
   /has@1.0.4:
@@ -17748,6 +17615,7 @@ packages:
     dependencies:
       capital-case: 1.0.4
       tslib: 2.6.2
+    dev: true
 
   /heap@0.2.7:
     resolution: {integrity: sha512-2bsegYkkHO+h/9MGbn6KWcE45cHZgPANo5LXF7EvWdT0yT2EguSVO1nDgU5c8+ZOPwp2vMNa7YFsJhVcDR9Sdg==}
@@ -17826,6 +17694,7 @@ packages:
 
   /http-cache-semantics@4.1.1:
     resolution: {integrity: sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==}
+    dev: true
 
   /http-errors@2.0.0:
     resolution: {integrity: sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==}
@@ -17847,7 +17716,7 @@ packages:
       debug: 4.3.4(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
-    dev: false
+    dev: true
     optional: true
 
   /http-response-object@3.0.2:
@@ -17889,6 +17758,7 @@ packages:
       debug: 4.3.4(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /https-proxy-agent@7.0.4:
     resolution: {integrity: sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==}
@@ -17899,7 +17769,7 @@ packages:
       debug: 4.3.4(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
-    dev: false
+    dev: true
     optional: true
 
   /human-signals@2.1.0:
@@ -17946,6 +17816,7 @@ packages:
     requiresBuild: true
     dependencies:
       safer-buffer: 2.1.2
+    dev: true
 
   /icss-utils@5.1.0(postcss@8.4.38):
     resolution: {integrity: sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==}
@@ -17978,10 +17849,10 @@ packages:
   /ignore@5.3.1:
     resolution: {integrity: sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==}
     engines: {node: '>= 4'}
+    dev: true
 
   /immediate@3.0.6:
     resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
-    dev: false
 
   /immer@10.0.2:
     resolution: {integrity: sha512-Rx3CqeqQ19sxUtYV9CU911Vhy8/721wRFnJv3REVGWUmoAcIwzifTsdmJte/MV+0/XpM35LZdQMBGkRIoLPwQA==}
@@ -17994,6 +17865,7 @@ packages:
   /immutable@3.7.6:
     resolution: {integrity: sha512-AizQPcaofEtO11RZhPPHBOJRdo/20MKQF9mBLnVkBoyHi1/zXK8fzVdnEpSV9gxqtnh6Qomfp3F0xT5qP/vThw==}
     engines: {node: '>=0.8.0'}
+    dev: true
 
   /immutable@4.2.1:
     resolution: {integrity: sha512-7WYV7Q5BTs0nlQm7tl92rDYYoyELLKHoDMBKhrxEoiV4mrfVdRz8hzPiYOzH7yWjzoVEamxRuAqhxL2PLRwZYQ==}
@@ -18009,10 +17881,12 @@ packages:
     dependencies:
       parent-module: 1.0.1
       resolve-from: 4.0.0
+    dev: true
 
   /import-from@4.0.0:
     resolution: {integrity: sha512-P9J71vT5nLlDeV8FHs5nNxaLbrpfAV5cF5srvbZfpwpcJoM/xZR3hiv+q+SAnuSmuGbXMWud063iIMx/V/EWZQ==}
     engines: {node: '>=12.2'}
+    dev: true
 
   /import-local@3.1.0:
     resolution: {integrity: sha512-ASB07uLtnDs1o6EHjKpX34BKYDSqnFerfTOJL2HvMqF70LnxpjkzDB8J44oT9pu4AMPkQwf8jl6szgvNd2tRIg==}
@@ -18026,16 +17900,19 @@ packages:
   /imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
+    dev: true
 
   /indent-string@4.0.0:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
+    dev: true
 
   /inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
     dependencies:
       once: 1.4.0
       wrappy: 1.0.2
+    dev: true
 
   /inherits@2.0.3:
     resolution: {integrity: sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==}
@@ -18137,7 +18014,7 @@ packages:
     dependencies:
       jsbn: 1.1.0
       sprintf-js: 1.1.3
-    dev: false
+    dev: true
     optional: true
 
   /ip-regex@4.3.0:
@@ -18269,6 +18146,7 @@ packages:
     dependencies:
       is-relative: 1.0.0
       is-windows: 1.0.2
+    dev: true
 
   /is-arguments@1.1.1:
     resolution: {integrity: sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==}
@@ -18288,6 +18166,7 @@ packages:
 
   /is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
+    dev: true
 
   /is-arrayish@0.3.2:
     resolution: {integrity: sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==}
@@ -18359,6 +18238,7 @@ packages:
     resolution: {integrity: sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==}
     engines: {node: '>=8'}
     hasBin: true
+    dev: true
 
   /is-docker@3.0.0:
     resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
@@ -18452,13 +18332,14 @@ packages:
   /is-lambda@1.0.1:
     resolution: {integrity: sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==}
     requiresBuild: true
-    dev: false
+    dev: true
     optional: true
 
   /is-lower-case@2.0.2:
     resolution: {integrity: sha512-bVcMJy4X5Og6VZfdOZstSexlEy20Sr0k/p/b2IlQJlfdKAQuMpiv5w2Ccxb8sKdRUNAG1PnHVHjFSdRDVS6NlQ==}
     dependencies:
       tslib: 2.6.2
+    dev: true
 
   /is-map@2.0.3:
     resolution: {integrity: sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==}
@@ -18522,7 +18403,6 @@ packages:
 
   /is-property@1.0.2:
     resolution: {integrity: sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==}
-    dev: false
 
   /is-regex@1.1.4:
     resolution: {integrity: sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==}
@@ -18544,6 +18424,7 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       is-unc-path: 1.0.0
+    dev: true
 
   /is-root@2.1.0:
     resolution: {integrity: sha512-AGOriNp96vNBd3HtU+RzFEc75FfR5ymiYv8E553I71SCeXBiMsVDUtdio1OEFvrPyLIQ9tVR5RxXIFe5PUFjMg==}
@@ -18605,6 +18486,7 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       unc-path-regex: 0.1.2
+    dev: true
 
   /is-unicode-supported@0.1.0:
     resolution: {integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==}
@@ -18615,6 +18497,7 @@ packages:
     resolution: {integrity: sha512-44pxmxAvnnAOwBg4tHPnkfvgjPwbc5QIsSstNU+YcJ1ovxVzCWpSGosPJOZh/a1tdl81fbgnLc9LLv+x2ywbPQ==}
     dependencies:
       tslib: 2.6.2
+    dev: true
 
   /is-valid-domain@0.1.6:
     resolution: {integrity: sha512-ZKtq737eFkZr71At8NxOFcP9O1K89gW3DkdrGMpp1upr/ueWjj+Weh4l9AI4rN0Gt8W2M1w7jrG2b/Yv83Ljpg==}
@@ -18651,12 +18534,14 @@ packages:
   /is-windows@1.0.2:
     resolution: {integrity: sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==}
     engines: {node: '>=0.10.0'}
+    dev: true
 
   /is-wsl@2.2.0:
     resolution: {integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==}
     engines: {node: '>=8'}
     dependencies:
       is-docker: 2.2.1
+    dev: true
 
   /is-wsl@3.1.0:
     resolution: {integrity: sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==}
@@ -18689,7 +18574,7 @@ packages:
     resolution: {integrity: sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==}
     engines: {node: '>=16'}
     requiresBuild: true
-    dev: false
+    dev: true
     optional: true
 
   /iso-url@1.2.1:
@@ -18724,7 +18609,6 @@ packages:
       ws: '*'
     dependencies:
       ws: 8.17.0
-    dev: false
 
   /isows@1.0.3(ws@8.13.0):
     resolution: {integrity: sha512-2cKei4vlmg2cxEjm3wVSqn8pcoRF/LX/wpifuuNquFO4SQmPwarClT+SUCA2lt+l581tTeZIPIZuIDo2jWN1fg==}
@@ -19394,7 +19278,7 @@ packages:
   /jsbn@1.1.0:
     resolution: {integrity: sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==}
     requiresBuild: true
-    dev: false
+    dev: true
     optional: true
 
   /jsdoc-type-pratt-parser@4.0.0:
@@ -19414,7 +19298,7 @@ packages:
 
   /json-bigint-patch@0.0.8:
     resolution: {integrity: sha512-xa0LTQsyaq8awYyZyuUsporWisZFiyqzxGW8CKM3t7oouf0GFAKYJnqAm6e9NLNBQOCtOLvy614DEiRX/rPbnA==}
-    dev: false
+    dev: true
 
   /json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
@@ -19426,12 +19310,12 @@ packages:
 
   /json-parse-even-better-errors@2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
+    dev: true
 
   /json-pointer@0.6.2:
     resolution: {integrity: sha512-vLWcKbOaXlO+jvRy4qNd+TI1QUPZzfJj1tpJ3vAXDych5XJf93ftpUKe5pKCrzyIIwgBJcOcCVRUfqQP25afBw==}
     dependencies:
       foreach: 2.0.6
-    dev: false
 
   /json-rpc-engine@6.1.0:
     resolution: {integrity: sha512-NEdLrtrq1jUZyfjkr9OCz9EzCNhnRyWtt1PAnvnhwy6e8XETS0Dtc+ZNCO2gvuAoKsIn2+vCSowXTYE4CkgnAQ==}
@@ -19448,7 +19332,6 @@ packages:
     resolution: {integrity: sha512-EJAj1pgHc1hxF6vo2Z3s69fMjO1INq6eGHXZ8Z6wCQeldCuwxGK9Sxf4/cScGn3FZubCVUehfWtcDM/PLteCQw==}
     dependencies:
       fast-deep-equal: 3.1.3
-    dev: false
 
   /json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
@@ -19458,7 +19341,6 @@ packages:
 
   /json-schema@0.4.0:
     resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
-    dev: false
 
   /json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -19609,7 +19491,6 @@ packages:
     resolution: {integrity: sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==}
     dependencies:
       immediate: 3.0.6
-    dev: false
 
   /lilconfig@2.1.0:
     resolution: {integrity: sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==}
@@ -19733,7 +19614,6 @@ packages:
     resolution: {integrity: sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==}
     dependencies:
       lie: 3.1.1
-    dev: false
 
   /locate-path@2.0.0:
     resolution: {integrity: sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==}
@@ -19805,7 +19685,6 @@ packages:
 
   /lodash.get@4.4.2:
     resolution: {integrity: sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==}
-    dev: false
 
   /lodash.isequal@4.5.0:
     resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
@@ -19842,7 +19721,6 @@ packages:
 
   /lodash.mergewith@4.6.2:
     resolution: {integrity: sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==}
-    dev: false
 
   /lodash.pad@4.5.1:
     resolution: {integrity: sha512-mvUHifnLqM+03YNzeTBS1/Gr6JRFjd3rRx88FHWUvamVaT9k2O/kXha3yBSOwB9/DTQrSTLJNHvLBBt2FdX7Mg==}
@@ -19870,7 +19748,6 @@ packages:
 
   /lodash.topath@4.5.2:
     resolution: {integrity: sha512-1/W4dM+35DwvE/iEd1M9ekewOSTlpFekhw9mhAtrwjVqUr83/ilQiyAvmg4tVX7Unkcfl1KC+i9WdaT4B6aQcg==}
-    dev: false
 
   /lodash.trim@4.5.1:
     resolution: {integrity: sha512-nJAlRl/K+eiOehWKDzoBVrSMhK0K3A3YQsUNXHQa5yIrKBAhsZgSu3KoAFoFT+mEgiyBHddZ0pRk1ITpIp90Wg==}
@@ -19942,11 +19819,13 @@ packages:
     resolution: {integrity: sha512-EVm/rR94FJTZi3zefZ82fLWab+GX14LJN4HrWBcuo6Evmsl9hEfnqxgcHCKb9q+mNf6EVdsjx/qucYFIIB84pg==}
     dependencies:
       tslib: 2.6.2
+    dev: true
 
   /lower-case@2.0.2:
     resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
     dependencies:
       tslib: 2.6.2
+    dev: true
 
   /lowercase-keys@2.0.0:
     resolution: {integrity: sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==}
@@ -20014,6 +19893,7 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       semver: 6.3.1
+    dev: true
 
   /make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
@@ -20024,6 +19904,7 @@ packages:
 
   /make-error@1.3.6:
     resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
+    dev: true
 
   /make-fetch-happen@13.0.1:
     resolution: {integrity: sha512-cKTUFc/rbKUd/9meOvgrpJ2WrNzymt6jfRDdwg5UCnVzv9dTpEj9JS5m3wtziXVCjluIXyL8pcaukYqezIzZQA==}
@@ -20044,7 +19925,7 @@ packages:
       ssri: 10.0.6
     transitivePeerDependencies:
       - supports-color
-    dev: false
+    dev: true
     optional: true
 
   /makeerror@1.0.12:
@@ -20056,6 +19937,7 @@ packages:
   /map-cache@0.2.2:
     resolution: {integrity: sha512-8y/eV9QQZCiyn1SprXSrCmqJN0yNRATe+PO8ztwqrvrbdRLA3eYJF0yaR0YayLWkMbsQSKWS9N2gPcGEc4UsZg==}
     engines: {node: '>=0.10.0'}
+    dev: true
 
   /markdown-table@1.1.3:
     resolution: {integrity: sha512-1RUZVgQlpJSPWYbFSpmudq5nHY1doEIv89gBtF0s4gW1GF2XorxcA/70M5vq7rLv0a6mhOUccRsqkwhwLCIQ2Q==}
@@ -20157,7 +20039,6 @@ packages:
         optional: true
     dependencies:
       '@types/node': 20.12.12
-    dev: false
 
   /methods@1.1.2:
     resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
@@ -20267,6 +20148,7 @@ packages:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
     dependencies:
       brace-expansion: 1.1.11
+    dev: true
 
   /minimatch@5.0.1:
     resolution: {integrity: sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==}
@@ -20304,6 +20186,7 @@ packages:
 
   /minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+    dev: true
 
   /minipass-collect@2.0.1:
     resolution: {integrity: sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw==}
@@ -20311,7 +20194,7 @@ packages:
     requiresBuild: true
     dependencies:
       minipass: 7.1.1
-    dev: false
+    dev: true
     optional: true
 
   /minipass-fetch@3.0.5:
@@ -20324,7 +20207,7 @@ packages:
       minizlib: 2.1.2
     optionalDependencies:
       encoding: 0.1.13
-    dev: false
+    dev: true
     optional: true
 
   /minipass-flush@1.0.5:
@@ -20333,7 +20216,7 @@ packages:
     requiresBuild: true
     dependencies:
       minipass: 3.3.6
-    dev: false
+    dev: true
     optional: true
 
   /minipass-pipeline@1.2.4:
@@ -20342,7 +20225,7 @@ packages:
     requiresBuild: true
     dependencies:
       minipass: 3.3.6
-    dev: false
+    dev: true
     optional: true
 
   /minipass-sized@1.0.3:
@@ -20351,7 +20234,7 @@ packages:
     requiresBuild: true
     dependencies:
       minipass: 3.3.6
-    dev: false
+    dev: true
     optional: true
 
   /minipass@3.3.6:
@@ -20359,6 +20242,7 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       yallist: 4.0.0
+    dev: true
 
   /minipass@4.2.8:
     resolution: {integrity: sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==}
@@ -20368,6 +20252,7 @@ packages:
   /minipass@5.0.0:
     resolution: {integrity: sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==}
     engines: {node: '>=8'}
+    dev: true
 
   /minipass@7.1.1:
     resolution: {integrity: sha512-UZ7eQ+h8ywIRAW1hIEl2AqdwzJucU/Kp59+8kkZeSvafXhZjul247BvIJjEVFVeON6d7lM46XX1HXCduKAS8VA==}
@@ -20379,6 +20264,7 @@ packages:
     dependencies:
       minipass: 3.3.6
       yallist: 4.0.0
+    dev: true
 
   /mitt@1.2.0:
     resolution: {integrity: sha512-r6lj77KlwqLhIUku9UWYes7KJtsczvolZkzp8hbaDPPaE24OmWl5s539Mytlj22siEQKosZ26qCBgda2PKwoJw==}
@@ -20399,12 +20285,13 @@ packages:
     resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
     engines: {node: '>=10'}
     hasBin: true
+    dev: true
 
   /mkdirp@3.0.1:
     resolution: {integrity: sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==}
     engines: {node: '>=10'}
     hasBin: true
-    dev: false
+    dev: true
 
   /mlly@1.7.0:
     resolution: {integrity: sha512-U9SDaXGEREBYQgfejV97coK0UL1r+qnF2SyO9A3qcI8MzKnsIFKHNVEkrDyNncQTKQQumsasmeq84eNMdBfsNQ==}
@@ -20577,7 +20464,7 @@ packages:
   /nan@2.18.0:
     resolution: {integrity: sha512-W7tfG7vMOGtD30sHoZSSc/JVYiyDPEyQVso/Zz+/uQd0B0L46gtC+pHha5FFMRpil6fm/AoEcRWyOVi4+E/f8w==}
     requiresBuild: true
-    dev: false
+    dev: true
     optional: true
 
   /nanoid@3.3.7:
@@ -20632,6 +20519,7 @@ packages:
   /negotiator@0.6.3:
     resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
     engines: {node: '>= 0.6'}
+    dev: true
 
   /neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
@@ -20646,6 +20534,7 @@ packages:
     dependencies:
       lower-case: 2.0.2
       tslib: 2.6.2
+    dev: true
 
   /node-abi@3.62.0:
     resolution: {integrity: sha512-CPMcGa+y33xuL1E0TcNIu4YyaZCxnnvkVaEXrsosR3FxN+fV8xvb7Mzpb7IgKler10qeMkE6+Dp8qJhpzdq35g==}
@@ -20729,7 +20618,7 @@ packages:
       which: 4.0.0
     transitivePeerDependencies:
       - supports-color
-    dev: false
+    dev: true
     optional: true
 
   /node-html-parser@5.4.2:
@@ -20741,6 +20630,7 @@ packages:
 
   /node-int64@0.4.0:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
+    dev: true
 
   /node-libcurl@4.0.0:
     resolution: {integrity: sha512-v+u+OgSq6ldvf8MrdjieAy/mv8WeTN94nrTomh62zhItF2HH0Ckin/QEqs8+35DWyYrE5nBM2480UtWVXktzbQ==}
@@ -20757,7 +20647,7 @@ packages:
     transitivePeerDependencies:
       - encoding
       - supports-color
-    dev: false
+    dev: true
     optional: true
 
   /node-object-hash@2.3.10:
@@ -20787,7 +20677,7 @@ packages:
     requiresBuild: true
     dependencies:
       abbrev: 1.1.1
-    dev: false
+    dev: true
     optional: true
 
   /nopt@7.2.1:
@@ -20797,7 +20687,7 @@ packages:
     requiresBuild: true
     dependencies:
       abbrev: 2.0.0
-    dev: false
+    dev: true
     optional: true
 
   /normalize-path@2.1.1:
@@ -20805,6 +20695,7 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       remove-trailing-separator: 1.1.0
+    dev: true
 
   /normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
@@ -20846,7 +20737,7 @@ packages:
       console-control-strings: 1.1.0
       gauge: 3.0.2
       set-blocking: 2.0.0
-    dev: false
+    dev: true
     optional: true
 
   /npmlog@7.0.1:
@@ -20858,7 +20749,7 @@ packages:
       console-control-strings: 1.1.0
       gauge: 5.0.2
       set-blocking: 2.0.0
-    dev: false
+    dev: true
     optional: true
 
   /nth-check@2.1.1:
@@ -20880,6 +20771,7 @@ packages:
 
   /nullthrows@1.1.1:
     resolution: {integrity: sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==}
+    dev: true
 
   /number-to-bn@1.7.0:
     resolution: {integrity: sha512-wsJ9gfSz1/s4ZsJN01lyonwuxA1tml6X1yBDnfpMglypcBRFZZkus26EdPSlqS5GJfYddVZa22p3VNb3z5m5Ig==}
@@ -20899,7 +20791,6 @@ packages:
 
   /object-inspect@1.12.3:
     resolution: {integrity: sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==}
-    dev: false
 
   /object-inspect@1.13.1:
     resolution: {integrity: sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==}
@@ -21035,6 +20926,7 @@ packages:
     dependencies:
       is-docker: 2.2.1
       is-wsl: 2.2.0
+    dev: true
 
   /open@8.4.2:
     resolution: {integrity: sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==}
@@ -21058,7 +20950,6 @@ packages:
       '@wry/context': 0.7.4
       '@wry/trie': 0.4.3
       tslib: 2.6.2
-    dev: false
     optional: true
 
   /optionator@0.8.3:
@@ -21170,6 +21061,7 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       yocto-queue: 0.1.0
+    dev: true
 
   /p-locate@2.0.0:
     resolution: {integrity: sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==}
@@ -21203,6 +21095,7 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       aggregate-error: 3.1.0
+    dev: true
 
   /p-try@1.0.0:
     resolution: {integrity: sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==}
@@ -21232,12 +21125,14 @@ packages:
     dependencies:
       dot-case: 3.0.4
       tslib: 2.6.2
+    dev: true
 
   /parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
     dependencies:
       callsites: 3.1.0
+    dev: true
 
   /parents@1.0.1:
     resolution: {integrity: sha512-mXKF3xkoUt5td2DoxpLmtOmZvko9VfFpwRwkKDHSNvgmpLAeBo18YDhcPbBzJq+QLCHMbGOfzia2cX4U+0v9Mg==}
@@ -21272,6 +21167,7 @@ packages:
       is-absolute: 1.0.0
       map-cache: 0.2.2
       path-root: 0.1.1
+    dev: true
 
   /parse-json@5.2.0:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
@@ -21281,6 +21177,7 @@ packages:
       error-ex: 1.3.2
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
+    dev: true
 
   /parse-path@7.0.0:
     resolution: {integrity: sha512-Euf9GG8WT9CdqwuWJGdf3RkUcTBArppHABkO7Lm8IzRQp0e2r/kkFnmhu4TSK30Wcu5rVAZLmfPKSBBi9tWFog==}
@@ -21304,6 +21201,7 @@ packages:
     dependencies:
       no-case: 3.0.4
       tslib: 2.6.2
+    dev: true
 
   /password-prompt@1.1.3:
     resolution: {integrity: sha512-HkrjG2aJlvF0t2BMH0e2LB/EHf3Lcq3fNMzy4GYHcQblAvOl+QQji1Lx7WRBMqpVK8p+KR7bCg7oqAMXtdgqyw==}
@@ -21320,6 +21218,7 @@ packages:
     dependencies:
       dot-case: 3.0.4
       tslib: 2.6.2
+    dev: true
 
   /path-exists@3.0.0:
     resolution: {integrity: sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==}
@@ -21333,6 +21232,7 @@ packages:
   /path-is-absolute@1.0.1:
     resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
     engines: {node: '>=0.10.0'}
+    dev: true
 
   /path-is-inside@1.0.2:
     resolution: {integrity: sha512-DUWJr3+ULp4zXmol/SZkFf3JGsS9/SIv+Y3Rt93/UjPpDpklB5f1er4O3POIbUuUJ3FXgqte2Q7SrU6zAqwk8w==}
@@ -21357,12 +21257,14 @@ packages:
   /path-root-regex@0.1.2:
     resolution: {integrity: sha512-4GlJ6rZDhQZFE0DPVKh0e9jmZ5egZfxTkp7bcRDuPlJXbAwhxcl2dINPUAsjLdejqaLsCeg8axcLjIbvBjN4pQ==}
     engines: {node: '>=0.10.0'}
+    dev: true
 
   /path-root@0.1.1:
     resolution: {integrity: sha512-QLcPegTHF11axjfojBIoDygmS2E3Lf+8+jI6wOVmNVenrKSo3mFdSGiIgdSHenczw3wPtlVMQaFVwGmM7BJdtg==}
     engines: {node: '>=0.10.0'}
     dependencies:
       path-root-regex: 0.1.2
+    dev: true
 
   /path-scurry@1.11.1:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
@@ -21382,6 +21284,7 @@ packages:
   /path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
+    dev: true
 
   /pathe@1.1.2:
     resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
@@ -22054,14 +21957,14 @@ packages:
     resolution: {integrity: sha512-++Vn7NS4Xf9NacaU9Xq3URUuqZETPsf8L4j5/ckhaRYsfPeRyzGw+iDjFhV/Jr3uNmTvvddEJFWh5R1gRgUH8A==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
     requiresBuild: true
-    dev: false
+    dev: true
     optional: true
 
   /proc-log@4.2.0:
     resolution: {integrity: sha512-g8+OnU/L2v+wyiVK+D5fA34J7EH8jZ8DDlvwhRCMxmMj7UCBvxiO1mGeN+36JXIKF4zevU4kRBd8lVgG9vLelA==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
     requiresBuild: true
-    dev: false
+    dev: true
     optional: true
 
   /process-nextick-args@2.0.1:
@@ -22089,7 +21992,7 @@ packages:
     dependencies:
       err-code: 2.0.3
       retry: 0.12.0
-    dev: false
+    dev: true
     optional: true
 
   /promise@7.3.1:
@@ -22851,7 +22754,6 @@ packages:
     dependencies:
       '@types/react': 18.3.2
       react: 18.3.1
-    dev: false
     optional: true
 
   /relay-runtime@12.0.0:
@@ -22862,9 +22764,11 @@ packages:
       invariant: 2.2.4
     transitivePeerDependencies:
       - encoding
+    dev: true
 
   /remove-trailing-separator@1.1.0:
     resolution: {integrity: sha512-/hS+Y0u3aOfIETiaiirUFwDBDzmXPvO+jAfKTitUngIPzdKc6Z0LoFjM/CK5PL4C+eKwHohlHAb6H0VFfmmUsw==}
+    dev: true
 
   /renderkid@2.0.7:
     resolution: {integrity: sha512-oCcFyxaMrKsKcTY59qnCAtmDVSLfPbrv6A3tVbPdFMMrv5jaK10V6m40cKsoPNhAqN6rmHW9sswW4o3ruSrwUQ==}
@@ -22932,10 +22836,12 @@ packages:
   /resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
+    dev: true
 
   /resolve-from@5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
+    dev: true
 
   /resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
@@ -22977,7 +22883,6 @@ packages:
     resolution: {integrity: sha512-pVzEEzrsg23Sh053rmDUvLSkGXluZio0qu8VT6ukrYuvtjVfCbDZH9d6PGXb8HZfzdNZt8feXv/jvUzlhRgLnw==}
     engines: {node: '>=0.8'}
     requiresBuild: true
-    dev: false
     optional: true
 
   /responselike@2.0.1:
@@ -23008,6 +22913,7 @@ packages:
   /retry@0.12.0:
     resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
     engines: {node: '>= 4'}
+    dev: true
 
   /retry@0.13.1:
     resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
@@ -23033,6 +22939,7 @@ packages:
     hasBin: true
     dependencies:
       glob: 7.2.3
+    dev: true
 
   /rimraf@5.0.5:
     resolution: {integrity: sha512-CqDakW+hMe/Bz202FPEymy68P+G50RfMQK+Qo5YUqc9SPipvbGjCGKd0RSKEelbsfQuw3g5NZDSrlZZAJurH1A==}
@@ -23041,7 +22948,7 @@ packages:
     requiresBuild: true
     dependencies:
       glob: 10.3.15
-    dev: false
+    dev: true
     optional: true
 
   /rimraf@5.0.7:
@@ -23050,7 +22957,7 @@ packages:
     hasBin: true
     dependencies:
       glob: 10.3.15
-    dev: false
+    dev: true
 
   /ripemd160@2.0.2:
     resolution: {integrity: sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==}
@@ -23122,6 +23029,7 @@ packages:
 
   /safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+    dev: true
 
   /sc-istanbul@0.4.6:
     resolution: {integrity: sha512-qJFF/8tW/zJsbyfh/iT/ZM5QNHE3CXxtLJbZsL+CzdJLBsPD7SedJZoUA4d8iAcN2IoMp/Dx80shOOd2x96X/g==}
@@ -23240,6 +23148,7 @@ packages:
       no-case: 3.0.4
       tslib: 2.6.2
       upper-case-first: 2.0.2
+    dev: true
 
   /serialize-javascript@5.0.1:
     resolution: {integrity: sha512-SaaNal9imEO737H2c05Og0/8LUXG7EnsZyMa8MzkmuHoELfT6txuj0cMqRj6zfPKnmQ1yasR4PCJc8x+M4JSPA==}
@@ -23407,6 +23316,7 @@ packages:
 
   /signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
+    dev: true
 
   /signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
@@ -23414,6 +23324,7 @@ packages:
 
   /signedsource@1.0.0:
     resolution: {integrity: sha512-6+eerH9fEnNmi/hyM1DXcRK3pWdoMQtlkQ+ns0ntzunjKqp5i3sKCc80ym8Fib3iaYhdJUOPdhlJWj1tvge2Ww==}
+    dev: true
 
   /simple-concat@1.0.1:
     resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
@@ -23440,6 +23351,7 @@ packages:
   /slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
+    dev: true
 
   /slash@4.0.0:
     resolution: {integrity: sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==}
@@ -23464,7 +23376,7 @@ packages:
     resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
     engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
     requiresBuild: true
-    dev: false
+    dev: true
     optional: true
 
   /snake-case@3.0.4:
@@ -23472,6 +23384,7 @@ packages:
     dependencies:
       dot-case: 3.0.4
       tslib: 2.6.2
+    dev: true
 
   /socket.io-adapter@2.5.4:
     resolution: {integrity: sha512-wDNHGXGewWAjQPt3pyeYBtpWSq9cLE5UW1ZUPL/2eGK9jtse/FpXib7epSTsz0Q0m+6sg6Y4KtcFTlah1bdOVg==}
@@ -23535,7 +23448,7 @@ packages:
       socks: 2.8.3
     transitivePeerDependencies:
       - supports-color
-    dev: false
+    dev: true
     optional: true
 
   /socks@2.8.3:
@@ -23545,7 +23458,7 @@ packages:
     dependencies:
       ip-address: 9.0.5
       smart-buffer: 4.2.0
-    dev: false
+    dev: true
     optional: true
 
   /solc@0.7.3(debug@4.3.4):
@@ -23762,6 +23675,7 @@ packages:
     resolution: {integrity: sha512-dblb9Et4DAtiZ5YSUZHLl4XhH4uK80GhAZrVXdN4O2P4gQ40Wa5UIOPUHlA/nFd2PLblBZWUioLMMAVrgpoYcA==}
     dependencies:
       tslib: 2.6.2
+    dev: true
 
   /sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
@@ -23770,7 +23684,7 @@ packages:
   /sprintf-js@1.1.3:
     resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
     requiresBuild: true
-    dev: false
+    dev: true
     optional: true
 
   /ssri@10.0.6:
@@ -23779,7 +23693,7 @@ packages:
     requiresBuild: true
     dependencies:
       minipass: 7.1.1
-    dev: false
+    dev: true
     optional: true
 
   /stable@0.1.8:
@@ -23912,7 +23826,6 @@ packages:
   /string-similarity@4.0.4:
     resolution: {integrity: sha512-/q/8Q4Bl4ZKAPjj8WerIBJWALKkaPRfrvhfF8k/B23i4nzrlRj2/go1m90In7nG/3XDSbOo0+pu6RvCTM9RGMQ==}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
-    dev: false
 
   /string-width@2.1.1:
     resolution: {integrity: sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==}
@@ -24034,6 +23947,7 @@ packages:
   /strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
+    dev: true
 
   /strip-bom@4.0.0:
     resolution: {integrity: sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==}
@@ -24213,6 +24127,7 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       has-flag: 4.0.0
+    dev: true
 
   /supports-color@8.1.1:
     resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
@@ -24255,6 +24170,7 @@ packages:
     resolution: {integrity: sha512-kc6S2YS/2yXbtkSMunBtKdah4VFETZ8Oh6ONSmSd9bRxhqTrtARUCBUiWXH3xVPpvR7tz2CSnkuXVE42EcGnMw==}
     dependencies:
       tslib: 2.6.2
+    dev: true
 
   /swc-loader@0.2.6(@swc/core@1.3.78)(webpack@5.91.0):
     resolution: {integrity: sha512-9Zi9UP2YmDpgmQVbyOPJClY0dwf58JDyDMQ7uRc4krmc72twNI2fvlBWHLqVekBpPc7h5NJkGVT1zNDxFrqhvg==}
@@ -24281,7 +24197,6 @@ packages:
     resolution: {integrity: sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==}
     engines: {node: '>=0.10'}
     requiresBuild: true
-    dev: false
     optional: true
 
   /sync-request@6.1.0:
@@ -24470,6 +24385,7 @@ packages:
       minizlib: 2.1.2
       mkdirp: 1.0.4
       yallist: 4.0.0
+    dev: true
 
   /terser-webpack-plugin@5.3.10(@swc/core@1.3.78)(webpack@5.91.0):
     resolution: {integrity: sha512-BKFPWlPDndPs+NGGCr1U59t0XScL5317Y0UReNrHaw9/FwhPENlq6bfgs+4yPfyP51vqC1bQ4rp1EfXW5ZSH9w==}
@@ -24636,12 +24552,12 @@ packages:
   /tiny-lru@11.2.6:
     resolution: {integrity: sha512-0PU3c9PjMnltZaFo2sGYv/nnJsMjG0Cxx8X6FXHPPGjFyoo1SJDxvUXW1207rdiSxYizf31roo+GrkIByQeZoA==}
     engines: {node: '>=12'}
-    dev: false
 
   /title-case@3.0.3:
     resolution: {integrity: sha512-e1zGYRvbffpcHIrnuqT0Dh+gEJtDaxDSoG4JAIpq4oDFyooziLBIiYQv0GBT4FUAnUop5uZ1hiIAj7oAF6sOCA==}
     dependencies:
       tslib: 2.6.2
+    dev: true
 
   /tmp-promise@3.0.3:
     resolution: {integrity: sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==}
@@ -24748,7 +24664,6 @@ packages:
     requiresBuild: true
     dependencies:
       tslib: 2.6.2
-    dev: false
     optional: true
 
   /ts-jest@29.1.2(@babel/core@7.24.5)(babel-jest@29.7.0)(jest@29.7.0)(typescript@4.9.5):
@@ -24912,6 +24827,7 @@ packages:
       typescript: 5.4.5
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
+    dev: true
 
   /tsconfck@3.0.3(typescript@5.2.2):
     resolution: {integrity: sha512-4t0noZX9t6GcPTfBAbIbbIU4pfpCwh0ueq3S4O/5qXI1VwK1outmxhe9dOiEWqMz3MW2LKgDTpqWV+37IWuVbA==}
@@ -24942,7 +24858,7 @@ packages:
       json5: 2.2.3
       minimist: 1.2.8
       strip-bom: 3.0.0
-    dev: false
+    dev: true
 
   /tslib@1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
@@ -24953,10 +24869,10 @@ packages:
 
   /tslib@2.4.1:
     resolution: {integrity: sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==}
+    dev: true
 
   /tslib@2.6.0:
     resolution: {integrity: sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==}
-    dev: false
 
   /tslib@2.6.2:
     resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
@@ -25201,6 +25117,7 @@ packages:
   /unc-path-regex@0.1.2:
     resolution: {integrity: sha512-eXL4nmJT7oCpkZsHZUOJo8hcX3GbsiDOa0Qu9F646fi8dT3XuSVopVqAcEiVzSKKH7UoDti23wNX3qGFxcW5Qg==}
     engines: {node: '>=0.10.0'}
+    dev: true
 
   /uncrypto@0.1.3:
     resolution: {integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==}
@@ -25274,7 +25191,7 @@ packages:
     requiresBuild: true
     dependencies:
       unique-slug: 4.0.0
-    dev: false
+    dev: true
     optional: true
 
   /unique-slug@4.0.0:
@@ -25283,7 +25200,7 @@ packages:
     requiresBuild: true
     dependencies:
       imurmurhash: 0.1.4
-    dev: false
+    dev: true
     optional: true
 
   /unique-string@2.0.0:
@@ -25308,6 +25225,7 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       normalize-path: 2.1.1
+    dev: true
 
   /unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
@@ -25396,11 +25314,13 @@ packages:
     resolution: {integrity: sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==}
     dependencies:
       tslib: 2.6.2
+    dev: true
 
   /upper-case@2.0.2:
     resolution: {integrity: sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==}
     dependencies:
       tslib: 2.6.2
+    dev: true
 
   /uqr@0.1.2:
     resolution: {integrity: sha512-MJu7ypHq6QasgF5YRTjqscSzQp/W11zoUk6kvmlH+fmWEs63Y0Eib13hYFwAzagRJcVY8WVnlV+eBDUGMJ5IbA==}
@@ -25437,7 +25357,6 @@ packages:
 
   /urlpattern-polyfill@10.0.0:
     resolution: {integrity: sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg==}
-    dev: false
 
   /urlpattern-polyfill@8.0.2:
     resolution: {integrity: sha512-Qp95D4TPJl1kC9SKigDcqgyM2VDVO4RiJc2d4qe5GrYm+zbIQCWWKAFaJNQ4BhdFeDGwBmAxqJBwWSJDb9T3BQ==}
@@ -25583,6 +25502,7 @@ packages:
 
   /v8-compile-cache-lib@3.0.1:
     resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
+    dev: true
 
   /v8-compile-cache@2.4.0:
     resolution: {integrity: sha512-ocyWc3bAHBB/guyqJQVI5o4BZkPhznPYUG2ea80Gond/BgNWpap8TOmLSeeQG7bnh2KMISxskdADG59j7zruhw==}
@@ -26112,7 +26032,7 @@ packages:
     requiresBuild: true
     dependencies:
       isexe: 3.1.1
-    dev: false
+    dev: true
     optional: true
 
   /wide-align@1.1.5:
@@ -26120,7 +26040,7 @@ packages:
     requiresBuild: true
     dependencies:
       string-width: 4.2.3
-    dev: false
+    dev: true
     optional: true
 
   /widest-line@3.1.0:
@@ -26261,7 +26181,6 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
-    dev: false
 
   /ws@8.5.0:
     resolution: {integrity: sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==}
@@ -26304,6 +26223,7 @@ packages:
   /y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
+    dev: true
 
   /yallist@2.1.2:
     resolution: {integrity: sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==}
@@ -26314,6 +26234,7 @@ packages:
 
   /yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
+    dev: true
 
   /yaml-loader@0.8.1:
     resolution: {integrity: sha512-BCEndnUoi3BaZmePkwGGe93txRxLgMhBa/gE725v1/GHnura8QvNs7c4+4C1yyhhKoj3Dg63M7IqhA++15j6ww==}
@@ -26349,6 +26270,7 @@ packages:
   /yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
+    dev: true
 
   /yargs-unparser@2.0.0:
     resolution: {integrity: sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==}
@@ -26400,14 +26322,17 @@ packages:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
+    dev: true
 
   /yn@3.1.1:
     resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}
     engines: {node: '>=6'}
+    dev: true
 
   /yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+    dev: true
 
   /yoga-layout-prebuilt@1.10.0:
     resolution: {integrity: sha512-YnOmtSbv4MTf7RGJMK0FvZ+KD8OEe/J5BNnR0GHhD8J/XcG/Qvxgszm0Un6FTHWW4uHlTgP0IztiXQnGyIR45g==}
@@ -26432,13 +26357,11 @@ packages:
     requiresBuild: true
     dependencies:
       zen-observable: 0.8.15
-    dev: false
     optional: true
 
   /zen-observable@0.8.15:
     resolution: {integrity: sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==}
     requiresBuild: true
-    dev: false
     optional: true
 
   /zustand@4.5.2(@types/react@18.3.2)(react@18.3.1):
@@ -26461,8 +26384,8 @@ packages:
       use-sync-external-store: 1.2.0(react@18.3.1)
     dev: false
 
-  github.com/uNetworking/uWebSockets.js/8fa05571bf6ea95be8966ad313d9d39453e381ae:
-    resolution: {tarball: https://codeload.github.com/uNetworking/uWebSockets.js/tar.gz/8fa05571bf6ea95be8966ad313d9d39453e381ae}
+  github.com/uNetworking/uWebSockets.js/6f4b450fc642abba540535f0755c990b42a16026:
+    resolution: {tarball: https://codeload.github.com/uNetworking/uWebSockets.js/tar.gz/6f4b450fc642abba540535f0755c990b42a16026}
     name: uWebSockets.js
-    version: 20.44.0
-    dev: false
+    version: 20.47.0
+    dev: true

--- a/sdk/.graphclient/index.ts
+++ b/sdk/.graphclient/index.ts
@@ -23,148 +23,193 @@ export type InputMaybe<T> = Maybe<T>;
 export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
 export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
 export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
+export type MakeEmpty<T extends { [key: string]: unknown }, K extends keyof T> = { [_ in K]?: never };
+export type Incremental<T> = T | { [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never };
 export type RequireFields<T, K extends keyof T> = Omit<T, K> & { [P in K]-?: NonNullable<T[P]> };
 
 
 
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
-  ID: string;
-  String: string;
-  Boolean: boolean;
-  Int: number;
-  Float: number;
-  BigDecimal: any;
-  BigInt: any;
-  Bytes: any;
+  ID: { input: string; output: string; }
+  String: { input: string; output: string; }
+  Boolean: { input: boolean; output: boolean; }
+  Int: { input: number; output: number; }
+  Float: { input: number; output: number; }
+  BigDecimal: { input: any; output: any; }
+  BigInt: { input: any; output: any; }
+  Bytes: { input: any; output: any; }
+  Int8: { input: any; output: any; }
+  Timestamp: { input: any; output: any; }
 };
 
+export type Aggregation_interval =
+  | 'hour'
+  | 'day';
+
 export type Attestation = {
-  id: Scalars['ID'];
-  schemaId: Scalars['Bytes'];
-  replacedBy: Scalars['Bytes'];
-  attester: Scalars['Bytes'];
-  portal: Scalars['Bytes'];
-  attestedDate: Scalars['BigInt'];
-  expirationDate: Scalars['BigInt'];
-  revocationDate: Scalars['BigInt'];
-  version: Scalars['BigInt'];
-  revoked: Scalars['Boolean'];
-  subject: Scalars['Bytes'];
-  attestationData: Scalars['Bytes'];
-  schemaString?: Maybe<Scalars['String']>;
-  decodedData?: Maybe<Array<Scalars['String']>>;
+  id: Scalars['ID']['output'];
+  schemaId: Scalars['Bytes']['output'];
+  replacedBy: Scalars['Bytes']['output'];
+  attester: Scalars['Bytes']['output'];
+  portal: Scalars['Bytes']['output'];
+  attestedDate: Scalars['BigInt']['output'];
+  expirationDate: Scalars['BigInt']['output'];
+  revocationDate: Scalars['BigInt']['output'];
+  version: Scalars['BigInt']['output'];
+  revoked: Scalars['Boolean']['output'];
+  subject: Scalars['Bytes']['output'];
+  encodedSubject: Scalars['Bytes']['output'];
+  attestationData: Scalars['Bytes']['output'];
+  schemaString?: Maybe<Scalars['String']['output']>;
+  decodedData?: Maybe<Array<Scalars['String']['output']>>;
 };
 
 export type Attestation_filter = {
-  id?: InputMaybe<Scalars['ID']>;
-  id_not?: InputMaybe<Scalars['ID']>;
-  id_gt?: InputMaybe<Scalars['ID']>;
-  id_lt?: InputMaybe<Scalars['ID']>;
-  id_gte?: InputMaybe<Scalars['ID']>;
-  id_lte?: InputMaybe<Scalars['ID']>;
-  id_in?: InputMaybe<Array<Scalars['ID']>>;
-  id_not_in?: InputMaybe<Array<Scalars['ID']>>;
-  schemaId?: InputMaybe<Scalars['Bytes']>;
-  schemaId_not?: InputMaybe<Scalars['Bytes']>;
-  schemaId_in?: InputMaybe<Array<Scalars['Bytes']>>;
-  schemaId_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
-  schemaId_contains?: InputMaybe<Scalars['Bytes']>;
-  schemaId_not_contains?: InputMaybe<Scalars['Bytes']>;
-  replacedBy?: InputMaybe<Scalars['Bytes']>;
-  replacedBy_not?: InputMaybe<Scalars['Bytes']>;
-  replacedBy_in?: InputMaybe<Array<Scalars['Bytes']>>;
-  replacedBy_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
-  replacedBy_contains?: InputMaybe<Scalars['Bytes']>;
-  replacedBy_not_contains?: InputMaybe<Scalars['Bytes']>;
-  attester?: InputMaybe<Scalars['Bytes']>;
-  attester_not?: InputMaybe<Scalars['Bytes']>;
-  attester_in?: InputMaybe<Array<Scalars['Bytes']>>;
-  attester_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
-  attester_contains?: InputMaybe<Scalars['Bytes']>;
-  attester_not_contains?: InputMaybe<Scalars['Bytes']>;
-  portal?: InputMaybe<Scalars['Bytes']>;
-  portal_not?: InputMaybe<Scalars['Bytes']>;
-  portal_in?: InputMaybe<Array<Scalars['Bytes']>>;
-  portal_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
-  portal_contains?: InputMaybe<Scalars['Bytes']>;
-  portal_not_contains?: InputMaybe<Scalars['Bytes']>;
-  attestedDate?: InputMaybe<Scalars['BigInt']>;
-  attestedDate_not?: InputMaybe<Scalars['BigInt']>;
-  attestedDate_gt?: InputMaybe<Scalars['BigInt']>;
-  attestedDate_lt?: InputMaybe<Scalars['BigInt']>;
-  attestedDate_gte?: InputMaybe<Scalars['BigInt']>;
-  attestedDate_lte?: InputMaybe<Scalars['BigInt']>;
-  attestedDate_in?: InputMaybe<Array<Scalars['BigInt']>>;
-  attestedDate_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
-  expirationDate?: InputMaybe<Scalars['BigInt']>;
-  expirationDate_not?: InputMaybe<Scalars['BigInt']>;
-  expirationDate_gt?: InputMaybe<Scalars['BigInt']>;
-  expirationDate_lt?: InputMaybe<Scalars['BigInt']>;
-  expirationDate_gte?: InputMaybe<Scalars['BigInt']>;
-  expirationDate_lte?: InputMaybe<Scalars['BigInt']>;
-  expirationDate_in?: InputMaybe<Array<Scalars['BigInt']>>;
-  expirationDate_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
-  revocationDate?: InputMaybe<Scalars['BigInt']>;
-  revocationDate_not?: InputMaybe<Scalars['BigInt']>;
-  revocationDate_gt?: InputMaybe<Scalars['BigInt']>;
-  revocationDate_lt?: InputMaybe<Scalars['BigInt']>;
-  revocationDate_gte?: InputMaybe<Scalars['BigInt']>;
-  revocationDate_lte?: InputMaybe<Scalars['BigInt']>;
-  revocationDate_in?: InputMaybe<Array<Scalars['BigInt']>>;
-  revocationDate_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
-  version?: InputMaybe<Scalars['BigInt']>;
-  version_not?: InputMaybe<Scalars['BigInt']>;
-  version_gt?: InputMaybe<Scalars['BigInt']>;
-  version_lt?: InputMaybe<Scalars['BigInt']>;
-  version_gte?: InputMaybe<Scalars['BigInt']>;
-  version_lte?: InputMaybe<Scalars['BigInt']>;
-  version_in?: InputMaybe<Array<Scalars['BigInt']>>;
-  version_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
-  revoked?: InputMaybe<Scalars['Boolean']>;
-  revoked_not?: InputMaybe<Scalars['Boolean']>;
-  revoked_in?: InputMaybe<Array<Scalars['Boolean']>>;
-  revoked_not_in?: InputMaybe<Array<Scalars['Boolean']>>;
-  subject?: InputMaybe<Scalars['Bytes']>;
-  subject_not?: InputMaybe<Scalars['Bytes']>;
-  subject_in?: InputMaybe<Array<Scalars['Bytes']>>;
-  subject_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
-  subject_contains?: InputMaybe<Scalars['Bytes']>;
-  subject_not_contains?: InputMaybe<Scalars['Bytes']>;
-  attestationData?: InputMaybe<Scalars['Bytes']>;
-  attestationData_not?: InputMaybe<Scalars['Bytes']>;
-  attestationData_in?: InputMaybe<Array<Scalars['Bytes']>>;
-  attestationData_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
-  attestationData_contains?: InputMaybe<Scalars['Bytes']>;
-  attestationData_not_contains?: InputMaybe<Scalars['Bytes']>;
-  schemaString?: InputMaybe<Scalars['String']>;
-  schemaString_not?: InputMaybe<Scalars['String']>;
-  schemaString_gt?: InputMaybe<Scalars['String']>;
-  schemaString_lt?: InputMaybe<Scalars['String']>;
-  schemaString_gte?: InputMaybe<Scalars['String']>;
-  schemaString_lte?: InputMaybe<Scalars['String']>;
-  schemaString_in?: InputMaybe<Array<Scalars['String']>>;
-  schemaString_not_in?: InputMaybe<Array<Scalars['String']>>;
-  schemaString_contains?: InputMaybe<Scalars['String']>;
-  schemaString_contains_nocase?: InputMaybe<Scalars['String']>;
-  schemaString_not_contains?: InputMaybe<Scalars['String']>;
-  schemaString_not_contains_nocase?: InputMaybe<Scalars['String']>;
-  schemaString_starts_with?: InputMaybe<Scalars['String']>;
-  schemaString_starts_with_nocase?: InputMaybe<Scalars['String']>;
-  schemaString_not_starts_with?: InputMaybe<Scalars['String']>;
-  schemaString_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
-  schemaString_ends_with?: InputMaybe<Scalars['String']>;
-  schemaString_ends_with_nocase?: InputMaybe<Scalars['String']>;
-  schemaString_not_ends_with?: InputMaybe<Scalars['String']>;
-  schemaString_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
-  decodedData?: InputMaybe<Array<Scalars['String']>>;
-  decodedData_not?: InputMaybe<Array<Scalars['String']>>;
-  decodedData_contains?: InputMaybe<Array<Scalars['String']>>;
-  decodedData_contains_nocase?: InputMaybe<Array<Scalars['String']>>;
-  decodedData_not_contains?: InputMaybe<Array<Scalars['String']>>;
-  decodedData_not_contains_nocase?: InputMaybe<Array<Scalars['String']>>;
+  id?: InputMaybe<Scalars['ID']['input']>;
+  id_not?: InputMaybe<Scalars['ID']['input']>;
+  id_gt?: InputMaybe<Scalars['ID']['input']>;
+  id_lt?: InputMaybe<Scalars['ID']['input']>;
+  id_gte?: InputMaybe<Scalars['ID']['input']>;
+  id_lte?: InputMaybe<Scalars['ID']['input']>;
+  id_in?: InputMaybe<Array<Scalars['ID']['input']>>;
+  id_not_in?: InputMaybe<Array<Scalars['ID']['input']>>;
+  schemaId?: InputMaybe<Scalars['Bytes']['input']>;
+  schemaId_not?: InputMaybe<Scalars['Bytes']['input']>;
+  schemaId_gt?: InputMaybe<Scalars['Bytes']['input']>;
+  schemaId_lt?: InputMaybe<Scalars['Bytes']['input']>;
+  schemaId_gte?: InputMaybe<Scalars['Bytes']['input']>;
+  schemaId_lte?: InputMaybe<Scalars['Bytes']['input']>;
+  schemaId_in?: InputMaybe<Array<Scalars['Bytes']['input']>>;
+  schemaId_not_in?: InputMaybe<Array<Scalars['Bytes']['input']>>;
+  schemaId_contains?: InputMaybe<Scalars['Bytes']['input']>;
+  schemaId_not_contains?: InputMaybe<Scalars['Bytes']['input']>;
+  replacedBy?: InputMaybe<Scalars['Bytes']['input']>;
+  replacedBy_not?: InputMaybe<Scalars['Bytes']['input']>;
+  replacedBy_gt?: InputMaybe<Scalars['Bytes']['input']>;
+  replacedBy_lt?: InputMaybe<Scalars['Bytes']['input']>;
+  replacedBy_gte?: InputMaybe<Scalars['Bytes']['input']>;
+  replacedBy_lte?: InputMaybe<Scalars['Bytes']['input']>;
+  replacedBy_in?: InputMaybe<Array<Scalars['Bytes']['input']>>;
+  replacedBy_not_in?: InputMaybe<Array<Scalars['Bytes']['input']>>;
+  replacedBy_contains?: InputMaybe<Scalars['Bytes']['input']>;
+  replacedBy_not_contains?: InputMaybe<Scalars['Bytes']['input']>;
+  attester?: InputMaybe<Scalars['Bytes']['input']>;
+  attester_not?: InputMaybe<Scalars['Bytes']['input']>;
+  attester_gt?: InputMaybe<Scalars['Bytes']['input']>;
+  attester_lt?: InputMaybe<Scalars['Bytes']['input']>;
+  attester_gte?: InputMaybe<Scalars['Bytes']['input']>;
+  attester_lte?: InputMaybe<Scalars['Bytes']['input']>;
+  attester_in?: InputMaybe<Array<Scalars['Bytes']['input']>>;
+  attester_not_in?: InputMaybe<Array<Scalars['Bytes']['input']>>;
+  attester_contains?: InputMaybe<Scalars['Bytes']['input']>;
+  attester_not_contains?: InputMaybe<Scalars['Bytes']['input']>;
+  portal?: InputMaybe<Scalars['Bytes']['input']>;
+  portal_not?: InputMaybe<Scalars['Bytes']['input']>;
+  portal_gt?: InputMaybe<Scalars['Bytes']['input']>;
+  portal_lt?: InputMaybe<Scalars['Bytes']['input']>;
+  portal_gte?: InputMaybe<Scalars['Bytes']['input']>;
+  portal_lte?: InputMaybe<Scalars['Bytes']['input']>;
+  portal_in?: InputMaybe<Array<Scalars['Bytes']['input']>>;
+  portal_not_in?: InputMaybe<Array<Scalars['Bytes']['input']>>;
+  portal_contains?: InputMaybe<Scalars['Bytes']['input']>;
+  portal_not_contains?: InputMaybe<Scalars['Bytes']['input']>;
+  attestedDate?: InputMaybe<Scalars['BigInt']['input']>;
+  attestedDate_not?: InputMaybe<Scalars['BigInt']['input']>;
+  attestedDate_gt?: InputMaybe<Scalars['BigInt']['input']>;
+  attestedDate_lt?: InputMaybe<Scalars['BigInt']['input']>;
+  attestedDate_gte?: InputMaybe<Scalars['BigInt']['input']>;
+  attestedDate_lte?: InputMaybe<Scalars['BigInt']['input']>;
+  attestedDate_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  attestedDate_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  expirationDate?: InputMaybe<Scalars['BigInt']['input']>;
+  expirationDate_not?: InputMaybe<Scalars['BigInt']['input']>;
+  expirationDate_gt?: InputMaybe<Scalars['BigInt']['input']>;
+  expirationDate_lt?: InputMaybe<Scalars['BigInt']['input']>;
+  expirationDate_gte?: InputMaybe<Scalars['BigInt']['input']>;
+  expirationDate_lte?: InputMaybe<Scalars['BigInt']['input']>;
+  expirationDate_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  expirationDate_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  revocationDate?: InputMaybe<Scalars['BigInt']['input']>;
+  revocationDate_not?: InputMaybe<Scalars['BigInt']['input']>;
+  revocationDate_gt?: InputMaybe<Scalars['BigInt']['input']>;
+  revocationDate_lt?: InputMaybe<Scalars['BigInt']['input']>;
+  revocationDate_gte?: InputMaybe<Scalars['BigInt']['input']>;
+  revocationDate_lte?: InputMaybe<Scalars['BigInt']['input']>;
+  revocationDate_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  revocationDate_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  version?: InputMaybe<Scalars['BigInt']['input']>;
+  version_not?: InputMaybe<Scalars['BigInt']['input']>;
+  version_gt?: InputMaybe<Scalars['BigInt']['input']>;
+  version_lt?: InputMaybe<Scalars['BigInt']['input']>;
+  version_gte?: InputMaybe<Scalars['BigInt']['input']>;
+  version_lte?: InputMaybe<Scalars['BigInt']['input']>;
+  version_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  version_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  revoked?: InputMaybe<Scalars['Boolean']['input']>;
+  revoked_not?: InputMaybe<Scalars['Boolean']['input']>;
+  revoked_in?: InputMaybe<Array<Scalars['Boolean']['input']>>;
+  revoked_not_in?: InputMaybe<Array<Scalars['Boolean']['input']>>;
+  subject?: InputMaybe<Scalars['Bytes']['input']>;
+  subject_not?: InputMaybe<Scalars['Bytes']['input']>;
+  subject_gt?: InputMaybe<Scalars['Bytes']['input']>;
+  subject_lt?: InputMaybe<Scalars['Bytes']['input']>;
+  subject_gte?: InputMaybe<Scalars['Bytes']['input']>;
+  subject_lte?: InputMaybe<Scalars['Bytes']['input']>;
+  subject_in?: InputMaybe<Array<Scalars['Bytes']['input']>>;
+  subject_not_in?: InputMaybe<Array<Scalars['Bytes']['input']>>;
+  subject_contains?: InputMaybe<Scalars['Bytes']['input']>;
+  subject_not_contains?: InputMaybe<Scalars['Bytes']['input']>;
+  encodedSubject?: InputMaybe<Scalars['Bytes']['input']>;
+  encodedSubject_not?: InputMaybe<Scalars['Bytes']['input']>;
+  encodedSubject_gt?: InputMaybe<Scalars['Bytes']['input']>;
+  encodedSubject_lt?: InputMaybe<Scalars['Bytes']['input']>;
+  encodedSubject_gte?: InputMaybe<Scalars['Bytes']['input']>;
+  encodedSubject_lte?: InputMaybe<Scalars['Bytes']['input']>;
+  encodedSubject_in?: InputMaybe<Array<Scalars['Bytes']['input']>>;
+  encodedSubject_not_in?: InputMaybe<Array<Scalars['Bytes']['input']>>;
+  encodedSubject_contains?: InputMaybe<Scalars['Bytes']['input']>;
+  encodedSubject_not_contains?: InputMaybe<Scalars['Bytes']['input']>;
+  attestationData?: InputMaybe<Scalars['Bytes']['input']>;
+  attestationData_not?: InputMaybe<Scalars['Bytes']['input']>;
+  attestationData_gt?: InputMaybe<Scalars['Bytes']['input']>;
+  attestationData_lt?: InputMaybe<Scalars['Bytes']['input']>;
+  attestationData_gte?: InputMaybe<Scalars['Bytes']['input']>;
+  attestationData_lte?: InputMaybe<Scalars['Bytes']['input']>;
+  attestationData_in?: InputMaybe<Array<Scalars['Bytes']['input']>>;
+  attestationData_not_in?: InputMaybe<Array<Scalars['Bytes']['input']>>;
+  attestationData_contains?: InputMaybe<Scalars['Bytes']['input']>;
+  attestationData_not_contains?: InputMaybe<Scalars['Bytes']['input']>;
+  schemaString?: InputMaybe<Scalars['String']['input']>;
+  schemaString_not?: InputMaybe<Scalars['String']['input']>;
+  schemaString_gt?: InputMaybe<Scalars['String']['input']>;
+  schemaString_lt?: InputMaybe<Scalars['String']['input']>;
+  schemaString_gte?: InputMaybe<Scalars['String']['input']>;
+  schemaString_lte?: InputMaybe<Scalars['String']['input']>;
+  schemaString_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  schemaString_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  schemaString_contains?: InputMaybe<Scalars['String']['input']>;
+  schemaString_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  schemaString_not_contains?: InputMaybe<Scalars['String']['input']>;
+  schemaString_not_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  schemaString_starts_with?: InputMaybe<Scalars['String']['input']>;
+  schemaString_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  schemaString_not_starts_with?: InputMaybe<Scalars['String']['input']>;
+  schemaString_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  schemaString_ends_with?: InputMaybe<Scalars['String']['input']>;
+  schemaString_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  schemaString_not_ends_with?: InputMaybe<Scalars['String']['input']>;
+  schemaString_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  decodedData?: InputMaybe<Array<Scalars['String']['input']>>;
+  decodedData_not?: InputMaybe<Array<Scalars['String']['input']>>;
+  decodedData_contains?: InputMaybe<Array<Scalars['String']['input']>>;
+  decodedData_contains_nocase?: InputMaybe<Array<Scalars['String']['input']>>;
+  decodedData_not_contains?: InputMaybe<Array<Scalars['String']['input']>>;
+  decodedData_not_contains_nocase?: InputMaybe<Array<Scalars['String']['input']>>;
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<Attestation_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<Attestation_filter>>>;
 };
 
 export type Attestation_orderBy =
@@ -179,71 +224,74 @@ export type Attestation_orderBy =
   | 'version'
   | 'revoked'
   | 'subject'
+  | 'encodedSubject'
   | 'attestationData'
   | 'schemaString'
   | 'decodedData';
 
 export type BlockChangedFilter = {
-  number_gte: Scalars['Int'];
+  number_gte: Scalars['Int']['input'];
 };
 
 export type Block_height = {
-  hash?: InputMaybe<Scalars['Bytes']>;
-  number?: InputMaybe<Scalars['Int']>;
-  number_gte?: InputMaybe<Scalars['Int']>;
+  hash?: InputMaybe<Scalars['Bytes']['input']>;
+  number?: InputMaybe<Scalars['Int']['input']>;
+  number_gte?: InputMaybe<Scalars['Int']['input']>;
 };
 
 export type Counter = {
-  id: Scalars['ID'];
-  attestations?: Maybe<Scalars['Int']>;
-  modules?: Maybe<Scalars['Int']>;
-  portals?: Maybe<Scalars['Int']>;
-  schemas?: Maybe<Scalars['Int']>;
+  id: Scalars['ID']['output'];
+  attestations?: Maybe<Scalars['Int']['output']>;
+  modules?: Maybe<Scalars['Int']['output']>;
+  portals?: Maybe<Scalars['Int']['output']>;
+  schemas?: Maybe<Scalars['Int']['output']>;
 };
 
 export type Counter_filter = {
-  id?: InputMaybe<Scalars['ID']>;
-  id_not?: InputMaybe<Scalars['ID']>;
-  id_gt?: InputMaybe<Scalars['ID']>;
-  id_lt?: InputMaybe<Scalars['ID']>;
-  id_gte?: InputMaybe<Scalars['ID']>;
-  id_lte?: InputMaybe<Scalars['ID']>;
-  id_in?: InputMaybe<Array<Scalars['ID']>>;
-  id_not_in?: InputMaybe<Array<Scalars['ID']>>;
-  attestations?: InputMaybe<Scalars['Int']>;
-  attestations_not?: InputMaybe<Scalars['Int']>;
-  attestations_gt?: InputMaybe<Scalars['Int']>;
-  attestations_lt?: InputMaybe<Scalars['Int']>;
-  attestations_gte?: InputMaybe<Scalars['Int']>;
-  attestations_lte?: InputMaybe<Scalars['Int']>;
-  attestations_in?: InputMaybe<Array<Scalars['Int']>>;
-  attestations_not_in?: InputMaybe<Array<Scalars['Int']>>;
-  modules?: InputMaybe<Scalars['Int']>;
-  modules_not?: InputMaybe<Scalars['Int']>;
-  modules_gt?: InputMaybe<Scalars['Int']>;
-  modules_lt?: InputMaybe<Scalars['Int']>;
-  modules_gte?: InputMaybe<Scalars['Int']>;
-  modules_lte?: InputMaybe<Scalars['Int']>;
-  modules_in?: InputMaybe<Array<Scalars['Int']>>;
-  modules_not_in?: InputMaybe<Array<Scalars['Int']>>;
-  portals?: InputMaybe<Scalars['Int']>;
-  portals_not?: InputMaybe<Scalars['Int']>;
-  portals_gt?: InputMaybe<Scalars['Int']>;
-  portals_lt?: InputMaybe<Scalars['Int']>;
-  portals_gte?: InputMaybe<Scalars['Int']>;
-  portals_lte?: InputMaybe<Scalars['Int']>;
-  portals_in?: InputMaybe<Array<Scalars['Int']>>;
-  portals_not_in?: InputMaybe<Array<Scalars['Int']>>;
-  schemas?: InputMaybe<Scalars['Int']>;
-  schemas_not?: InputMaybe<Scalars['Int']>;
-  schemas_gt?: InputMaybe<Scalars['Int']>;
-  schemas_lt?: InputMaybe<Scalars['Int']>;
-  schemas_gte?: InputMaybe<Scalars['Int']>;
-  schemas_lte?: InputMaybe<Scalars['Int']>;
-  schemas_in?: InputMaybe<Array<Scalars['Int']>>;
-  schemas_not_in?: InputMaybe<Array<Scalars['Int']>>;
+  id?: InputMaybe<Scalars['ID']['input']>;
+  id_not?: InputMaybe<Scalars['ID']['input']>;
+  id_gt?: InputMaybe<Scalars['ID']['input']>;
+  id_lt?: InputMaybe<Scalars['ID']['input']>;
+  id_gte?: InputMaybe<Scalars['ID']['input']>;
+  id_lte?: InputMaybe<Scalars['ID']['input']>;
+  id_in?: InputMaybe<Array<Scalars['ID']['input']>>;
+  id_not_in?: InputMaybe<Array<Scalars['ID']['input']>>;
+  attestations?: InputMaybe<Scalars['Int']['input']>;
+  attestations_not?: InputMaybe<Scalars['Int']['input']>;
+  attestations_gt?: InputMaybe<Scalars['Int']['input']>;
+  attestations_lt?: InputMaybe<Scalars['Int']['input']>;
+  attestations_gte?: InputMaybe<Scalars['Int']['input']>;
+  attestations_lte?: InputMaybe<Scalars['Int']['input']>;
+  attestations_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  attestations_not_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  modules?: InputMaybe<Scalars['Int']['input']>;
+  modules_not?: InputMaybe<Scalars['Int']['input']>;
+  modules_gt?: InputMaybe<Scalars['Int']['input']>;
+  modules_lt?: InputMaybe<Scalars['Int']['input']>;
+  modules_gte?: InputMaybe<Scalars['Int']['input']>;
+  modules_lte?: InputMaybe<Scalars['Int']['input']>;
+  modules_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  modules_not_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  portals?: InputMaybe<Scalars['Int']['input']>;
+  portals_not?: InputMaybe<Scalars['Int']['input']>;
+  portals_gt?: InputMaybe<Scalars['Int']['input']>;
+  portals_lt?: InputMaybe<Scalars['Int']['input']>;
+  portals_gte?: InputMaybe<Scalars['Int']['input']>;
+  portals_lte?: InputMaybe<Scalars['Int']['input']>;
+  portals_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  portals_not_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  schemas?: InputMaybe<Scalars['Int']['input']>;
+  schemas_not?: InputMaybe<Scalars['Int']['input']>;
+  schemas_gt?: InputMaybe<Scalars['Int']['input']>;
+  schemas_lt?: InputMaybe<Scalars['Int']['input']>;
+  schemas_gte?: InputMaybe<Scalars['Int']['input']>;
+  schemas_lte?: InputMaybe<Scalars['Int']['input']>;
+  schemas_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  schemas_not_in?: InputMaybe<Array<Scalars['Int']['input']>>;
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<Counter_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<Counter_filter>>>;
 };
 
 export type Counter_orderBy =
@@ -253,70 +301,98 @@ export type Counter_orderBy =
   | 'portals'
   | 'schemas';
 
+export type Issuer = {
+  id: Scalars['ID']['output'];
+};
+
+export type Issuer_filter = {
+  id?: InputMaybe<Scalars['ID']['input']>;
+  id_not?: InputMaybe<Scalars['ID']['input']>;
+  id_gt?: InputMaybe<Scalars['ID']['input']>;
+  id_lt?: InputMaybe<Scalars['ID']['input']>;
+  id_gte?: InputMaybe<Scalars['ID']['input']>;
+  id_lte?: InputMaybe<Scalars['ID']['input']>;
+  id_in?: InputMaybe<Array<Scalars['ID']['input']>>;
+  id_not_in?: InputMaybe<Array<Scalars['ID']['input']>>;
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<Issuer_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<Issuer_filter>>>;
+};
+
+export type Issuer_orderBy =
+  | 'id';
+
 export type Module = {
-  id: Scalars['ID'];
-  moduleAddress: Scalars['Bytes'];
-  name: Scalars['String'];
-  description: Scalars['String'];
+  id: Scalars['ID']['output'];
+  moduleAddress: Scalars['Bytes']['output'];
+  name: Scalars['String']['output'];
+  description: Scalars['String']['output'];
 };
 
 export type Module_filter = {
-  id?: InputMaybe<Scalars['ID']>;
-  id_not?: InputMaybe<Scalars['ID']>;
-  id_gt?: InputMaybe<Scalars['ID']>;
-  id_lt?: InputMaybe<Scalars['ID']>;
-  id_gte?: InputMaybe<Scalars['ID']>;
-  id_lte?: InputMaybe<Scalars['ID']>;
-  id_in?: InputMaybe<Array<Scalars['ID']>>;
-  id_not_in?: InputMaybe<Array<Scalars['ID']>>;
-  moduleAddress?: InputMaybe<Scalars['Bytes']>;
-  moduleAddress_not?: InputMaybe<Scalars['Bytes']>;
-  moduleAddress_in?: InputMaybe<Array<Scalars['Bytes']>>;
-  moduleAddress_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
-  moduleAddress_contains?: InputMaybe<Scalars['Bytes']>;
-  moduleAddress_not_contains?: InputMaybe<Scalars['Bytes']>;
-  name?: InputMaybe<Scalars['String']>;
-  name_not?: InputMaybe<Scalars['String']>;
-  name_gt?: InputMaybe<Scalars['String']>;
-  name_lt?: InputMaybe<Scalars['String']>;
-  name_gte?: InputMaybe<Scalars['String']>;
-  name_lte?: InputMaybe<Scalars['String']>;
-  name_in?: InputMaybe<Array<Scalars['String']>>;
-  name_not_in?: InputMaybe<Array<Scalars['String']>>;
-  name_contains?: InputMaybe<Scalars['String']>;
-  name_contains_nocase?: InputMaybe<Scalars['String']>;
-  name_not_contains?: InputMaybe<Scalars['String']>;
-  name_not_contains_nocase?: InputMaybe<Scalars['String']>;
-  name_starts_with?: InputMaybe<Scalars['String']>;
-  name_starts_with_nocase?: InputMaybe<Scalars['String']>;
-  name_not_starts_with?: InputMaybe<Scalars['String']>;
-  name_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
-  name_ends_with?: InputMaybe<Scalars['String']>;
-  name_ends_with_nocase?: InputMaybe<Scalars['String']>;
-  name_not_ends_with?: InputMaybe<Scalars['String']>;
-  name_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
-  description?: InputMaybe<Scalars['String']>;
-  description_not?: InputMaybe<Scalars['String']>;
-  description_gt?: InputMaybe<Scalars['String']>;
-  description_lt?: InputMaybe<Scalars['String']>;
-  description_gte?: InputMaybe<Scalars['String']>;
-  description_lte?: InputMaybe<Scalars['String']>;
-  description_in?: InputMaybe<Array<Scalars['String']>>;
-  description_not_in?: InputMaybe<Array<Scalars['String']>>;
-  description_contains?: InputMaybe<Scalars['String']>;
-  description_contains_nocase?: InputMaybe<Scalars['String']>;
-  description_not_contains?: InputMaybe<Scalars['String']>;
-  description_not_contains_nocase?: InputMaybe<Scalars['String']>;
-  description_starts_with?: InputMaybe<Scalars['String']>;
-  description_starts_with_nocase?: InputMaybe<Scalars['String']>;
-  description_not_starts_with?: InputMaybe<Scalars['String']>;
-  description_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
-  description_ends_with?: InputMaybe<Scalars['String']>;
-  description_ends_with_nocase?: InputMaybe<Scalars['String']>;
-  description_not_ends_with?: InputMaybe<Scalars['String']>;
-  description_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  id?: InputMaybe<Scalars['ID']['input']>;
+  id_not?: InputMaybe<Scalars['ID']['input']>;
+  id_gt?: InputMaybe<Scalars['ID']['input']>;
+  id_lt?: InputMaybe<Scalars['ID']['input']>;
+  id_gte?: InputMaybe<Scalars['ID']['input']>;
+  id_lte?: InputMaybe<Scalars['ID']['input']>;
+  id_in?: InputMaybe<Array<Scalars['ID']['input']>>;
+  id_not_in?: InputMaybe<Array<Scalars['ID']['input']>>;
+  moduleAddress?: InputMaybe<Scalars['Bytes']['input']>;
+  moduleAddress_not?: InputMaybe<Scalars['Bytes']['input']>;
+  moduleAddress_gt?: InputMaybe<Scalars['Bytes']['input']>;
+  moduleAddress_lt?: InputMaybe<Scalars['Bytes']['input']>;
+  moduleAddress_gte?: InputMaybe<Scalars['Bytes']['input']>;
+  moduleAddress_lte?: InputMaybe<Scalars['Bytes']['input']>;
+  moduleAddress_in?: InputMaybe<Array<Scalars['Bytes']['input']>>;
+  moduleAddress_not_in?: InputMaybe<Array<Scalars['Bytes']['input']>>;
+  moduleAddress_contains?: InputMaybe<Scalars['Bytes']['input']>;
+  moduleAddress_not_contains?: InputMaybe<Scalars['Bytes']['input']>;
+  name?: InputMaybe<Scalars['String']['input']>;
+  name_not?: InputMaybe<Scalars['String']['input']>;
+  name_gt?: InputMaybe<Scalars['String']['input']>;
+  name_lt?: InputMaybe<Scalars['String']['input']>;
+  name_gte?: InputMaybe<Scalars['String']['input']>;
+  name_lte?: InputMaybe<Scalars['String']['input']>;
+  name_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  name_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  name_contains?: InputMaybe<Scalars['String']['input']>;
+  name_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  name_not_contains?: InputMaybe<Scalars['String']['input']>;
+  name_not_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  name_starts_with?: InputMaybe<Scalars['String']['input']>;
+  name_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  name_not_starts_with?: InputMaybe<Scalars['String']['input']>;
+  name_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  name_ends_with?: InputMaybe<Scalars['String']['input']>;
+  name_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  name_not_ends_with?: InputMaybe<Scalars['String']['input']>;
+  name_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  description_not?: InputMaybe<Scalars['String']['input']>;
+  description_gt?: InputMaybe<Scalars['String']['input']>;
+  description_lt?: InputMaybe<Scalars['String']['input']>;
+  description_gte?: InputMaybe<Scalars['String']['input']>;
+  description_lte?: InputMaybe<Scalars['String']['input']>;
+  description_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  description_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  description_contains?: InputMaybe<Scalars['String']['input']>;
+  description_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  description_not_contains?: InputMaybe<Scalars['String']['input']>;
+  description_not_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  description_starts_with?: InputMaybe<Scalars['String']['input']>;
+  description_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  description_not_starts_with?: InputMaybe<Scalars['String']['input']>;
+  description_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  description_ends_with?: InputMaybe<Scalars['String']['input']>;
+  description_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  description_not_ends_with?: InputMaybe<Scalars['String']['input']>;
+  description_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<Module_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<Module_filter>>>;
 };
 
 export type Module_orderBy =
@@ -331,102 +407,117 @@ export type OrderDirection =
   | 'desc';
 
 export type Portal = {
-  id: Scalars['ID'];
-  ownerAddress: Scalars['Bytes'];
-  modules?: Maybe<Array<Scalars['Bytes']>>;
-  isRevocable: Scalars['Boolean'];
-  name: Scalars['String'];
-  description: Scalars['String'];
-  ownerName: Scalars['String'];
+  id: Scalars['ID']['output'];
+  ownerAddress: Scalars['Bytes']['output'];
+  modules?: Maybe<Array<Scalars['Bytes']['output']>>;
+  isRevocable: Scalars['Boolean']['output'];
+  name: Scalars['String']['output'];
+  description: Scalars['String']['output'];
+  ownerName: Scalars['String']['output'];
+  attestationCounter?: Maybe<Scalars['Int']['output']>;
 };
 
 export type Portal_filter = {
-  id?: InputMaybe<Scalars['ID']>;
-  id_not?: InputMaybe<Scalars['ID']>;
-  id_gt?: InputMaybe<Scalars['ID']>;
-  id_lt?: InputMaybe<Scalars['ID']>;
-  id_gte?: InputMaybe<Scalars['ID']>;
-  id_lte?: InputMaybe<Scalars['ID']>;
-  id_in?: InputMaybe<Array<Scalars['ID']>>;
-  id_not_in?: InputMaybe<Array<Scalars['ID']>>;
-  ownerAddress?: InputMaybe<Scalars['Bytes']>;
-  ownerAddress_not?: InputMaybe<Scalars['Bytes']>;
-  ownerAddress_in?: InputMaybe<Array<Scalars['Bytes']>>;
-  ownerAddress_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
-  ownerAddress_contains?: InputMaybe<Scalars['Bytes']>;
-  ownerAddress_not_contains?: InputMaybe<Scalars['Bytes']>;
-  modules?: InputMaybe<Array<Scalars['Bytes']>>;
-  modules_not?: InputMaybe<Array<Scalars['Bytes']>>;
-  modules_contains?: InputMaybe<Array<Scalars['Bytes']>>;
-  modules_contains_nocase?: InputMaybe<Array<Scalars['Bytes']>>;
-  modules_not_contains?: InputMaybe<Array<Scalars['Bytes']>>;
-  modules_not_contains_nocase?: InputMaybe<Array<Scalars['Bytes']>>;
-  isRevocable?: InputMaybe<Scalars['Boolean']>;
-  isRevocable_not?: InputMaybe<Scalars['Boolean']>;
-  isRevocable_in?: InputMaybe<Array<Scalars['Boolean']>>;
-  isRevocable_not_in?: InputMaybe<Array<Scalars['Boolean']>>;
-  name?: InputMaybe<Scalars['String']>;
-  name_not?: InputMaybe<Scalars['String']>;
-  name_gt?: InputMaybe<Scalars['String']>;
-  name_lt?: InputMaybe<Scalars['String']>;
-  name_gte?: InputMaybe<Scalars['String']>;
-  name_lte?: InputMaybe<Scalars['String']>;
-  name_in?: InputMaybe<Array<Scalars['String']>>;
-  name_not_in?: InputMaybe<Array<Scalars['String']>>;
-  name_contains?: InputMaybe<Scalars['String']>;
-  name_contains_nocase?: InputMaybe<Scalars['String']>;
-  name_not_contains?: InputMaybe<Scalars['String']>;
-  name_not_contains_nocase?: InputMaybe<Scalars['String']>;
-  name_starts_with?: InputMaybe<Scalars['String']>;
-  name_starts_with_nocase?: InputMaybe<Scalars['String']>;
-  name_not_starts_with?: InputMaybe<Scalars['String']>;
-  name_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
-  name_ends_with?: InputMaybe<Scalars['String']>;
-  name_ends_with_nocase?: InputMaybe<Scalars['String']>;
-  name_not_ends_with?: InputMaybe<Scalars['String']>;
-  name_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
-  description?: InputMaybe<Scalars['String']>;
-  description_not?: InputMaybe<Scalars['String']>;
-  description_gt?: InputMaybe<Scalars['String']>;
-  description_lt?: InputMaybe<Scalars['String']>;
-  description_gte?: InputMaybe<Scalars['String']>;
-  description_lte?: InputMaybe<Scalars['String']>;
-  description_in?: InputMaybe<Array<Scalars['String']>>;
-  description_not_in?: InputMaybe<Array<Scalars['String']>>;
-  description_contains?: InputMaybe<Scalars['String']>;
-  description_contains_nocase?: InputMaybe<Scalars['String']>;
-  description_not_contains?: InputMaybe<Scalars['String']>;
-  description_not_contains_nocase?: InputMaybe<Scalars['String']>;
-  description_starts_with?: InputMaybe<Scalars['String']>;
-  description_starts_with_nocase?: InputMaybe<Scalars['String']>;
-  description_not_starts_with?: InputMaybe<Scalars['String']>;
-  description_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
-  description_ends_with?: InputMaybe<Scalars['String']>;
-  description_ends_with_nocase?: InputMaybe<Scalars['String']>;
-  description_not_ends_with?: InputMaybe<Scalars['String']>;
-  description_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
-  ownerName?: InputMaybe<Scalars['String']>;
-  ownerName_not?: InputMaybe<Scalars['String']>;
-  ownerName_gt?: InputMaybe<Scalars['String']>;
-  ownerName_lt?: InputMaybe<Scalars['String']>;
-  ownerName_gte?: InputMaybe<Scalars['String']>;
-  ownerName_lte?: InputMaybe<Scalars['String']>;
-  ownerName_in?: InputMaybe<Array<Scalars['String']>>;
-  ownerName_not_in?: InputMaybe<Array<Scalars['String']>>;
-  ownerName_contains?: InputMaybe<Scalars['String']>;
-  ownerName_contains_nocase?: InputMaybe<Scalars['String']>;
-  ownerName_not_contains?: InputMaybe<Scalars['String']>;
-  ownerName_not_contains_nocase?: InputMaybe<Scalars['String']>;
-  ownerName_starts_with?: InputMaybe<Scalars['String']>;
-  ownerName_starts_with_nocase?: InputMaybe<Scalars['String']>;
-  ownerName_not_starts_with?: InputMaybe<Scalars['String']>;
-  ownerName_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
-  ownerName_ends_with?: InputMaybe<Scalars['String']>;
-  ownerName_ends_with_nocase?: InputMaybe<Scalars['String']>;
-  ownerName_not_ends_with?: InputMaybe<Scalars['String']>;
-  ownerName_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  id?: InputMaybe<Scalars['ID']['input']>;
+  id_not?: InputMaybe<Scalars['ID']['input']>;
+  id_gt?: InputMaybe<Scalars['ID']['input']>;
+  id_lt?: InputMaybe<Scalars['ID']['input']>;
+  id_gte?: InputMaybe<Scalars['ID']['input']>;
+  id_lte?: InputMaybe<Scalars['ID']['input']>;
+  id_in?: InputMaybe<Array<Scalars['ID']['input']>>;
+  id_not_in?: InputMaybe<Array<Scalars['ID']['input']>>;
+  ownerAddress?: InputMaybe<Scalars['Bytes']['input']>;
+  ownerAddress_not?: InputMaybe<Scalars['Bytes']['input']>;
+  ownerAddress_gt?: InputMaybe<Scalars['Bytes']['input']>;
+  ownerAddress_lt?: InputMaybe<Scalars['Bytes']['input']>;
+  ownerAddress_gte?: InputMaybe<Scalars['Bytes']['input']>;
+  ownerAddress_lte?: InputMaybe<Scalars['Bytes']['input']>;
+  ownerAddress_in?: InputMaybe<Array<Scalars['Bytes']['input']>>;
+  ownerAddress_not_in?: InputMaybe<Array<Scalars['Bytes']['input']>>;
+  ownerAddress_contains?: InputMaybe<Scalars['Bytes']['input']>;
+  ownerAddress_not_contains?: InputMaybe<Scalars['Bytes']['input']>;
+  modules?: InputMaybe<Array<Scalars['Bytes']['input']>>;
+  modules_not?: InputMaybe<Array<Scalars['Bytes']['input']>>;
+  modules_contains?: InputMaybe<Array<Scalars['Bytes']['input']>>;
+  modules_contains_nocase?: InputMaybe<Array<Scalars['Bytes']['input']>>;
+  modules_not_contains?: InputMaybe<Array<Scalars['Bytes']['input']>>;
+  modules_not_contains_nocase?: InputMaybe<Array<Scalars['Bytes']['input']>>;
+  isRevocable?: InputMaybe<Scalars['Boolean']['input']>;
+  isRevocable_not?: InputMaybe<Scalars['Boolean']['input']>;
+  isRevocable_in?: InputMaybe<Array<Scalars['Boolean']['input']>>;
+  isRevocable_not_in?: InputMaybe<Array<Scalars['Boolean']['input']>>;
+  name?: InputMaybe<Scalars['String']['input']>;
+  name_not?: InputMaybe<Scalars['String']['input']>;
+  name_gt?: InputMaybe<Scalars['String']['input']>;
+  name_lt?: InputMaybe<Scalars['String']['input']>;
+  name_gte?: InputMaybe<Scalars['String']['input']>;
+  name_lte?: InputMaybe<Scalars['String']['input']>;
+  name_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  name_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  name_contains?: InputMaybe<Scalars['String']['input']>;
+  name_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  name_not_contains?: InputMaybe<Scalars['String']['input']>;
+  name_not_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  name_starts_with?: InputMaybe<Scalars['String']['input']>;
+  name_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  name_not_starts_with?: InputMaybe<Scalars['String']['input']>;
+  name_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  name_ends_with?: InputMaybe<Scalars['String']['input']>;
+  name_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  name_not_ends_with?: InputMaybe<Scalars['String']['input']>;
+  name_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  description_not?: InputMaybe<Scalars['String']['input']>;
+  description_gt?: InputMaybe<Scalars['String']['input']>;
+  description_lt?: InputMaybe<Scalars['String']['input']>;
+  description_gte?: InputMaybe<Scalars['String']['input']>;
+  description_lte?: InputMaybe<Scalars['String']['input']>;
+  description_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  description_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  description_contains?: InputMaybe<Scalars['String']['input']>;
+  description_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  description_not_contains?: InputMaybe<Scalars['String']['input']>;
+  description_not_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  description_starts_with?: InputMaybe<Scalars['String']['input']>;
+  description_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  description_not_starts_with?: InputMaybe<Scalars['String']['input']>;
+  description_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  description_ends_with?: InputMaybe<Scalars['String']['input']>;
+  description_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  description_not_ends_with?: InputMaybe<Scalars['String']['input']>;
+  description_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  ownerName?: InputMaybe<Scalars['String']['input']>;
+  ownerName_not?: InputMaybe<Scalars['String']['input']>;
+  ownerName_gt?: InputMaybe<Scalars['String']['input']>;
+  ownerName_lt?: InputMaybe<Scalars['String']['input']>;
+  ownerName_gte?: InputMaybe<Scalars['String']['input']>;
+  ownerName_lte?: InputMaybe<Scalars['String']['input']>;
+  ownerName_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  ownerName_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  ownerName_contains?: InputMaybe<Scalars['String']['input']>;
+  ownerName_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  ownerName_not_contains?: InputMaybe<Scalars['String']['input']>;
+  ownerName_not_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  ownerName_starts_with?: InputMaybe<Scalars['String']['input']>;
+  ownerName_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  ownerName_not_starts_with?: InputMaybe<Scalars['String']['input']>;
+  ownerName_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  ownerName_ends_with?: InputMaybe<Scalars['String']['input']>;
+  ownerName_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  ownerName_not_ends_with?: InputMaybe<Scalars['String']['input']>;
+  ownerName_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  attestationCounter?: InputMaybe<Scalars['Int']['input']>;
+  attestationCounter_not?: InputMaybe<Scalars['Int']['input']>;
+  attestationCounter_gt?: InputMaybe<Scalars['Int']['input']>;
+  attestationCounter_lt?: InputMaybe<Scalars['Int']['input']>;
+  attestationCounter_gte?: InputMaybe<Scalars['Int']['input']>;
+  attestationCounter_lte?: InputMaybe<Scalars['Int']['input']>;
+  attestationCounter_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  attestationCounter_not_in?: InputMaybe<Array<Scalars['Int']['input']>>;
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<Portal_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<Portal_filter>>>;
 };
 
 export type Portal_orderBy =
@@ -436,7 +527,8 @@ export type Portal_orderBy =
   | 'isRevocable'
   | 'name'
   | 'description'
-  | 'ownerName';
+  | 'ownerName'
+  | 'attestationCounter';
 
 export type Query = {
   attestation?: Maybe<Attestation>;
@@ -449,21 +541,25 @@ export type Query = {
   schemas: Array<Schema>;
   counter?: Maybe<Counter>;
   counters: Array<Counter>;
+  issuer?: Maybe<Issuer>;
+  issuers: Array<Issuer>;
+  registryVersion?: Maybe<RegistryVersion>;
+  registryVersions: Array<RegistryVersion>;
   /** Access to subgraph metadata */
   _meta?: Maybe<_Meta_>;
 };
 
 
 export type QueryattestationArgs = {
-  id: Scalars['ID'];
+  id: Scalars['ID']['input'];
   block?: InputMaybe<Block_height>;
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
 
 export type QueryattestationsArgs = {
-  skip?: InputMaybe<Scalars['Int']>;
-  first?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Attestation_orderBy>;
   orderDirection?: InputMaybe<OrderDirection>;
   where?: InputMaybe<Attestation_filter>;
@@ -473,15 +569,15 @@ export type QueryattestationsArgs = {
 
 
 export type QuerymoduleArgs = {
-  id: Scalars['ID'];
+  id: Scalars['ID']['input'];
   block?: InputMaybe<Block_height>;
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
 
 export type QuerymodulesArgs = {
-  skip?: InputMaybe<Scalars['Int']>;
-  first?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Module_orderBy>;
   orderDirection?: InputMaybe<OrderDirection>;
   where?: InputMaybe<Module_filter>;
@@ -491,15 +587,15 @@ export type QuerymodulesArgs = {
 
 
 export type QueryportalArgs = {
-  id: Scalars['ID'];
+  id: Scalars['ID']['input'];
   block?: InputMaybe<Block_height>;
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
 
 export type QueryportalsArgs = {
-  skip?: InputMaybe<Scalars['Int']>;
-  first?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Portal_orderBy>;
   orderDirection?: InputMaybe<OrderDirection>;
   where?: InputMaybe<Portal_filter>;
@@ -509,15 +605,15 @@ export type QueryportalsArgs = {
 
 
 export type QueryschemaArgs = {
-  id: Scalars['ID'];
+  id: Scalars['ID']['input'];
   block?: InputMaybe<Block_height>;
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
 
 export type QueryschemasArgs = {
-  skip?: InputMaybe<Scalars['Int']>;
-  first?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Schema_orderBy>;
   orderDirection?: InputMaybe<OrderDirection>;
   where?: InputMaybe<Schema_filter>;
@@ -527,18 +623,54 @@ export type QueryschemasArgs = {
 
 
 export type QuerycounterArgs = {
-  id: Scalars['ID'];
+  id: Scalars['ID']['input'];
   block?: InputMaybe<Block_height>;
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
 
 export type QuerycountersArgs = {
-  skip?: InputMaybe<Scalars['Int']>;
-  first?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Counter_orderBy>;
   orderDirection?: InputMaybe<OrderDirection>;
   where?: InputMaybe<Counter_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryissuerArgs = {
+  id: Scalars['ID']['input'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryissuersArgs = {
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<Issuer_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<Issuer_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryregistryVersionArgs = {
+  id: Scalars['ID']['input'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryregistryVersionsArgs = {
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<RegistryVersion_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<RegistryVersion_filter>;
   block?: InputMaybe<Block_height>;
   subgraphError?: _SubgraphErrorPolicy_;
 };
@@ -548,105 +680,158 @@ export type Query_metaArgs = {
   block?: InputMaybe<Block_height>;
 };
 
+export type RegistryVersion = {
+  id: Scalars['ID']['output'];
+  versionNumber?: Maybe<Scalars['Int']['output']>;
+  timestamp?: Maybe<Scalars['BigInt']['output']>;
+};
+
+export type RegistryVersion_filter = {
+  id?: InputMaybe<Scalars['ID']['input']>;
+  id_not?: InputMaybe<Scalars['ID']['input']>;
+  id_gt?: InputMaybe<Scalars['ID']['input']>;
+  id_lt?: InputMaybe<Scalars['ID']['input']>;
+  id_gte?: InputMaybe<Scalars['ID']['input']>;
+  id_lte?: InputMaybe<Scalars['ID']['input']>;
+  id_in?: InputMaybe<Array<Scalars['ID']['input']>>;
+  id_not_in?: InputMaybe<Array<Scalars['ID']['input']>>;
+  versionNumber?: InputMaybe<Scalars['Int']['input']>;
+  versionNumber_not?: InputMaybe<Scalars['Int']['input']>;
+  versionNumber_gt?: InputMaybe<Scalars['Int']['input']>;
+  versionNumber_lt?: InputMaybe<Scalars['Int']['input']>;
+  versionNumber_gte?: InputMaybe<Scalars['Int']['input']>;
+  versionNumber_lte?: InputMaybe<Scalars['Int']['input']>;
+  versionNumber_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  versionNumber_not_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  timestamp?: InputMaybe<Scalars['BigInt']['input']>;
+  timestamp_not?: InputMaybe<Scalars['BigInt']['input']>;
+  timestamp_gt?: InputMaybe<Scalars['BigInt']['input']>;
+  timestamp_lt?: InputMaybe<Scalars['BigInt']['input']>;
+  timestamp_gte?: InputMaybe<Scalars['BigInt']['input']>;
+  timestamp_lte?: InputMaybe<Scalars['BigInt']['input']>;
+  timestamp_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  timestamp_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<RegistryVersion_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<RegistryVersion_filter>>>;
+};
+
+export type RegistryVersion_orderBy =
+  | 'id'
+  | 'versionNumber'
+  | 'timestamp';
+
 export type Schema = {
-  id: Scalars['ID'];
-  name: Scalars['String'];
-  description: Scalars['String'];
-  context: Scalars['String'];
-  schema: Scalars['String'];
+  id: Scalars['ID']['output'];
+  name: Scalars['String']['output'];
+  description: Scalars['String']['output'];
+  context: Scalars['String']['output'];
+  schema: Scalars['String']['output'];
+  attestationCounter?: Maybe<Scalars['Int']['output']>;
 };
 
 export type Schema_filter = {
-  id?: InputMaybe<Scalars['ID']>;
-  id_not?: InputMaybe<Scalars['ID']>;
-  id_gt?: InputMaybe<Scalars['ID']>;
-  id_lt?: InputMaybe<Scalars['ID']>;
-  id_gte?: InputMaybe<Scalars['ID']>;
-  id_lte?: InputMaybe<Scalars['ID']>;
-  id_in?: InputMaybe<Array<Scalars['ID']>>;
-  id_not_in?: InputMaybe<Array<Scalars['ID']>>;
-  name?: InputMaybe<Scalars['String']>;
-  name_not?: InputMaybe<Scalars['String']>;
-  name_gt?: InputMaybe<Scalars['String']>;
-  name_lt?: InputMaybe<Scalars['String']>;
-  name_gte?: InputMaybe<Scalars['String']>;
-  name_lte?: InputMaybe<Scalars['String']>;
-  name_in?: InputMaybe<Array<Scalars['String']>>;
-  name_not_in?: InputMaybe<Array<Scalars['String']>>;
-  name_contains?: InputMaybe<Scalars['String']>;
-  name_contains_nocase?: InputMaybe<Scalars['String']>;
-  name_not_contains?: InputMaybe<Scalars['String']>;
-  name_not_contains_nocase?: InputMaybe<Scalars['String']>;
-  name_starts_with?: InputMaybe<Scalars['String']>;
-  name_starts_with_nocase?: InputMaybe<Scalars['String']>;
-  name_not_starts_with?: InputMaybe<Scalars['String']>;
-  name_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
-  name_ends_with?: InputMaybe<Scalars['String']>;
-  name_ends_with_nocase?: InputMaybe<Scalars['String']>;
-  name_not_ends_with?: InputMaybe<Scalars['String']>;
-  name_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
-  description?: InputMaybe<Scalars['String']>;
-  description_not?: InputMaybe<Scalars['String']>;
-  description_gt?: InputMaybe<Scalars['String']>;
-  description_lt?: InputMaybe<Scalars['String']>;
-  description_gte?: InputMaybe<Scalars['String']>;
-  description_lte?: InputMaybe<Scalars['String']>;
-  description_in?: InputMaybe<Array<Scalars['String']>>;
-  description_not_in?: InputMaybe<Array<Scalars['String']>>;
-  description_contains?: InputMaybe<Scalars['String']>;
-  description_contains_nocase?: InputMaybe<Scalars['String']>;
-  description_not_contains?: InputMaybe<Scalars['String']>;
-  description_not_contains_nocase?: InputMaybe<Scalars['String']>;
-  description_starts_with?: InputMaybe<Scalars['String']>;
-  description_starts_with_nocase?: InputMaybe<Scalars['String']>;
-  description_not_starts_with?: InputMaybe<Scalars['String']>;
-  description_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
-  description_ends_with?: InputMaybe<Scalars['String']>;
-  description_ends_with_nocase?: InputMaybe<Scalars['String']>;
-  description_not_ends_with?: InputMaybe<Scalars['String']>;
-  description_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
-  context?: InputMaybe<Scalars['String']>;
-  context_not?: InputMaybe<Scalars['String']>;
-  context_gt?: InputMaybe<Scalars['String']>;
-  context_lt?: InputMaybe<Scalars['String']>;
-  context_gte?: InputMaybe<Scalars['String']>;
-  context_lte?: InputMaybe<Scalars['String']>;
-  context_in?: InputMaybe<Array<Scalars['String']>>;
-  context_not_in?: InputMaybe<Array<Scalars['String']>>;
-  context_contains?: InputMaybe<Scalars['String']>;
-  context_contains_nocase?: InputMaybe<Scalars['String']>;
-  context_not_contains?: InputMaybe<Scalars['String']>;
-  context_not_contains_nocase?: InputMaybe<Scalars['String']>;
-  context_starts_with?: InputMaybe<Scalars['String']>;
-  context_starts_with_nocase?: InputMaybe<Scalars['String']>;
-  context_not_starts_with?: InputMaybe<Scalars['String']>;
-  context_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
-  context_ends_with?: InputMaybe<Scalars['String']>;
-  context_ends_with_nocase?: InputMaybe<Scalars['String']>;
-  context_not_ends_with?: InputMaybe<Scalars['String']>;
-  context_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
-  schema?: InputMaybe<Scalars['String']>;
-  schema_not?: InputMaybe<Scalars['String']>;
-  schema_gt?: InputMaybe<Scalars['String']>;
-  schema_lt?: InputMaybe<Scalars['String']>;
-  schema_gte?: InputMaybe<Scalars['String']>;
-  schema_lte?: InputMaybe<Scalars['String']>;
-  schema_in?: InputMaybe<Array<Scalars['String']>>;
-  schema_not_in?: InputMaybe<Array<Scalars['String']>>;
-  schema_contains?: InputMaybe<Scalars['String']>;
-  schema_contains_nocase?: InputMaybe<Scalars['String']>;
-  schema_not_contains?: InputMaybe<Scalars['String']>;
-  schema_not_contains_nocase?: InputMaybe<Scalars['String']>;
-  schema_starts_with?: InputMaybe<Scalars['String']>;
-  schema_starts_with_nocase?: InputMaybe<Scalars['String']>;
-  schema_not_starts_with?: InputMaybe<Scalars['String']>;
-  schema_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
-  schema_ends_with?: InputMaybe<Scalars['String']>;
-  schema_ends_with_nocase?: InputMaybe<Scalars['String']>;
-  schema_not_ends_with?: InputMaybe<Scalars['String']>;
-  schema_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  id?: InputMaybe<Scalars['ID']['input']>;
+  id_not?: InputMaybe<Scalars['ID']['input']>;
+  id_gt?: InputMaybe<Scalars['ID']['input']>;
+  id_lt?: InputMaybe<Scalars['ID']['input']>;
+  id_gte?: InputMaybe<Scalars['ID']['input']>;
+  id_lte?: InputMaybe<Scalars['ID']['input']>;
+  id_in?: InputMaybe<Array<Scalars['ID']['input']>>;
+  id_not_in?: InputMaybe<Array<Scalars['ID']['input']>>;
+  name?: InputMaybe<Scalars['String']['input']>;
+  name_not?: InputMaybe<Scalars['String']['input']>;
+  name_gt?: InputMaybe<Scalars['String']['input']>;
+  name_lt?: InputMaybe<Scalars['String']['input']>;
+  name_gte?: InputMaybe<Scalars['String']['input']>;
+  name_lte?: InputMaybe<Scalars['String']['input']>;
+  name_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  name_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  name_contains?: InputMaybe<Scalars['String']['input']>;
+  name_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  name_not_contains?: InputMaybe<Scalars['String']['input']>;
+  name_not_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  name_starts_with?: InputMaybe<Scalars['String']['input']>;
+  name_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  name_not_starts_with?: InputMaybe<Scalars['String']['input']>;
+  name_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  name_ends_with?: InputMaybe<Scalars['String']['input']>;
+  name_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  name_not_ends_with?: InputMaybe<Scalars['String']['input']>;
+  name_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  description_not?: InputMaybe<Scalars['String']['input']>;
+  description_gt?: InputMaybe<Scalars['String']['input']>;
+  description_lt?: InputMaybe<Scalars['String']['input']>;
+  description_gte?: InputMaybe<Scalars['String']['input']>;
+  description_lte?: InputMaybe<Scalars['String']['input']>;
+  description_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  description_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  description_contains?: InputMaybe<Scalars['String']['input']>;
+  description_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  description_not_contains?: InputMaybe<Scalars['String']['input']>;
+  description_not_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  description_starts_with?: InputMaybe<Scalars['String']['input']>;
+  description_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  description_not_starts_with?: InputMaybe<Scalars['String']['input']>;
+  description_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  description_ends_with?: InputMaybe<Scalars['String']['input']>;
+  description_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  description_not_ends_with?: InputMaybe<Scalars['String']['input']>;
+  description_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  context?: InputMaybe<Scalars['String']['input']>;
+  context_not?: InputMaybe<Scalars['String']['input']>;
+  context_gt?: InputMaybe<Scalars['String']['input']>;
+  context_lt?: InputMaybe<Scalars['String']['input']>;
+  context_gte?: InputMaybe<Scalars['String']['input']>;
+  context_lte?: InputMaybe<Scalars['String']['input']>;
+  context_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  context_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  context_contains?: InputMaybe<Scalars['String']['input']>;
+  context_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  context_not_contains?: InputMaybe<Scalars['String']['input']>;
+  context_not_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  context_starts_with?: InputMaybe<Scalars['String']['input']>;
+  context_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  context_not_starts_with?: InputMaybe<Scalars['String']['input']>;
+  context_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  context_ends_with?: InputMaybe<Scalars['String']['input']>;
+  context_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  context_not_ends_with?: InputMaybe<Scalars['String']['input']>;
+  context_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  schema?: InputMaybe<Scalars['String']['input']>;
+  schema_not?: InputMaybe<Scalars['String']['input']>;
+  schema_gt?: InputMaybe<Scalars['String']['input']>;
+  schema_lt?: InputMaybe<Scalars['String']['input']>;
+  schema_gte?: InputMaybe<Scalars['String']['input']>;
+  schema_lte?: InputMaybe<Scalars['String']['input']>;
+  schema_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  schema_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  schema_contains?: InputMaybe<Scalars['String']['input']>;
+  schema_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  schema_not_contains?: InputMaybe<Scalars['String']['input']>;
+  schema_not_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  schema_starts_with?: InputMaybe<Scalars['String']['input']>;
+  schema_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  schema_not_starts_with?: InputMaybe<Scalars['String']['input']>;
+  schema_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  schema_ends_with?: InputMaybe<Scalars['String']['input']>;
+  schema_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  schema_not_ends_with?: InputMaybe<Scalars['String']['input']>;
+  schema_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  attestationCounter?: InputMaybe<Scalars['Int']['input']>;
+  attestationCounter_not?: InputMaybe<Scalars['Int']['input']>;
+  attestationCounter_gt?: InputMaybe<Scalars['Int']['input']>;
+  attestationCounter_lt?: InputMaybe<Scalars['Int']['input']>;
+  attestationCounter_gte?: InputMaybe<Scalars['Int']['input']>;
+  attestationCounter_lte?: InputMaybe<Scalars['Int']['input']>;
+  attestationCounter_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  attestationCounter_not_in?: InputMaybe<Array<Scalars['Int']['input']>>;
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<Schema_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<Schema_filter>>>;
 };
 
 export type Schema_orderBy =
@@ -654,7 +839,8 @@ export type Schema_orderBy =
   | 'name'
   | 'description'
   | 'context'
-  | 'schema';
+  | 'schema'
+  | 'attestationCounter';
 
 export type Subscription = {
   attestation?: Maybe<Attestation>;
@@ -667,21 +853,25 @@ export type Subscription = {
   schemas: Array<Schema>;
   counter?: Maybe<Counter>;
   counters: Array<Counter>;
+  issuer?: Maybe<Issuer>;
+  issuers: Array<Issuer>;
+  registryVersion?: Maybe<RegistryVersion>;
+  registryVersions: Array<RegistryVersion>;
   /** Access to subgraph metadata */
   _meta?: Maybe<_Meta_>;
 };
 
 
 export type SubscriptionattestationArgs = {
-  id: Scalars['ID'];
+  id: Scalars['ID']['input'];
   block?: InputMaybe<Block_height>;
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
 
 export type SubscriptionattestationsArgs = {
-  skip?: InputMaybe<Scalars['Int']>;
-  first?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Attestation_orderBy>;
   orderDirection?: InputMaybe<OrderDirection>;
   where?: InputMaybe<Attestation_filter>;
@@ -691,15 +881,15 @@ export type SubscriptionattestationsArgs = {
 
 
 export type SubscriptionmoduleArgs = {
-  id: Scalars['ID'];
+  id: Scalars['ID']['input'];
   block?: InputMaybe<Block_height>;
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
 
 export type SubscriptionmodulesArgs = {
-  skip?: InputMaybe<Scalars['Int']>;
-  first?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Module_orderBy>;
   orderDirection?: InputMaybe<OrderDirection>;
   where?: InputMaybe<Module_filter>;
@@ -709,15 +899,15 @@ export type SubscriptionmodulesArgs = {
 
 
 export type SubscriptionportalArgs = {
-  id: Scalars['ID'];
+  id: Scalars['ID']['input'];
   block?: InputMaybe<Block_height>;
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
 
 export type SubscriptionportalsArgs = {
-  skip?: InputMaybe<Scalars['Int']>;
-  first?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Portal_orderBy>;
   orderDirection?: InputMaybe<OrderDirection>;
   where?: InputMaybe<Portal_filter>;
@@ -727,15 +917,15 @@ export type SubscriptionportalsArgs = {
 
 
 export type SubscriptionschemaArgs = {
-  id: Scalars['ID'];
+  id: Scalars['ID']['input'];
   block?: InputMaybe<Block_height>;
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
 
 export type SubscriptionschemasArgs = {
-  skip?: InputMaybe<Scalars['Int']>;
-  first?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Schema_orderBy>;
   orderDirection?: InputMaybe<OrderDirection>;
   where?: InputMaybe<Schema_filter>;
@@ -745,18 +935,54 @@ export type SubscriptionschemasArgs = {
 
 
 export type SubscriptioncounterArgs = {
-  id: Scalars['ID'];
+  id: Scalars['ID']['input'];
   block?: InputMaybe<Block_height>;
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
 
 export type SubscriptioncountersArgs = {
-  skip?: InputMaybe<Scalars['Int']>;
-  first?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Counter_orderBy>;
   orderDirection?: InputMaybe<OrderDirection>;
   where?: InputMaybe<Counter_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionissuerArgs = {
+  id: Scalars['ID']['input'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionissuersArgs = {
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<Issuer_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<Issuer_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionregistryVersionArgs = {
+  id: Scalars['ID']['input'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionregistryVersionsArgs = {
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<RegistryVersion_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<RegistryVersion_filter>;
   block?: InputMaybe<Block_height>;
   subgraphError?: _SubgraphErrorPolicy_;
 };
@@ -768,11 +994,13 @@ export type Subscription_metaArgs = {
 
 export type _Block_ = {
   /** The hash of the block */
-  hash?: Maybe<Scalars['Bytes']>;
+  hash?: Maybe<Scalars['Bytes']['output']>;
   /** The block number */
-  number: Scalars['Int'];
+  number: Scalars['Int']['output'];
   /** Integer representation of the timestamp stored in blocks for the chain */
-  timestamp?: Maybe<Scalars['Int']>;
+  timestamp?: Maybe<Scalars['Int']['output']>;
+  /** The hash of the parent block */
+  parentHash?: Maybe<Scalars['Bytes']['output']>;
 };
 
 /** The type for the top-level _meta field */
@@ -786,9 +1014,9 @@ export type _Meta_ = {
    */
   block: _Block_;
   /** The deployment ID */
-  deployment: Scalars['String'];
+  deployment: Scalars['String']['output'];
   /** If `true`, the subgraph encountered indexing errors at some past block */
-  hasIndexingErrors: Scalars['Boolean'];
+  hasIndexingErrors: Scalars['Boolean']['output'];
 };
 
 export type _SubgraphErrorPolicy_ =
@@ -883,21 +1111,26 @@ export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs
 
 /** Mapping between all available schema types and the resolvers types */
 export type ResolversTypes = ResolversObject<{
+  Aggregation_interval: Aggregation_interval;
   Attestation: ResolverTypeWrapper<Attestation>;
   Attestation_filter: Attestation_filter;
   Attestation_orderBy: Attestation_orderBy;
-  BigDecimal: ResolverTypeWrapper<Scalars['BigDecimal']>;
-  BigInt: ResolverTypeWrapper<Scalars['BigInt']>;
+  BigDecimal: ResolverTypeWrapper<Scalars['BigDecimal']['output']>;
+  BigInt: ResolverTypeWrapper<Scalars['BigInt']['output']>;
   BlockChangedFilter: BlockChangedFilter;
   Block_height: Block_height;
-  Boolean: ResolverTypeWrapper<Scalars['Boolean']>;
-  Bytes: ResolverTypeWrapper<Scalars['Bytes']>;
+  Boolean: ResolverTypeWrapper<Scalars['Boolean']['output']>;
+  Bytes: ResolverTypeWrapper<Scalars['Bytes']['output']>;
   Counter: ResolverTypeWrapper<Counter>;
   Counter_filter: Counter_filter;
   Counter_orderBy: Counter_orderBy;
-  Float: ResolverTypeWrapper<Scalars['Float']>;
-  ID: ResolverTypeWrapper<Scalars['ID']>;
-  Int: ResolverTypeWrapper<Scalars['Int']>;
+  Float: ResolverTypeWrapper<Scalars['Float']['output']>;
+  ID: ResolverTypeWrapper<Scalars['ID']['output']>;
+  Int: ResolverTypeWrapper<Scalars['Int']['output']>;
+  Int8: ResolverTypeWrapper<Scalars['Int8']['output']>;
+  Issuer: ResolverTypeWrapper<Issuer>;
+  Issuer_filter: Issuer_filter;
+  Issuer_orderBy: Issuer_orderBy;
   Module: ResolverTypeWrapper<Module>;
   Module_filter: Module_filter;
   Module_orderBy: Module_orderBy;
@@ -906,11 +1139,15 @@ export type ResolversTypes = ResolversObject<{
   Portal_filter: Portal_filter;
   Portal_orderBy: Portal_orderBy;
   Query: ResolverTypeWrapper<{}>;
+  RegistryVersion: ResolverTypeWrapper<RegistryVersion>;
+  RegistryVersion_filter: RegistryVersion_filter;
+  RegistryVersion_orderBy: RegistryVersion_orderBy;
   Schema: ResolverTypeWrapper<Schema>;
   Schema_filter: Schema_filter;
   Schema_orderBy: Schema_orderBy;
-  String: ResolverTypeWrapper<Scalars['String']>;
+  String: ResolverTypeWrapper<Scalars['String']['output']>;
   Subscription: ResolverTypeWrapper<{}>;
+  Timestamp: ResolverTypeWrapper<Scalars['Timestamp']['output']>;
   _Block_: ResolverTypeWrapper<_Block_>;
   _Meta_: ResolverTypeWrapper<_Meta_>;
   _SubgraphErrorPolicy_: _SubgraphErrorPolicy_;
@@ -920,26 +1157,32 @@ export type ResolversTypes = ResolversObject<{
 export type ResolversParentTypes = ResolversObject<{
   Attestation: Attestation;
   Attestation_filter: Attestation_filter;
-  BigDecimal: Scalars['BigDecimal'];
-  BigInt: Scalars['BigInt'];
+  BigDecimal: Scalars['BigDecimal']['output'];
+  BigInt: Scalars['BigInt']['output'];
   BlockChangedFilter: BlockChangedFilter;
   Block_height: Block_height;
-  Boolean: Scalars['Boolean'];
-  Bytes: Scalars['Bytes'];
+  Boolean: Scalars['Boolean']['output'];
+  Bytes: Scalars['Bytes']['output'];
   Counter: Counter;
   Counter_filter: Counter_filter;
-  Float: Scalars['Float'];
-  ID: Scalars['ID'];
-  Int: Scalars['Int'];
+  Float: Scalars['Float']['output'];
+  ID: Scalars['ID']['output'];
+  Int: Scalars['Int']['output'];
+  Int8: Scalars['Int8']['output'];
+  Issuer: Issuer;
+  Issuer_filter: Issuer_filter;
   Module: Module;
   Module_filter: Module_filter;
   Portal: Portal;
   Portal_filter: Portal_filter;
   Query: {};
+  RegistryVersion: RegistryVersion;
+  RegistryVersion_filter: RegistryVersion_filter;
   Schema: Schema;
   Schema_filter: Schema_filter;
-  String: Scalars['String'];
+  String: Scalars['String']['output'];
   Subscription: {};
+  Timestamp: Scalars['Timestamp']['output'];
   _Block_: _Block_;
   _Meta_: _Meta_;
 }>;
@@ -949,13 +1192,13 @@ export type entityDirectiveArgs = { };
 export type entityDirectiveResolver<Result, Parent, ContextType = MeshContext, Args = entityDirectiveArgs> = DirectiveResolverFn<Result, Parent, ContextType, Args>;
 
 export type subgraphIdDirectiveArgs = {
-  id: Scalars['String'];
+  id: Scalars['String']['input'];
 };
 
 export type subgraphIdDirectiveResolver<Result, Parent, ContextType = MeshContext, Args = subgraphIdDirectiveArgs> = DirectiveResolverFn<Result, Parent, ContextType, Args>;
 
 export type derivedFromDirectiveArgs = {
-  field: Scalars['String'];
+  field: Scalars['String']['input'];
 };
 
 export type derivedFromDirectiveResolver<Result, Parent, ContextType = MeshContext, Args = derivedFromDirectiveArgs> = DirectiveResolverFn<Result, Parent, ContextType, Args>;
@@ -972,6 +1215,7 @@ export type AttestationResolvers<ContextType = MeshContext, ParentType extends R
   version?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
   revoked?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   subject?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
+  encodedSubject?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
   attestationData?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
   schemaString?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   decodedData?: Resolver<Maybe<Array<ResolversTypes['String']>>, ParentType, ContextType>;
@@ -999,6 +1243,15 @@ export type CounterResolvers<ContextType = MeshContext, ParentType extends Resol
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
+export interface Int8ScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['Int8'], any> {
+  name: 'Int8';
+}
+
+export type IssuerResolvers<ContextType = MeshContext, ParentType extends ResolversParentTypes['Issuer'] = ResolversParentTypes['Issuer']> = ResolversObject<{
+  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
 export type ModuleResolvers<ContextType = MeshContext, ParentType extends ResolversParentTypes['Module'] = ResolversParentTypes['Module']> = ResolversObject<{
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   moduleAddress?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
@@ -1015,6 +1268,7 @@ export type PortalResolvers<ContextType = MeshContext, ParentType extends Resolv
   name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   description?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   ownerName?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  attestationCounter?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
@@ -1029,7 +1283,18 @@ export type QueryResolvers<ContextType = MeshContext, ParentType extends Resolve
   schemas?: Resolver<Array<ResolversTypes['Schema']>, ParentType, ContextType, RequireFields<QueryschemasArgs, 'skip' | 'first' | 'subgraphError'>>;
   counter?: Resolver<Maybe<ResolversTypes['Counter']>, ParentType, ContextType, RequireFields<QuerycounterArgs, 'id' | 'subgraphError'>>;
   counters?: Resolver<Array<ResolversTypes['Counter']>, ParentType, ContextType, RequireFields<QuerycountersArgs, 'skip' | 'first' | 'subgraphError'>>;
+  issuer?: Resolver<Maybe<ResolversTypes['Issuer']>, ParentType, ContextType, RequireFields<QueryissuerArgs, 'id' | 'subgraphError'>>;
+  issuers?: Resolver<Array<ResolversTypes['Issuer']>, ParentType, ContextType, RequireFields<QueryissuersArgs, 'skip' | 'first' | 'subgraphError'>>;
+  registryVersion?: Resolver<Maybe<ResolversTypes['RegistryVersion']>, ParentType, ContextType, RequireFields<QueryregistryVersionArgs, 'id' | 'subgraphError'>>;
+  registryVersions?: Resolver<Array<ResolversTypes['RegistryVersion']>, ParentType, ContextType, RequireFields<QueryregistryVersionsArgs, 'skip' | 'first' | 'subgraphError'>>;
   _meta?: Resolver<Maybe<ResolversTypes['_Meta_']>, ParentType, ContextType, Partial<Query_metaArgs>>;
+}>;
+
+export type RegistryVersionResolvers<ContextType = MeshContext, ParentType extends ResolversParentTypes['RegistryVersion'] = ResolversParentTypes['RegistryVersion']> = ResolversObject<{
+  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  versionNumber?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  timestamp?: Resolver<Maybe<ResolversTypes['BigInt']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
 export type SchemaResolvers<ContextType = MeshContext, ParentType extends ResolversParentTypes['Schema'] = ResolversParentTypes['Schema']> = ResolversObject<{
@@ -1038,6 +1303,7 @@ export type SchemaResolvers<ContextType = MeshContext, ParentType extends Resolv
   description?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   context?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   schema?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  attestationCounter?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
@@ -1052,13 +1318,22 @@ export type SubscriptionResolvers<ContextType = MeshContext, ParentType extends 
   schemas?: SubscriptionResolver<Array<ResolversTypes['Schema']>, "schemas", ParentType, ContextType, RequireFields<SubscriptionschemasArgs, 'skip' | 'first' | 'subgraphError'>>;
   counter?: SubscriptionResolver<Maybe<ResolversTypes['Counter']>, "counter", ParentType, ContextType, RequireFields<SubscriptioncounterArgs, 'id' | 'subgraphError'>>;
   counters?: SubscriptionResolver<Array<ResolversTypes['Counter']>, "counters", ParentType, ContextType, RequireFields<SubscriptioncountersArgs, 'skip' | 'first' | 'subgraphError'>>;
+  issuer?: SubscriptionResolver<Maybe<ResolversTypes['Issuer']>, "issuer", ParentType, ContextType, RequireFields<SubscriptionissuerArgs, 'id' | 'subgraphError'>>;
+  issuers?: SubscriptionResolver<Array<ResolversTypes['Issuer']>, "issuers", ParentType, ContextType, RequireFields<SubscriptionissuersArgs, 'skip' | 'first' | 'subgraphError'>>;
+  registryVersion?: SubscriptionResolver<Maybe<ResolversTypes['RegistryVersion']>, "registryVersion", ParentType, ContextType, RequireFields<SubscriptionregistryVersionArgs, 'id' | 'subgraphError'>>;
+  registryVersions?: SubscriptionResolver<Array<ResolversTypes['RegistryVersion']>, "registryVersions", ParentType, ContextType, RequireFields<SubscriptionregistryVersionsArgs, 'skip' | 'first' | 'subgraphError'>>;
   _meta?: SubscriptionResolver<Maybe<ResolversTypes['_Meta_']>, "_meta", ParentType, ContextType, Partial<Subscription_metaArgs>>;
 }>;
+
+export interface TimestampScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['Timestamp'], any> {
+  name: 'Timestamp';
+}
 
 export type _Block_Resolvers<ContextType = MeshContext, ParentType extends ResolversParentTypes['_Block_'] = ResolversParentTypes['_Block_']> = ResolversObject<{
   hash?: Resolver<Maybe<ResolversTypes['Bytes']>, ParentType, ContextType>;
   number?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   timestamp?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  parentHash?: Resolver<Maybe<ResolversTypes['Bytes']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
@@ -1075,11 +1350,15 @@ export type Resolvers<ContextType = MeshContext> = ResolversObject<{
   BigInt?: GraphQLScalarType;
   Bytes?: GraphQLScalarType;
   Counter?: CounterResolvers<ContextType>;
+  Int8?: GraphQLScalarType;
+  Issuer?: IssuerResolvers<ContextType>;
   Module?: ModuleResolvers<ContextType>;
   Portal?: PortalResolvers<ContextType>;
   Query?: QueryResolvers<ContextType>;
+  RegistryVersion?: RegistryVersionResolvers<ContextType>;
   Schema?: SchemaResolvers<ContextType>;
   Subscription?: SubscriptionResolvers<ContextType>;
+  Timestamp?: GraphQLScalarType;
   _Block_?: _Block_Resolvers<ContextType>;
   _Meta_?: _Meta_Resolvers<ContextType>;
 }>;
@@ -1093,8 +1372,7 @@ export type DirectiveResolvers<ContextType = MeshContext> = ResolversObject<{
 export type MeshContext = LineaAttestationRegistryTypes.Context & BaseMeshContext;
 
 
-import { fileURLToPath } from '@graphql-mesh/utils';
-const baseDir = pathModule.join(pathModule.dirname(fileURLToPath(import.meta.url)), '..');
+const baseDir = pathModule.join(typeof __dirname === 'string' ? __dirname : '/', '..');
 
 const importFn: ImportFn = <T>(moduleId: string) => {
   const relativeModuleId = (pathModule.isAbsolute(moduleId) ? pathModule.relative(baseDir, moduleId) : moduleId).split('\\').join('/').replace(baseDir + '/', '');
@@ -1136,7 +1414,7 @@ const lineaAttestationRegistryTransforms = [];
 const additionalTypeDefs = [] as any[];
 const lineaAttestationRegistryHandler = new GraphqlHandler({
               name: "linea-attestation-registry",
-              config: {"endpoint":"https://graph-query.linea.build/subgraphs/name/Consensys/linea-attestation-registry"},
+              config: {"endpoint":"https://api.studio.thegraph.com/query/67521/verax-v1-linea/v0.0.1"},
               baseDir,
               cache,
               pubsub,
@@ -1187,8 +1465,24 @@ export function createBuiltMeshHTTPHandler<TServerContext = {}>(): MeshHTTPHandl
 
 let meshInstance$: Promise<MeshInstance> | undefined;
 
+export const pollingInterval = null;
+
 export function getBuiltGraphClient(): Promise<MeshInstance> {
   if (meshInstance$ == null) {
+    if (pollingInterval) {
+      setInterval(() => {
+        getMeshOptions()
+        .then(meshOptions => getMesh(meshOptions))
+        .then(newMesh =>
+          meshInstance$.then(oldMesh => {
+            oldMesh.destroy()
+            meshInstance$ = Promise.resolve(newMesh)
+          })
+        ).catch(err => {
+          console.error("Mesh polling failed so the existing version will be used:", err);
+        });
+      }, pollingInterval)
+    }
     meshInstance$ = getMeshOptions().then(meshOptions => getMesh(meshOptions)).then(mesh => {
       const id = mesh.pubsub.subscribe('destroy', () => {
         meshInstance$ = undefined;

--- a/sdk/.graphclient/schema.graphql
+++ b/sdk/.graphclient/schema.graphql
@@ -3,14 +3,23 @@ schema {
   subscription: Subscription
 }
 
-"Marks the GraphQL type as indexable entity.  Each type that should be an entity is required to be annotated with this directive."
+"""
+Marks the GraphQL type as indexable entity.  Each type that should be an entity is required to be annotated with this directive.
+"""
 directive @entity on OBJECT
 
-"Defined a Subgraph ID for an object type"
+"""Defined a Subgraph ID for an object type"""
 directive @subgraphId(id: String!) on OBJECT
 
-"creates a virtual field on the entity that may be queried but cannot be set manually through the mappings API."
+"""
+creates a virtual field on the entity that may be queried but cannot be set manually through the mappings API.
+"""
 directive @derivedFrom(field: String!) on FIELD_DEFINITION
+
+enum Aggregation_interval {
+  hour
+  day
+}
 
 type Attestation {
   id: ID!
@@ -24,6 +33,7 @@ type Attestation {
   version: BigInt!
   revoked: Boolean!
   subject: Bytes!
+  encodedSubject: Bytes!
   attestationData: Bytes!
   schemaString: String
   decodedData: [String!]
@@ -40,24 +50,40 @@ input Attestation_filter {
   id_not_in: [ID!]
   schemaId: Bytes
   schemaId_not: Bytes
+  schemaId_gt: Bytes
+  schemaId_lt: Bytes
+  schemaId_gte: Bytes
+  schemaId_lte: Bytes
   schemaId_in: [Bytes!]
   schemaId_not_in: [Bytes!]
   schemaId_contains: Bytes
   schemaId_not_contains: Bytes
   replacedBy: Bytes
   replacedBy_not: Bytes
+  replacedBy_gt: Bytes
+  replacedBy_lt: Bytes
+  replacedBy_gte: Bytes
+  replacedBy_lte: Bytes
   replacedBy_in: [Bytes!]
   replacedBy_not_in: [Bytes!]
   replacedBy_contains: Bytes
   replacedBy_not_contains: Bytes
   attester: Bytes
   attester_not: Bytes
+  attester_gt: Bytes
+  attester_lt: Bytes
+  attester_gte: Bytes
+  attester_lte: Bytes
   attester_in: [Bytes!]
   attester_not_in: [Bytes!]
   attester_contains: Bytes
   attester_not_contains: Bytes
   portal: Bytes
   portal_not: Bytes
+  portal_gt: Bytes
+  portal_lt: Bytes
+  portal_gte: Bytes
+  portal_lte: Bytes
   portal_in: [Bytes!]
   portal_not_in: [Bytes!]
   portal_contains: Bytes
@@ -100,12 +126,30 @@ input Attestation_filter {
   revoked_not_in: [Boolean!]
   subject: Bytes
   subject_not: Bytes
+  subject_gt: Bytes
+  subject_lt: Bytes
+  subject_gte: Bytes
+  subject_lte: Bytes
   subject_in: [Bytes!]
   subject_not_in: [Bytes!]
   subject_contains: Bytes
   subject_not_contains: Bytes
+  encodedSubject: Bytes
+  encodedSubject_not: Bytes
+  encodedSubject_gt: Bytes
+  encodedSubject_lt: Bytes
+  encodedSubject_gte: Bytes
+  encodedSubject_lte: Bytes
+  encodedSubject_in: [Bytes!]
+  encodedSubject_not_in: [Bytes!]
+  encodedSubject_contains: Bytes
+  encodedSubject_not_contains: Bytes
   attestationData: Bytes
   attestationData_not: Bytes
+  attestationData_gt: Bytes
+  attestationData_lt: Bytes
+  attestationData_gte: Bytes
+  attestationData_lte: Bytes
   attestationData_in: [Bytes!]
   attestationData_not_in: [Bytes!]
   attestationData_contains: Bytes
@@ -138,6 +182,8 @@ input Attestation_filter {
   decodedData_not_contains_nocase: [String!]
   """Filter for the block changed event."""
   _change_block: BlockChangedFilter
+  and: [Attestation_filter]
+  or: [Attestation_filter]
 }
 
 enum Attestation_orderBy {
@@ -152,6 +198,7 @@ enum Attestation_orderBy {
   version
   revoked
   subject
+  encodedSubject
   attestationData
   schemaString
   decodedData
@@ -224,6 +271,8 @@ input Counter_filter {
   schemas_not_in: [Int!]
   """Filter for the block changed event."""
   _change_block: BlockChangedFilter
+  and: [Counter_filter]
+  or: [Counter_filter]
 }
 
 enum Counter_orderBy {
@@ -232,6 +281,35 @@ enum Counter_orderBy {
   modules
   portals
   schemas
+}
+
+"""
+8 bytes signed integer
+
+"""
+scalar Int8
+
+type Issuer {
+  id: ID!
+}
+
+input Issuer_filter {
+  id: ID
+  id_not: ID
+  id_gt: ID
+  id_lt: ID
+  id_gte: ID
+  id_lte: ID
+  id_in: [ID!]
+  id_not_in: [ID!]
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [Issuer_filter]
+  or: [Issuer_filter]
+}
+
+enum Issuer_orderBy {
+  id
 }
 
 type Module {
@@ -252,6 +330,10 @@ input Module_filter {
   id_not_in: [ID!]
   moduleAddress: Bytes
   moduleAddress_not: Bytes
+  moduleAddress_gt: Bytes
+  moduleAddress_lt: Bytes
+  moduleAddress_gte: Bytes
+  moduleAddress_lte: Bytes
   moduleAddress_in: [Bytes!]
   moduleAddress_not_in: [Bytes!]
   moduleAddress_contains: Bytes
@@ -298,6 +380,8 @@ input Module_filter {
   description_not_ends_with_nocase: String
   """Filter for the block changed event."""
   _change_block: BlockChangedFilter
+  and: [Module_filter]
+  or: [Module_filter]
 }
 
 enum Module_orderBy {
@@ -321,6 +405,7 @@ type Portal {
   name: String!
   description: String!
   ownerName: String!
+  attestationCounter: Int
 }
 
 input Portal_filter {
@@ -334,6 +419,10 @@ input Portal_filter {
   id_not_in: [ID!]
   ownerAddress: Bytes
   ownerAddress_not: Bytes
+  ownerAddress_gt: Bytes
+  ownerAddress_lt: Bytes
+  ownerAddress_gte: Bytes
+  ownerAddress_lte: Bytes
   ownerAddress_in: [Bytes!]
   ownerAddress_not_in: [Bytes!]
   ownerAddress_contains: Bytes
@@ -408,8 +497,18 @@ input Portal_filter {
   ownerName_ends_with_nocase: String
   ownerName_not_ends_with: String
   ownerName_not_ends_with_nocase: String
+  attestationCounter: Int
+  attestationCounter_not: Int
+  attestationCounter_gt: Int
+  attestationCounter_lt: Int
+  attestationCounter_gte: Int
+  attestationCounter_lte: Int
+  attestationCounter_in: [Int!]
+  attestationCounter_not_in: [Int!]
   """Filter for the block changed event."""
   _change_block: BlockChangedFilter
+  and: [Portal_filter]
+  or: [Portal_filter]
 }
 
 enum Portal_orderBy {
@@ -420,6 +519,7 @@ enum Portal_orderBy {
   name
   description
   ownerName
+  attestationCounter
 }
 
 type Query {
@@ -553,8 +653,103 @@ type Query {
     """
     subgraphError: _SubgraphErrorPolicy_! = deny
   ): [Counter!]!
+  issuer(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): Issuer
+  issuers(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: Issuer_orderBy
+    orderDirection: OrderDirection
+    where: Issuer_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [Issuer!]!
+  registryVersion(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): RegistryVersion
+  registryVersions(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: RegistryVersion_orderBy
+    orderDirection: OrderDirection
+    where: RegistryVersion_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [RegistryVersion!]!
   """Access to subgraph metadata"""
   _meta(block: Block_height): _Meta_
+}
+
+type RegistryVersion {
+  id: ID!
+  versionNumber: Int
+  timestamp: BigInt
+}
+
+input RegistryVersion_filter {
+  id: ID
+  id_not: ID
+  id_gt: ID
+  id_lt: ID
+  id_gte: ID
+  id_lte: ID
+  id_in: [ID!]
+  id_not_in: [ID!]
+  versionNumber: Int
+  versionNumber_not: Int
+  versionNumber_gt: Int
+  versionNumber_lt: Int
+  versionNumber_gte: Int
+  versionNumber_lte: Int
+  versionNumber_in: [Int!]
+  versionNumber_not_in: [Int!]
+  timestamp: BigInt
+  timestamp_not: BigInt
+  timestamp_gt: BigInt
+  timestamp_lt: BigInt
+  timestamp_gte: BigInt
+  timestamp_lte: BigInt
+  timestamp_in: [BigInt!]
+  timestamp_not_in: [BigInt!]
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [RegistryVersion_filter]
+  or: [RegistryVersion_filter]
+}
+
+enum RegistryVersion_orderBy {
+  id
+  versionNumber
+  timestamp
 }
 
 type Schema {
@@ -563,6 +758,7 @@ type Schema {
   description: String!
   context: String!
   schema: String!
+  attestationCounter: Int
 }
 
 input Schema_filter {
@@ -654,8 +850,18 @@ input Schema_filter {
   schema_ends_with_nocase: String
   schema_not_ends_with: String
   schema_not_ends_with_nocase: String
+  attestationCounter: Int
+  attestationCounter_not: Int
+  attestationCounter_gt: Int
+  attestationCounter_lt: Int
+  attestationCounter_gte: Int
+  attestationCounter_lte: Int
+  attestationCounter_in: [Int!]
+  attestationCounter_not_in: [Int!]
   """Filter for the block changed event."""
   _change_block: BlockChangedFilter
+  and: [Schema_filter]
+  or: [Schema_filter]
 }
 
 enum Schema_orderBy {
@@ -664,6 +870,7 @@ enum Schema_orderBy {
   description
   context
   schema
+  attestationCounter
 }
 
 type Subscription {
@@ -797,9 +1004,67 @@ type Subscription {
     """
     subgraphError: _SubgraphErrorPolicy_! = deny
   ): [Counter!]!
+  issuer(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): Issuer
+  issuers(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: Issuer_orderBy
+    orderDirection: OrderDirection
+    where: Issuer_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [Issuer!]!
+  registryVersion(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): RegistryVersion
+  registryVersions(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: RegistryVersion_orderBy
+    orderDirection: OrderDirection
+    where: RegistryVersion_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [RegistryVersion!]!
   """Access to subgraph metadata"""
   _meta(block: Block_height): _Meta_
 }
+
+"""
+A string representation of microseconds UNIX timestamp (16 digits)
+
+"""
+scalar Timestamp
 
 type _Block_ {
   """The hash of the block"""
@@ -808,6 +1073,8 @@ type _Block_ {
   number: Int!
   """Integer representation of the timestamp stored in blocks for the chain"""
   timestamp: Int
+  """The hash of the parent block"""
+  parentHash: Bytes
 }
 
 """The type for the top-level _meta field"""

--- a/sdk/.graphclient/sources/linea-attestation-registry/introspectionSchema.ts
+++ b/sdk/.graphclient/sources/linea-attestation-registry/introspectionSchema.ts
@@ -36,7 +36,8 @@ const schemaAST = {
       "kind": "DirectiveDefinition",
       "description": {
         "kind": "StringValue",
-        "value": "Marks the GraphQL type as indexable entity.  Each type that should be an entity is required to be annotated with this directive."
+        "value": "Marks the GraphQL type as indexable entity.  Each type that should be an entity is required to be annotated with this directive.",
+        "block": true
       },
       "name": {
         "kind": "Name",
@@ -55,7 +56,8 @@ const schemaAST = {
       "kind": "DirectiveDefinition",
       "description": {
         "kind": "StringValue",
-        "value": "Defined a Subgraph ID for an object type"
+        "value": "Defined a Subgraph ID for an object type",
+        "block": true
       },
       "name": {
         "kind": "Name",
@@ -93,7 +95,8 @@ const schemaAST = {
       "kind": "DirectiveDefinition",
       "description": {
         "kind": "StringValue",
-        "value": "creates a virtual field on the entity that may be queried but cannot be set manually through the mappings API."
+        "value": "creates a virtual field on the entity that may be queried but cannot be set manually through the mappings API.",
+        "block": true
       },
       "name": {
         "kind": "Name",
@@ -126,6 +129,32 @@ const schemaAST = {
           "value": "FIELD_DEFINITION"
         }
       ]
+    },
+    {
+      "kind": "EnumTypeDefinition",
+      "name": {
+        "kind": "Name",
+        "value": "Aggregation_interval"
+      },
+      "values": [
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "hour"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "day"
+          },
+          "directives": []
+        }
+      ],
+      "directives": []
     },
     {
       "kind": "ObjectTypeDefinition",
@@ -329,6 +358,25 @@ const schemaAST = {
           "name": {
             "kind": "Name",
             "value": "subject"
+          },
+          "arguments": [],
+          "type": {
+            "kind": "NonNullType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "Bytes"
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "FieldDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "encodedSubject"
           },
           "arguments": [],
           "type": {
@@ -577,6 +625,66 @@ const schemaAST = {
           "kind": "InputValueDefinition",
           "name": {
             "kind": "Name",
+            "value": "schemaId_gt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "schemaId_lt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "schemaId_gte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "schemaId_lte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
             "value": "schemaId_in"
           },
           "type": {
@@ -665,6 +773,66 @@ const schemaAST = {
           "name": {
             "kind": "Name",
             "value": "replacedBy_not"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "replacedBy_gt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "replacedBy_lt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "replacedBy_gte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "replacedBy_lte"
           },
           "type": {
             "kind": "NamedType",
@@ -781,6 +949,66 @@ const schemaAST = {
           "kind": "InputValueDefinition",
           "name": {
             "kind": "Name",
+            "value": "attester_gt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "attester_lt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "attester_gte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "attester_lte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
             "value": "attester_in"
           },
           "type": {
@@ -869,6 +1097,66 @@ const schemaAST = {
           "name": {
             "kind": "Name",
             "value": "portal_not"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "portal_gt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "portal_lt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "portal_gte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "portal_lte"
           },
           "type": {
             "kind": "NamedType",
@@ -1585,6 +1873,66 @@ const schemaAST = {
           "kind": "InputValueDefinition",
           "name": {
             "kind": "Name",
+            "value": "subject_gt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "subject_lt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "subject_gte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "subject_lte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
             "value": "subject_in"
           },
           "type": {
@@ -1657,6 +2005,168 @@ const schemaAST = {
           "kind": "InputValueDefinition",
           "name": {
             "kind": "Name",
+            "value": "encodedSubject"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "encodedSubject_not"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "encodedSubject_gt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "encodedSubject_lt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "encodedSubject_gte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "encodedSubject_lte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "encodedSubject_in"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NonNullType",
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "Bytes"
+                }
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "encodedSubject_not_in"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NonNullType",
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "Bytes"
+                }
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "encodedSubject_contains"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "encodedSubject_not_contains"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
             "value": "attestationData"
           },
           "type": {
@@ -1673,6 +2183,66 @@ const schemaAST = {
           "name": {
             "kind": "Name",
             "value": "attestationData_not"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "attestationData_gt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "attestationData_lt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "attestationData_gte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "attestationData_lte"
           },
           "type": {
             "kind": "NamedType",
@@ -2212,6 +2782,42 @@ const schemaAST = {
             }
           },
           "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "and"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "Attestation_filter"
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "or"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "Attestation_filter"
+              }
+            }
+          },
+          "directives": []
         }
       ],
       "directives": []
@@ -2308,6 +2914,14 @@ const schemaAST = {
           "name": {
             "kind": "Name",
             "value": "subject"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "encodedSubject"
           },
           "directives": []
         },
@@ -3225,6 +3839,42 @@ const schemaAST = {
             }
           },
           "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "and"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "Counter_filter"
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "or"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "Counter_filter"
+              }
+            }
+          },
+          "directives": []
         }
       ],
       "directives": []
@@ -3273,6 +3923,265 @@ const schemaAST = {
           "name": {
             "kind": "Name",
             "value": "schemas"
+          },
+          "directives": []
+        }
+      ],
+      "directives": []
+    },
+    {
+      "kind": "ScalarTypeDefinition",
+      "description": {
+        "kind": "StringValue",
+        "value": "8 bytes signed integer\n",
+        "block": true
+      },
+      "name": {
+        "kind": "Name",
+        "value": "Int8"
+      },
+      "directives": []
+    },
+    {
+      "kind": "ObjectTypeDefinition",
+      "name": {
+        "kind": "Name",
+        "value": "Issuer"
+      },
+      "fields": [
+        {
+          "kind": "FieldDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "id"
+          },
+          "arguments": [],
+          "type": {
+            "kind": "NonNullType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "ID"
+              }
+            }
+          },
+          "directives": []
+        }
+      ],
+      "interfaces": [],
+      "directives": []
+    },
+    {
+      "kind": "InputObjectTypeDefinition",
+      "name": {
+        "kind": "Name",
+        "value": "Issuer_filter"
+      },
+      "fields": [
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "id"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "ID"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "id_not"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "ID"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "id_gt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "ID"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "id_lt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "ID"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "id_gte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "ID"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "id_lte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "ID"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "id_in"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NonNullType",
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "ID"
+                }
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "id_not_in"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NonNullType",
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "ID"
+                }
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "description": {
+            "kind": "StringValue",
+            "value": "Filter for the block changed event.",
+            "block": true
+          },
+          "name": {
+            "kind": "Name",
+            "value": "_change_block"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "BlockChangedFilter"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "and"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "Issuer_filter"
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "or"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "Issuer_filter"
+              }
+            }
+          },
+          "directives": []
+        }
+      ],
+      "directives": []
+    },
+    {
+      "kind": "EnumTypeDefinition",
+      "name": {
+        "kind": "Name",
+        "value": "Issuer_orderBy"
+      },
+      "values": [
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "id"
           },
           "directives": []
         }
@@ -3525,6 +4434,66 @@ const schemaAST = {
           "name": {
             "kind": "Name",
             "value": "moduleAddress_not"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "moduleAddress_gt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "moduleAddress_lt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "moduleAddress_gte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "moduleAddress_lte"
           },
           "type": {
             "kind": "NamedType",
@@ -4250,6 +5219,42 @@ const schemaAST = {
             }
           },
           "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "and"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "Module_filter"
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "or"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "Module_filter"
+              }
+            }
+          },
+          "directives": []
         }
       ],
       "directives": []
@@ -4469,6 +5474,22 @@ const schemaAST = {
             }
           },
           "directives": []
+        },
+        {
+          "kind": "FieldDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "attestationCounter"
+          },
+          "arguments": [],
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Int"
+            }
+          },
+          "directives": []
         }
       ],
       "interfaces": [],
@@ -4633,6 +5654,66 @@ const schemaAST = {
           "name": {
             "kind": "Name",
             "value": "ownerAddress_not"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "ownerAddress_gt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "ownerAddress_lt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "ownerAddress_gte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "ownerAddress_lte"
           },
           "type": {
             "kind": "NamedType",
@@ -5851,6 +6932,138 @@ const schemaAST = {
         },
         {
           "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "attestationCounter"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Int"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "attestationCounter_not"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Int"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "attestationCounter_gt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Int"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "attestationCounter_lt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Int"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "attestationCounter_gte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Int"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "attestationCounter_lte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Int"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "attestationCounter_in"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NonNullType",
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "Int"
+                }
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "attestationCounter_not_in"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NonNullType",
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "Int"
+                }
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
           "description": {
             "kind": "StringValue",
             "value": "Filter for the block changed event.",
@@ -5865,6 +7078,42 @@ const schemaAST = {
             "name": {
               "kind": "Name",
               "value": "BlockChangedFilter"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "and"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "Portal_filter"
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "or"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "Portal_filter"
+              }
             }
           },
           "directives": []
@@ -5932,6 +7181,14 @@ const schemaAST = {
           "name": {
             "kind": "Name",
             "value": "ownerName"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "attestationCounter"
           },
           "directives": []
         }
@@ -7137,6 +8394,482 @@ const schemaAST = {
         },
         {
           "kind": "FieldDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "issuer"
+          },
+          "arguments": [
+            {
+              "kind": "InputValueDefinition",
+              "name": {
+                "kind": "Name",
+                "value": "id"
+              },
+              "type": {
+                "kind": "NonNullType",
+                "type": {
+                  "kind": "NamedType",
+                  "name": {
+                    "kind": "Name",
+                    "value": "ID"
+                  }
+                }
+              },
+              "directives": []
+            },
+            {
+              "kind": "InputValueDefinition",
+              "description": {
+                "kind": "StringValue",
+                "value": "The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.",
+                "block": true
+              },
+              "name": {
+                "kind": "Name",
+                "value": "block"
+              },
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "Block_height"
+                }
+              },
+              "directives": []
+            },
+            {
+              "kind": "InputValueDefinition",
+              "description": {
+                "kind": "StringValue",
+                "value": "Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.",
+                "block": true
+              },
+              "name": {
+                "kind": "Name",
+                "value": "subgraphError"
+              },
+              "type": {
+                "kind": "NonNullType",
+                "type": {
+                  "kind": "NamedType",
+                  "name": {
+                    "kind": "Name",
+                    "value": "_SubgraphErrorPolicy_"
+                  }
+                }
+              },
+              "defaultValue": {
+                "kind": "EnumValue",
+                "value": "deny"
+              },
+              "directives": []
+            }
+          ],
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Issuer"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "FieldDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "issuers"
+          },
+          "arguments": [
+            {
+              "kind": "InputValueDefinition",
+              "name": {
+                "kind": "Name",
+                "value": "skip"
+              },
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "Int"
+                }
+              },
+              "defaultValue": {
+                "kind": "IntValue",
+                "value": "0"
+              },
+              "directives": []
+            },
+            {
+              "kind": "InputValueDefinition",
+              "name": {
+                "kind": "Name",
+                "value": "first"
+              },
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "Int"
+                }
+              },
+              "defaultValue": {
+                "kind": "IntValue",
+                "value": "100"
+              },
+              "directives": []
+            },
+            {
+              "kind": "InputValueDefinition",
+              "name": {
+                "kind": "Name",
+                "value": "orderBy"
+              },
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "Issuer_orderBy"
+                }
+              },
+              "directives": []
+            },
+            {
+              "kind": "InputValueDefinition",
+              "name": {
+                "kind": "Name",
+                "value": "orderDirection"
+              },
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "OrderDirection"
+                }
+              },
+              "directives": []
+            },
+            {
+              "kind": "InputValueDefinition",
+              "name": {
+                "kind": "Name",
+                "value": "where"
+              },
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "Issuer_filter"
+                }
+              },
+              "directives": []
+            },
+            {
+              "kind": "InputValueDefinition",
+              "description": {
+                "kind": "StringValue",
+                "value": "The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.",
+                "block": true
+              },
+              "name": {
+                "kind": "Name",
+                "value": "block"
+              },
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "Block_height"
+                }
+              },
+              "directives": []
+            },
+            {
+              "kind": "InputValueDefinition",
+              "description": {
+                "kind": "StringValue",
+                "value": "Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.",
+                "block": true
+              },
+              "name": {
+                "kind": "Name",
+                "value": "subgraphError"
+              },
+              "type": {
+                "kind": "NonNullType",
+                "type": {
+                  "kind": "NamedType",
+                  "name": {
+                    "kind": "Name",
+                    "value": "_SubgraphErrorPolicy_"
+                  }
+                }
+              },
+              "defaultValue": {
+                "kind": "EnumValue",
+                "value": "deny"
+              },
+              "directives": []
+            }
+          ],
+          "type": {
+            "kind": "NonNullType",
+            "type": {
+              "kind": "ListType",
+              "type": {
+                "kind": "NonNullType",
+                "type": {
+                  "kind": "NamedType",
+                  "name": {
+                    "kind": "Name",
+                    "value": "Issuer"
+                  }
+                }
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "FieldDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "registryVersion"
+          },
+          "arguments": [
+            {
+              "kind": "InputValueDefinition",
+              "name": {
+                "kind": "Name",
+                "value": "id"
+              },
+              "type": {
+                "kind": "NonNullType",
+                "type": {
+                  "kind": "NamedType",
+                  "name": {
+                    "kind": "Name",
+                    "value": "ID"
+                  }
+                }
+              },
+              "directives": []
+            },
+            {
+              "kind": "InputValueDefinition",
+              "description": {
+                "kind": "StringValue",
+                "value": "The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.",
+                "block": true
+              },
+              "name": {
+                "kind": "Name",
+                "value": "block"
+              },
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "Block_height"
+                }
+              },
+              "directives": []
+            },
+            {
+              "kind": "InputValueDefinition",
+              "description": {
+                "kind": "StringValue",
+                "value": "Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.",
+                "block": true
+              },
+              "name": {
+                "kind": "Name",
+                "value": "subgraphError"
+              },
+              "type": {
+                "kind": "NonNullType",
+                "type": {
+                  "kind": "NamedType",
+                  "name": {
+                    "kind": "Name",
+                    "value": "_SubgraphErrorPolicy_"
+                  }
+                }
+              },
+              "defaultValue": {
+                "kind": "EnumValue",
+                "value": "deny"
+              },
+              "directives": []
+            }
+          ],
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "RegistryVersion"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "FieldDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "registryVersions"
+          },
+          "arguments": [
+            {
+              "kind": "InputValueDefinition",
+              "name": {
+                "kind": "Name",
+                "value": "skip"
+              },
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "Int"
+                }
+              },
+              "defaultValue": {
+                "kind": "IntValue",
+                "value": "0"
+              },
+              "directives": []
+            },
+            {
+              "kind": "InputValueDefinition",
+              "name": {
+                "kind": "Name",
+                "value": "first"
+              },
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "Int"
+                }
+              },
+              "defaultValue": {
+                "kind": "IntValue",
+                "value": "100"
+              },
+              "directives": []
+            },
+            {
+              "kind": "InputValueDefinition",
+              "name": {
+                "kind": "Name",
+                "value": "orderBy"
+              },
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "RegistryVersion_orderBy"
+                }
+              },
+              "directives": []
+            },
+            {
+              "kind": "InputValueDefinition",
+              "name": {
+                "kind": "Name",
+                "value": "orderDirection"
+              },
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "OrderDirection"
+                }
+              },
+              "directives": []
+            },
+            {
+              "kind": "InputValueDefinition",
+              "name": {
+                "kind": "Name",
+                "value": "where"
+              },
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "RegistryVersion_filter"
+                }
+              },
+              "directives": []
+            },
+            {
+              "kind": "InputValueDefinition",
+              "description": {
+                "kind": "StringValue",
+                "value": "The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.",
+                "block": true
+              },
+              "name": {
+                "kind": "Name",
+                "value": "block"
+              },
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "Block_height"
+                }
+              },
+              "directives": []
+            },
+            {
+              "kind": "InputValueDefinition",
+              "description": {
+                "kind": "StringValue",
+                "value": "Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.",
+                "block": true
+              },
+              "name": {
+                "kind": "Name",
+                "value": "subgraphError"
+              },
+              "type": {
+                "kind": "NonNullType",
+                "type": {
+                  "kind": "NamedType",
+                  "name": {
+                    "kind": "Name",
+                    "value": "_SubgraphErrorPolicy_"
+                  }
+                }
+              },
+              "defaultValue": {
+                "kind": "EnumValue",
+                "value": "deny"
+              },
+              "directives": []
+            }
+          ],
+          "type": {
+            "kind": "NonNullType",
+            "type": {
+              "kind": "ListType",
+              "type": {
+                "kind": "NonNullType",
+                "type": {
+                  "kind": "NamedType",
+                  "name": {
+                    "kind": "Name",
+                    "value": "RegistryVersion"
+                  }
+                }
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "FieldDefinition",
           "description": {
             "kind": "StringValue",
             "value": "Access to subgraph metadata",
@@ -7174,6 +8907,564 @@ const schemaAST = {
         }
       ],
       "interfaces": [],
+      "directives": []
+    },
+    {
+      "kind": "ObjectTypeDefinition",
+      "name": {
+        "kind": "Name",
+        "value": "RegistryVersion"
+      },
+      "fields": [
+        {
+          "kind": "FieldDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "id"
+          },
+          "arguments": [],
+          "type": {
+            "kind": "NonNullType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "ID"
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "FieldDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "versionNumber"
+          },
+          "arguments": [],
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Int"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "FieldDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "timestamp"
+          },
+          "arguments": [],
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "BigInt"
+            }
+          },
+          "directives": []
+        }
+      ],
+      "interfaces": [],
+      "directives": []
+    },
+    {
+      "kind": "InputObjectTypeDefinition",
+      "name": {
+        "kind": "Name",
+        "value": "RegistryVersion_filter"
+      },
+      "fields": [
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "id"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "ID"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "id_not"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "ID"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "id_gt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "ID"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "id_lt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "ID"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "id_gte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "ID"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "id_lte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "ID"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "id_in"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NonNullType",
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "ID"
+                }
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "id_not_in"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NonNullType",
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "ID"
+                }
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "versionNumber"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Int"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "versionNumber_not"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Int"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "versionNumber_gt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Int"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "versionNumber_lt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Int"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "versionNumber_gte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Int"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "versionNumber_lte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Int"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "versionNumber_in"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NonNullType",
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "Int"
+                }
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "versionNumber_not_in"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NonNullType",
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "Int"
+                }
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "timestamp"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "BigInt"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "timestamp_not"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "BigInt"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "timestamp_gt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "BigInt"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "timestamp_lt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "BigInt"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "timestamp_gte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "BigInt"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "timestamp_lte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "BigInt"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "timestamp_in"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NonNullType",
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "BigInt"
+                }
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "timestamp_not_in"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NonNullType",
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "BigInt"
+                }
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "description": {
+            "kind": "StringValue",
+            "value": "Filter for the block changed event.",
+            "block": true
+          },
+          "name": {
+            "kind": "Name",
+            "value": "_change_block"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "BlockChangedFilter"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "and"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "RegistryVersion_filter"
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "or"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "RegistryVersion_filter"
+              }
+            }
+          },
+          "directives": []
+        }
+      ],
+      "directives": []
+    },
+    {
+      "kind": "EnumTypeDefinition",
+      "name": {
+        "kind": "Name",
+        "value": "RegistryVersion_orderBy"
+      },
+      "values": [
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "id"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "versionNumber"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "timestamp"
+          },
+          "directives": []
+        }
+      ],
       "directives": []
     },
     {
@@ -7274,6 +9565,22 @@ const schemaAST = {
                 "kind": "Name",
                 "value": "String"
               }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "FieldDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "attestationCounter"
+          },
+          "arguments": [],
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Int"
             }
           },
           "directives": []
@@ -8671,6 +10978,138 @@ const schemaAST = {
         },
         {
           "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "attestationCounter"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Int"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "attestationCounter_not"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Int"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "attestationCounter_gt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Int"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "attestationCounter_lt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Int"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "attestationCounter_gte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Int"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "attestationCounter_lte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Int"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "attestationCounter_in"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NonNullType",
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "Int"
+                }
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "attestationCounter_not_in"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NonNullType",
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "Int"
+                }
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
           "description": {
             "kind": "StringValue",
             "value": "Filter for the block changed event.",
@@ -8685,6 +11124,42 @@ const schemaAST = {
             "name": {
               "kind": "Name",
               "value": "BlockChangedFilter"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "and"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "Schema_filter"
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "or"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "Schema_filter"
+              }
             }
           },
           "directives": []
@@ -8736,6 +11211,14 @@ const schemaAST = {
           "name": {
             "kind": "Name",
             "value": "schema"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "attestationCounter"
           },
           "directives": []
         }
@@ -9941,6 +12424,482 @@ const schemaAST = {
         },
         {
           "kind": "FieldDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "issuer"
+          },
+          "arguments": [
+            {
+              "kind": "InputValueDefinition",
+              "name": {
+                "kind": "Name",
+                "value": "id"
+              },
+              "type": {
+                "kind": "NonNullType",
+                "type": {
+                  "kind": "NamedType",
+                  "name": {
+                    "kind": "Name",
+                    "value": "ID"
+                  }
+                }
+              },
+              "directives": []
+            },
+            {
+              "kind": "InputValueDefinition",
+              "description": {
+                "kind": "StringValue",
+                "value": "The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.",
+                "block": true
+              },
+              "name": {
+                "kind": "Name",
+                "value": "block"
+              },
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "Block_height"
+                }
+              },
+              "directives": []
+            },
+            {
+              "kind": "InputValueDefinition",
+              "description": {
+                "kind": "StringValue",
+                "value": "Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.",
+                "block": true
+              },
+              "name": {
+                "kind": "Name",
+                "value": "subgraphError"
+              },
+              "type": {
+                "kind": "NonNullType",
+                "type": {
+                  "kind": "NamedType",
+                  "name": {
+                    "kind": "Name",
+                    "value": "_SubgraphErrorPolicy_"
+                  }
+                }
+              },
+              "defaultValue": {
+                "kind": "EnumValue",
+                "value": "deny"
+              },
+              "directives": []
+            }
+          ],
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Issuer"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "FieldDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "issuers"
+          },
+          "arguments": [
+            {
+              "kind": "InputValueDefinition",
+              "name": {
+                "kind": "Name",
+                "value": "skip"
+              },
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "Int"
+                }
+              },
+              "defaultValue": {
+                "kind": "IntValue",
+                "value": "0"
+              },
+              "directives": []
+            },
+            {
+              "kind": "InputValueDefinition",
+              "name": {
+                "kind": "Name",
+                "value": "first"
+              },
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "Int"
+                }
+              },
+              "defaultValue": {
+                "kind": "IntValue",
+                "value": "100"
+              },
+              "directives": []
+            },
+            {
+              "kind": "InputValueDefinition",
+              "name": {
+                "kind": "Name",
+                "value": "orderBy"
+              },
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "Issuer_orderBy"
+                }
+              },
+              "directives": []
+            },
+            {
+              "kind": "InputValueDefinition",
+              "name": {
+                "kind": "Name",
+                "value": "orderDirection"
+              },
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "OrderDirection"
+                }
+              },
+              "directives": []
+            },
+            {
+              "kind": "InputValueDefinition",
+              "name": {
+                "kind": "Name",
+                "value": "where"
+              },
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "Issuer_filter"
+                }
+              },
+              "directives": []
+            },
+            {
+              "kind": "InputValueDefinition",
+              "description": {
+                "kind": "StringValue",
+                "value": "The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.",
+                "block": true
+              },
+              "name": {
+                "kind": "Name",
+                "value": "block"
+              },
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "Block_height"
+                }
+              },
+              "directives": []
+            },
+            {
+              "kind": "InputValueDefinition",
+              "description": {
+                "kind": "StringValue",
+                "value": "Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.",
+                "block": true
+              },
+              "name": {
+                "kind": "Name",
+                "value": "subgraphError"
+              },
+              "type": {
+                "kind": "NonNullType",
+                "type": {
+                  "kind": "NamedType",
+                  "name": {
+                    "kind": "Name",
+                    "value": "_SubgraphErrorPolicy_"
+                  }
+                }
+              },
+              "defaultValue": {
+                "kind": "EnumValue",
+                "value": "deny"
+              },
+              "directives": []
+            }
+          ],
+          "type": {
+            "kind": "NonNullType",
+            "type": {
+              "kind": "ListType",
+              "type": {
+                "kind": "NonNullType",
+                "type": {
+                  "kind": "NamedType",
+                  "name": {
+                    "kind": "Name",
+                    "value": "Issuer"
+                  }
+                }
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "FieldDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "registryVersion"
+          },
+          "arguments": [
+            {
+              "kind": "InputValueDefinition",
+              "name": {
+                "kind": "Name",
+                "value": "id"
+              },
+              "type": {
+                "kind": "NonNullType",
+                "type": {
+                  "kind": "NamedType",
+                  "name": {
+                    "kind": "Name",
+                    "value": "ID"
+                  }
+                }
+              },
+              "directives": []
+            },
+            {
+              "kind": "InputValueDefinition",
+              "description": {
+                "kind": "StringValue",
+                "value": "The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.",
+                "block": true
+              },
+              "name": {
+                "kind": "Name",
+                "value": "block"
+              },
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "Block_height"
+                }
+              },
+              "directives": []
+            },
+            {
+              "kind": "InputValueDefinition",
+              "description": {
+                "kind": "StringValue",
+                "value": "Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.",
+                "block": true
+              },
+              "name": {
+                "kind": "Name",
+                "value": "subgraphError"
+              },
+              "type": {
+                "kind": "NonNullType",
+                "type": {
+                  "kind": "NamedType",
+                  "name": {
+                    "kind": "Name",
+                    "value": "_SubgraphErrorPolicy_"
+                  }
+                }
+              },
+              "defaultValue": {
+                "kind": "EnumValue",
+                "value": "deny"
+              },
+              "directives": []
+            }
+          ],
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "RegistryVersion"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "FieldDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "registryVersions"
+          },
+          "arguments": [
+            {
+              "kind": "InputValueDefinition",
+              "name": {
+                "kind": "Name",
+                "value": "skip"
+              },
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "Int"
+                }
+              },
+              "defaultValue": {
+                "kind": "IntValue",
+                "value": "0"
+              },
+              "directives": []
+            },
+            {
+              "kind": "InputValueDefinition",
+              "name": {
+                "kind": "Name",
+                "value": "first"
+              },
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "Int"
+                }
+              },
+              "defaultValue": {
+                "kind": "IntValue",
+                "value": "100"
+              },
+              "directives": []
+            },
+            {
+              "kind": "InputValueDefinition",
+              "name": {
+                "kind": "Name",
+                "value": "orderBy"
+              },
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "RegistryVersion_orderBy"
+                }
+              },
+              "directives": []
+            },
+            {
+              "kind": "InputValueDefinition",
+              "name": {
+                "kind": "Name",
+                "value": "orderDirection"
+              },
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "OrderDirection"
+                }
+              },
+              "directives": []
+            },
+            {
+              "kind": "InputValueDefinition",
+              "name": {
+                "kind": "Name",
+                "value": "where"
+              },
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "RegistryVersion_filter"
+                }
+              },
+              "directives": []
+            },
+            {
+              "kind": "InputValueDefinition",
+              "description": {
+                "kind": "StringValue",
+                "value": "The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.",
+                "block": true
+              },
+              "name": {
+                "kind": "Name",
+                "value": "block"
+              },
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "Block_height"
+                }
+              },
+              "directives": []
+            },
+            {
+              "kind": "InputValueDefinition",
+              "description": {
+                "kind": "StringValue",
+                "value": "Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.",
+                "block": true
+              },
+              "name": {
+                "kind": "Name",
+                "value": "subgraphError"
+              },
+              "type": {
+                "kind": "NonNullType",
+                "type": {
+                  "kind": "NamedType",
+                  "name": {
+                    "kind": "Name",
+                    "value": "_SubgraphErrorPolicy_"
+                  }
+                }
+              },
+              "defaultValue": {
+                "kind": "EnumValue",
+                "value": "deny"
+              },
+              "directives": []
+            }
+          ],
+          "type": {
+            "kind": "NonNullType",
+            "type": {
+              "kind": "ListType",
+              "type": {
+                "kind": "NonNullType",
+                "type": {
+                  "kind": "NamedType",
+                  "name": {
+                    "kind": "Name",
+                    "value": "RegistryVersion"
+                  }
+                }
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "FieldDefinition",
           "description": {
             "kind": "StringValue",
             "value": "Access to subgraph metadata",
@@ -9978,6 +12937,19 @@ const schemaAST = {
         }
       ],
       "interfaces": [],
+      "directives": []
+    },
+    {
+      "kind": "ScalarTypeDefinition",
+      "description": {
+        "kind": "StringValue",
+        "value": "A string representation of microseconds UNIX timestamp (16 digits)\n",
+        "block": true
+      },
+      "name": {
+        "kind": "Name",
+        "value": "Timestamp"
+      },
       "directives": []
     },
     {
@@ -10049,6 +13021,27 @@ const schemaAST = {
             "name": {
               "kind": "Name",
               "value": "Int"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "FieldDefinition",
+          "description": {
+            "kind": "StringValue",
+            "value": "The hash of the parent block",
+            "block": true
+          },
+          "name": {
+            "kind": "Name",
+            "value": "parentHash"
+          },
+          "arguments": [],
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
             }
           },
           "directives": []

--- a/sdk/.graphclient/sources/linea-attestation-registry/schema.graphql
+++ b/sdk/.graphclient/sources/linea-attestation-registry/schema.graphql
@@ -3,14 +3,23 @@ schema {
   subscription: Subscription
 }
 
-"Marks the GraphQL type as indexable entity.  Each type that should be an entity is required to be annotated with this directive."
+"""
+Marks the GraphQL type as indexable entity.  Each type that should be an entity is required to be annotated with this directive.
+"""
 directive @entity on OBJECT
 
-"Defined a Subgraph ID for an object type"
+"""Defined a Subgraph ID for an object type"""
 directive @subgraphId(id: String!) on OBJECT
 
-"creates a virtual field on the entity that may be queried but cannot be set manually through the mappings API."
+"""
+creates a virtual field on the entity that may be queried but cannot be set manually through the mappings API.
+"""
 directive @derivedFrom(field: String!) on FIELD_DEFINITION
+
+enum Aggregation_interval {
+  hour
+  day
+}
 
 type Attestation {
   id: ID!
@@ -24,6 +33,7 @@ type Attestation {
   version: BigInt!
   revoked: Boolean!
   subject: Bytes!
+  encodedSubject: Bytes!
   attestationData: Bytes!
   schemaString: String
   decodedData: [String!]
@@ -40,24 +50,40 @@ input Attestation_filter {
   id_not_in: [ID!]
   schemaId: Bytes
   schemaId_not: Bytes
+  schemaId_gt: Bytes
+  schemaId_lt: Bytes
+  schemaId_gte: Bytes
+  schemaId_lte: Bytes
   schemaId_in: [Bytes!]
   schemaId_not_in: [Bytes!]
   schemaId_contains: Bytes
   schemaId_not_contains: Bytes
   replacedBy: Bytes
   replacedBy_not: Bytes
+  replacedBy_gt: Bytes
+  replacedBy_lt: Bytes
+  replacedBy_gte: Bytes
+  replacedBy_lte: Bytes
   replacedBy_in: [Bytes!]
   replacedBy_not_in: [Bytes!]
   replacedBy_contains: Bytes
   replacedBy_not_contains: Bytes
   attester: Bytes
   attester_not: Bytes
+  attester_gt: Bytes
+  attester_lt: Bytes
+  attester_gte: Bytes
+  attester_lte: Bytes
   attester_in: [Bytes!]
   attester_not_in: [Bytes!]
   attester_contains: Bytes
   attester_not_contains: Bytes
   portal: Bytes
   portal_not: Bytes
+  portal_gt: Bytes
+  portal_lt: Bytes
+  portal_gte: Bytes
+  portal_lte: Bytes
   portal_in: [Bytes!]
   portal_not_in: [Bytes!]
   portal_contains: Bytes
@@ -100,12 +126,30 @@ input Attestation_filter {
   revoked_not_in: [Boolean!]
   subject: Bytes
   subject_not: Bytes
+  subject_gt: Bytes
+  subject_lt: Bytes
+  subject_gte: Bytes
+  subject_lte: Bytes
   subject_in: [Bytes!]
   subject_not_in: [Bytes!]
   subject_contains: Bytes
   subject_not_contains: Bytes
+  encodedSubject: Bytes
+  encodedSubject_not: Bytes
+  encodedSubject_gt: Bytes
+  encodedSubject_lt: Bytes
+  encodedSubject_gte: Bytes
+  encodedSubject_lte: Bytes
+  encodedSubject_in: [Bytes!]
+  encodedSubject_not_in: [Bytes!]
+  encodedSubject_contains: Bytes
+  encodedSubject_not_contains: Bytes
   attestationData: Bytes
   attestationData_not: Bytes
+  attestationData_gt: Bytes
+  attestationData_lt: Bytes
+  attestationData_gte: Bytes
+  attestationData_lte: Bytes
   attestationData_in: [Bytes!]
   attestationData_not_in: [Bytes!]
   attestationData_contains: Bytes
@@ -138,6 +182,8 @@ input Attestation_filter {
   decodedData_not_contains_nocase: [String!]
   """Filter for the block changed event."""
   _change_block: BlockChangedFilter
+  and: [Attestation_filter]
+  or: [Attestation_filter]
 }
 
 enum Attestation_orderBy {
@@ -152,6 +198,7 @@ enum Attestation_orderBy {
   version
   revoked
   subject
+  encodedSubject
   attestationData
   schemaString
   decodedData
@@ -224,6 +271,8 @@ input Counter_filter {
   schemas_not_in: [Int!]
   """Filter for the block changed event."""
   _change_block: BlockChangedFilter
+  and: [Counter_filter]
+  or: [Counter_filter]
 }
 
 enum Counter_orderBy {
@@ -232,6 +281,35 @@ enum Counter_orderBy {
   modules
   portals
   schemas
+}
+
+"""
+8 bytes signed integer
+
+"""
+scalar Int8
+
+type Issuer {
+  id: ID!
+}
+
+input Issuer_filter {
+  id: ID
+  id_not: ID
+  id_gt: ID
+  id_lt: ID
+  id_gte: ID
+  id_lte: ID
+  id_in: [ID!]
+  id_not_in: [ID!]
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [Issuer_filter]
+  or: [Issuer_filter]
+}
+
+enum Issuer_orderBy {
+  id
 }
 
 type Module {
@@ -252,6 +330,10 @@ input Module_filter {
   id_not_in: [ID!]
   moduleAddress: Bytes
   moduleAddress_not: Bytes
+  moduleAddress_gt: Bytes
+  moduleAddress_lt: Bytes
+  moduleAddress_gte: Bytes
+  moduleAddress_lte: Bytes
   moduleAddress_in: [Bytes!]
   moduleAddress_not_in: [Bytes!]
   moduleAddress_contains: Bytes
@@ -298,6 +380,8 @@ input Module_filter {
   description_not_ends_with_nocase: String
   """Filter for the block changed event."""
   _change_block: BlockChangedFilter
+  and: [Module_filter]
+  or: [Module_filter]
 }
 
 enum Module_orderBy {
@@ -321,6 +405,7 @@ type Portal {
   name: String!
   description: String!
   ownerName: String!
+  attestationCounter: Int
 }
 
 input Portal_filter {
@@ -334,6 +419,10 @@ input Portal_filter {
   id_not_in: [ID!]
   ownerAddress: Bytes
   ownerAddress_not: Bytes
+  ownerAddress_gt: Bytes
+  ownerAddress_lt: Bytes
+  ownerAddress_gte: Bytes
+  ownerAddress_lte: Bytes
   ownerAddress_in: [Bytes!]
   ownerAddress_not_in: [Bytes!]
   ownerAddress_contains: Bytes
@@ -408,8 +497,18 @@ input Portal_filter {
   ownerName_ends_with_nocase: String
   ownerName_not_ends_with: String
   ownerName_not_ends_with_nocase: String
+  attestationCounter: Int
+  attestationCounter_not: Int
+  attestationCounter_gt: Int
+  attestationCounter_lt: Int
+  attestationCounter_gte: Int
+  attestationCounter_lte: Int
+  attestationCounter_in: [Int!]
+  attestationCounter_not_in: [Int!]
   """Filter for the block changed event."""
   _change_block: BlockChangedFilter
+  and: [Portal_filter]
+  or: [Portal_filter]
 }
 
 enum Portal_orderBy {
@@ -420,6 +519,7 @@ enum Portal_orderBy {
   name
   description
   ownerName
+  attestationCounter
 }
 
 type Query {
@@ -553,8 +653,103 @@ type Query {
     """
     subgraphError: _SubgraphErrorPolicy_! = deny
   ): [Counter!]!
+  issuer(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): Issuer
+  issuers(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: Issuer_orderBy
+    orderDirection: OrderDirection
+    where: Issuer_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [Issuer!]!
+  registryVersion(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): RegistryVersion
+  registryVersions(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: RegistryVersion_orderBy
+    orderDirection: OrderDirection
+    where: RegistryVersion_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [RegistryVersion!]!
   """Access to subgraph metadata"""
   _meta(block: Block_height): _Meta_
+}
+
+type RegistryVersion {
+  id: ID!
+  versionNumber: Int
+  timestamp: BigInt
+}
+
+input RegistryVersion_filter {
+  id: ID
+  id_not: ID
+  id_gt: ID
+  id_lt: ID
+  id_gte: ID
+  id_lte: ID
+  id_in: [ID!]
+  id_not_in: [ID!]
+  versionNumber: Int
+  versionNumber_not: Int
+  versionNumber_gt: Int
+  versionNumber_lt: Int
+  versionNumber_gte: Int
+  versionNumber_lte: Int
+  versionNumber_in: [Int!]
+  versionNumber_not_in: [Int!]
+  timestamp: BigInt
+  timestamp_not: BigInt
+  timestamp_gt: BigInt
+  timestamp_lt: BigInt
+  timestamp_gte: BigInt
+  timestamp_lte: BigInt
+  timestamp_in: [BigInt!]
+  timestamp_not_in: [BigInt!]
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [RegistryVersion_filter]
+  or: [RegistryVersion_filter]
+}
+
+enum RegistryVersion_orderBy {
+  id
+  versionNumber
+  timestamp
 }
 
 type Schema {
@@ -563,6 +758,7 @@ type Schema {
   description: String!
   context: String!
   schema: String!
+  attestationCounter: Int
 }
 
 input Schema_filter {
@@ -654,8 +850,18 @@ input Schema_filter {
   schema_ends_with_nocase: String
   schema_not_ends_with: String
   schema_not_ends_with_nocase: String
+  attestationCounter: Int
+  attestationCounter_not: Int
+  attestationCounter_gt: Int
+  attestationCounter_lt: Int
+  attestationCounter_gte: Int
+  attestationCounter_lte: Int
+  attestationCounter_in: [Int!]
+  attestationCounter_not_in: [Int!]
   """Filter for the block changed event."""
   _change_block: BlockChangedFilter
+  and: [Schema_filter]
+  or: [Schema_filter]
 }
 
 enum Schema_orderBy {
@@ -664,6 +870,7 @@ enum Schema_orderBy {
   description
   context
   schema
+  attestationCounter
 }
 
 type Subscription {
@@ -797,9 +1004,67 @@ type Subscription {
     """
     subgraphError: _SubgraphErrorPolicy_! = deny
   ): [Counter!]!
+  issuer(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): Issuer
+  issuers(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: Issuer_orderBy
+    orderDirection: OrderDirection
+    where: Issuer_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [Issuer!]!
+  registryVersion(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): RegistryVersion
+  registryVersions(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: RegistryVersion_orderBy
+    orderDirection: OrderDirection
+    where: RegistryVersion_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [RegistryVersion!]!
   """Access to subgraph metadata"""
   _meta(block: Block_height): _Meta_
 }
+
+"""
+A string representation of microseconds UNIX timestamp (16 digits)
+
+"""
+scalar Timestamp
 
 type _Block_ {
   """The hash of the block"""
@@ -808,6 +1073,8 @@ type _Block_ {
   number: Int!
   """Integer representation of the timestamp stored in blocks for the chain"""
   timestamp: Int
+  """The hash of the parent block"""
+  parentHash: Bytes
 }
 
 """The type for the top-level _meta field"""

--- a/sdk/.graphclient/sources/linea-attestation-registry/types.ts
+++ b/sdk/.graphclient/sources/linea-attestation-registry/types.ts
@@ -9,144 +9,189 @@ export type InputMaybe<T> = Maybe<T>;
 export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
 export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
 export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
+export type MakeEmpty<T extends { [key: string]: unknown }, K extends keyof T> = { [_ in K]?: never };
+export type Incremental<T> = T | { [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
-  ID: string;
-  String: string;
-  Boolean: boolean;
-  Int: number;
-  Float: number;
-  BigDecimal: any;
-  BigInt: any;
-  Bytes: any;
+  ID: { input: string; output: string; }
+  String: { input: string; output: string; }
+  Boolean: { input: boolean; output: boolean; }
+  Int: { input: number; output: number; }
+  Float: { input: number; output: number; }
+  BigDecimal: { input: any; output: any; }
+  BigInt: { input: any; output: any; }
+  Bytes: { input: any; output: any; }
+  Int8: { input: any; output: any; }
+  Timestamp: { input: any; output: any; }
 };
 
+export type Aggregation_interval =
+  | 'hour'
+  | 'day';
+
 export type Attestation = {
-  id: Scalars['ID'];
-  schemaId: Scalars['Bytes'];
-  replacedBy: Scalars['Bytes'];
-  attester: Scalars['Bytes'];
-  portal: Scalars['Bytes'];
-  attestedDate: Scalars['BigInt'];
-  expirationDate: Scalars['BigInt'];
-  revocationDate: Scalars['BigInt'];
-  version: Scalars['BigInt'];
-  revoked: Scalars['Boolean'];
-  subject: Scalars['Bytes'];
-  attestationData: Scalars['Bytes'];
-  schemaString?: Maybe<Scalars['String']>;
-  decodedData?: Maybe<Array<Scalars['String']>>;
+  id: Scalars['ID']['output'];
+  schemaId: Scalars['Bytes']['output'];
+  replacedBy: Scalars['Bytes']['output'];
+  attester: Scalars['Bytes']['output'];
+  portal: Scalars['Bytes']['output'];
+  attestedDate: Scalars['BigInt']['output'];
+  expirationDate: Scalars['BigInt']['output'];
+  revocationDate: Scalars['BigInt']['output'];
+  version: Scalars['BigInt']['output'];
+  revoked: Scalars['Boolean']['output'];
+  subject: Scalars['Bytes']['output'];
+  encodedSubject: Scalars['Bytes']['output'];
+  attestationData: Scalars['Bytes']['output'];
+  schemaString?: Maybe<Scalars['String']['output']>;
+  decodedData?: Maybe<Array<Scalars['String']['output']>>;
 };
 
 export type Attestation_filter = {
-  id?: InputMaybe<Scalars['ID']>;
-  id_not?: InputMaybe<Scalars['ID']>;
-  id_gt?: InputMaybe<Scalars['ID']>;
-  id_lt?: InputMaybe<Scalars['ID']>;
-  id_gte?: InputMaybe<Scalars['ID']>;
-  id_lte?: InputMaybe<Scalars['ID']>;
-  id_in?: InputMaybe<Array<Scalars['ID']>>;
-  id_not_in?: InputMaybe<Array<Scalars['ID']>>;
-  schemaId?: InputMaybe<Scalars['Bytes']>;
-  schemaId_not?: InputMaybe<Scalars['Bytes']>;
-  schemaId_in?: InputMaybe<Array<Scalars['Bytes']>>;
-  schemaId_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
-  schemaId_contains?: InputMaybe<Scalars['Bytes']>;
-  schemaId_not_contains?: InputMaybe<Scalars['Bytes']>;
-  replacedBy?: InputMaybe<Scalars['Bytes']>;
-  replacedBy_not?: InputMaybe<Scalars['Bytes']>;
-  replacedBy_in?: InputMaybe<Array<Scalars['Bytes']>>;
-  replacedBy_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
-  replacedBy_contains?: InputMaybe<Scalars['Bytes']>;
-  replacedBy_not_contains?: InputMaybe<Scalars['Bytes']>;
-  attester?: InputMaybe<Scalars['Bytes']>;
-  attester_not?: InputMaybe<Scalars['Bytes']>;
-  attester_in?: InputMaybe<Array<Scalars['Bytes']>>;
-  attester_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
-  attester_contains?: InputMaybe<Scalars['Bytes']>;
-  attester_not_contains?: InputMaybe<Scalars['Bytes']>;
-  portal?: InputMaybe<Scalars['Bytes']>;
-  portal_not?: InputMaybe<Scalars['Bytes']>;
-  portal_in?: InputMaybe<Array<Scalars['Bytes']>>;
-  portal_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
-  portal_contains?: InputMaybe<Scalars['Bytes']>;
-  portal_not_contains?: InputMaybe<Scalars['Bytes']>;
-  attestedDate?: InputMaybe<Scalars['BigInt']>;
-  attestedDate_not?: InputMaybe<Scalars['BigInt']>;
-  attestedDate_gt?: InputMaybe<Scalars['BigInt']>;
-  attestedDate_lt?: InputMaybe<Scalars['BigInt']>;
-  attestedDate_gte?: InputMaybe<Scalars['BigInt']>;
-  attestedDate_lte?: InputMaybe<Scalars['BigInt']>;
-  attestedDate_in?: InputMaybe<Array<Scalars['BigInt']>>;
-  attestedDate_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
-  expirationDate?: InputMaybe<Scalars['BigInt']>;
-  expirationDate_not?: InputMaybe<Scalars['BigInt']>;
-  expirationDate_gt?: InputMaybe<Scalars['BigInt']>;
-  expirationDate_lt?: InputMaybe<Scalars['BigInt']>;
-  expirationDate_gte?: InputMaybe<Scalars['BigInt']>;
-  expirationDate_lte?: InputMaybe<Scalars['BigInt']>;
-  expirationDate_in?: InputMaybe<Array<Scalars['BigInt']>>;
-  expirationDate_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
-  revocationDate?: InputMaybe<Scalars['BigInt']>;
-  revocationDate_not?: InputMaybe<Scalars['BigInt']>;
-  revocationDate_gt?: InputMaybe<Scalars['BigInt']>;
-  revocationDate_lt?: InputMaybe<Scalars['BigInt']>;
-  revocationDate_gte?: InputMaybe<Scalars['BigInt']>;
-  revocationDate_lte?: InputMaybe<Scalars['BigInt']>;
-  revocationDate_in?: InputMaybe<Array<Scalars['BigInt']>>;
-  revocationDate_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
-  version?: InputMaybe<Scalars['BigInt']>;
-  version_not?: InputMaybe<Scalars['BigInt']>;
-  version_gt?: InputMaybe<Scalars['BigInt']>;
-  version_lt?: InputMaybe<Scalars['BigInt']>;
-  version_gte?: InputMaybe<Scalars['BigInt']>;
-  version_lte?: InputMaybe<Scalars['BigInt']>;
-  version_in?: InputMaybe<Array<Scalars['BigInt']>>;
-  version_not_in?: InputMaybe<Array<Scalars['BigInt']>>;
-  revoked?: InputMaybe<Scalars['Boolean']>;
-  revoked_not?: InputMaybe<Scalars['Boolean']>;
-  revoked_in?: InputMaybe<Array<Scalars['Boolean']>>;
-  revoked_not_in?: InputMaybe<Array<Scalars['Boolean']>>;
-  subject?: InputMaybe<Scalars['Bytes']>;
-  subject_not?: InputMaybe<Scalars['Bytes']>;
-  subject_in?: InputMaybe<Array<Scalars['Bytes']>>;
-  subject_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
-  subject_contains?: InputMaybe<Scalars['Bytes']>;
-  subject_not_contains?: InputMaybe<Scalars['Bytes']>;
-  attestationData?: InputMaybe<Scalars['Bytes']>;
-  attestationData_not?: InputMaybe<Scalars['Bytes']>;
-  attestationData_in?: InputMaybe<Array<Scalars['Bytes']>>;
-  attestationData_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
-  attestationData_contains?: InputMaybe<Scalars['Bytes']>;
-  attestationData_not_contains?: InputMaybe<Scalars['Bytes']>;
-  schemaString?: InputMaybe<Scalars['String']>;
-  schemaString_not?: InputMaybe<Scalars['String']>;
-  schemaString_gt?: InputMaybe<Scalars['String']>;
-  schemaString_lt?: InputMaybe<Scalars['String']>;
-  schemaString_gte?: InputMaybe<Scalars['String']>;
-  schemaString_lte?: InputMaybe<Scalars['String']>;
-  schemaString_in?: InputMaybe<Array<Scalars['String']>>;
-  schemaString_not_in?: InputMaybe<Array<Scalars['String']>>;
-  schemaString_contains?: InputMaybe<Scalars['String']>;
-  schemaString_contains_nocase?: InputMaybe<Scalars['String']>;
-  schemaString_not_contains?: InputMaybe<Scalars['String']>;
-  schemaString_not_contains_nocase?: InputMaybe<Scalars['String']>;
-  schemaString_starts_with?: InputMaybe<Scalars['String']>;
-  schemaString_starts_with_nocase?: InputMaybe<Scalars['String']>;
-  schemaString_not_starts_with?: InputMaybe<Scalars['String']>;
-  schemaString_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
-  schemaString_ends_with?: InputMaybe<Scalars['String']>;
-  schemaString_ends_with_nocase?: InputMaybe<Scalars['String']>;
-  schemaString_not_ends_with?: InputMaybe<Scalars['String']>;
-  schemaString_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
-  decodedData?: InputMaybe<Array<Scalars['String']>>;
-  decodedData_not?: InputMaybe<Array<Scalars['String']>>;
-  decodedData_contains?: InputMaybe<Array<Scalars['String']>>;
-  decodedData_contains_nocase?: InputMaybe<Array<Scalars['String']>>;
-  decodedData_not_contains?: InputMaybe<Array<Scalars['String']>>;
-  decodedData_not_contains_nocase?: InputMaybe<Array<Scalars['String']>>;
+  id?: InputMaybe<Scalars['ID']['input']>;
+  id_not?: InputMaybe<Scalars['ID']['input']>;
+  id_gt?: InputMaybe<Scalars['ID']['input']>;
+  id_lt?: InputMaybe<Scalars['ID']['input']>;
+  id_gte?: InputMaybe<Scalars['ID']['input']>;
+  id_lte?: InputMaybe<Scalars['ID']['input']>;
+  id_in?: InputMaybe<Array<Scalars['ID']['input']>>;
+  id_not_in?: InputMaybe<Array<Scalars['ID']['input']>>;
+  schemaId?: InputMaybe<Scalars['Bytes']['input']>;
+  schemaId_not?: InputMaybe<Scalars['Bytes']['input']>;
+  schemaId_gt?: InputMaybe<Scalars['Bytes']['input']>;
+  schemaId_lt?: InputMaybe<Scalars['Bytes']['input']>;
+  schemaId_gte?: InputMaybe<Scalars['Bytes']['input']>;
+  schemaId_lte?: InputMaybe<Scalars['Bytes']['input']>;
+  schemaId_in?: InputMaybe<Array<Scalars['Bytes']['input']>>;
+  schemaId_not_in?: InputMaybe<Array<Scalars['Bytes']['input']>>;
+  schemaId_contains?: InputMaybe<Scalars['Bytes']['input']>;
+  schemaId_not_contains?: InputMaybe<Scalars['Bytes']['input']>;
+  replacedBy?: InputMaybe<Scalars['Bytes']['input']>;
+  replacedBy_not?: InputMaybe<Scalars['Bytes']['input']>;
+  replacedBy_gt?: InputMaybe<Scalars['Bytes']['input']>;
+  replacedBy_lt?: InputMaybe<Scalars['Bytes']['input']>;
+  replacedBy_gte?: InputMaybe<Scalars['Bytes']['input']>;
+  replacedBy_lte?: InputMaybe<Scalars['Bytes']['input']>;
+  replacedBy_in?: InputMaybe<Array<Scalars['Bytes']['input']>>;
+  replacedBy_not_in?: InputMaybe<Array<Scalars['Bytes']['input']>>;
+  replacedBy_contains?: InputMaybe<Scalars['Bytes']['input']>;
+  replacedBy_not_contains?: InputMaybe<Scalars['Bytes']['input']>;
+  attester?: InputMaybe<Scalars['Bytes']['input']>;
+  attester_not?: InputMaybe<Scalars['Bytes']['input']>;
+  attester_gt?: InputMaybe<Scalars['Bytes']['input']>;
+  attester_lt?: InputMaybe<Scalars['Bytes']['input']>;
+  attester_gte?: InputMaybe<Scalars['Bytes']['input']>;
+  attester_lte?: InputMaybe<Scalars['Bytes']['input']>;
+  attester_in?: InputMaybe<Array<Scalars['Bytes']['input']>>;
+  attester_not_in?: InputMaybe<Array<Scalars['Bytes']['input']>>;
+  attester_contains?: InputMaybe<Scalars['Bytes']['input']>;
+  attester_not_contains?: InputMaybe<Scalars['Bytes']['input']>;
+  portal?: InputMaybe<Scalars['Bytes']['input']>;
+  portal_not?: InputMaybe<Scalars['Bytes']['input']>;
+  portal_gt?: InputMaybe<Scalars['Bytes']['input']>;
+  portal_lt?: InputMaybe<Scalars['Bytes']['input']>;
+  portal_gte?: InputMaybe<Scalars['Bytes']['input']>;
+  portal_lte?: InputMaybe<Scalars['Bytes']['input']>;
+  portal_in?: InputMaybe<Array<Scalars['Bytes']['input']>>;
+  portal_not_in?: InputMaybe<Array<Scalars['Bytes']['input']>>;
+  portal_contains?: InputMaybe<Scalars['Bytes']['input']>;
+  portal_not_contains?: InputMaybe<Scalars['Bytes']['input']>;
+  attestedDate?: InputMaybe<Scalars['BigInt']['input']>;
+  attestedDate_not?: InputMaybe<Scalars['BigInt']['input']>;
+  attestedDate_gt?: InputMaybe<Scalars['BigInt']['input']>;
+  attestedDate_lt?: InputMaybe<Scalars['BigInt']['input']>;
+  attestedDate_gte?: InputMaybe<Scalars['BigInt']['input']>;
+  attestedDate_lte?: InputMaybe<Scalars['BigInt']['input']>;
+  attestedDate_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  attestedDate_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  expirationDate?: InputMaybe<Scalars['BigInt']['input']>;
+  expirationDate_not?: InputMaybe<Scalars['BigInt']['input']>;
+  expirationDate_gt?: InputMaybe<Scalars['BigInt']['input']>;
+  expirationDate_lt?: InputMaybe<Scalars['BigInt']['input']>;
+  expirationDate_gte?: InputMaybe<Scalars['BigInt']['input']>;
+  expirationDate_lte?: InputMaybe<Scalars['BigInt']['input']>;
+  expirationDate_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  expirationDate_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  revocationDate?: InputMaybe<Scalars['BigInt']['input']>;
+  revocationDate_not?: InputMaybe<Scalars['BigInt']['input']>;
+  revocationDate_gt?: InputMaybe<Scalars['BigInt']['input']>;
+  revocationDate_lt?: InputMaybe<Scalars['BigInt']['input']>;
+  revocationDate_gte?: InputMaybe<Scalars['BigInt']['input']>;
+  revocationDate_lte?: InputMaybe<Scalars['BigInt']['input']>;
+  revocationDate_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  revocationDate_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  version?: InputMaybe<Scalars['BigInt']['input']>;
+  version_not?: InputMaybe<Scalars['BigInt']['input']>;
+  version_gt?: InputMaybe<Scalars['BigInt']['input']>;
+  version_lt?: InputMaybe<Scalars['BigInt']['input']>;
+  version_gte?: InputMaybe<Scalars['BigInt']['input']>;
+  version_lte?: InputMaybe<Scalars['BigInt']['input']>;
+  version_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  version_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  revoked?: InputMaybe<Scalars['Boolean']['input']>;
+  revoked_not?: InputMaybe<Scalars['Boolean']['input']>;
+  revoked_in?: InputMaybe<Array<Scalars['Boolean']['input']>>;
+  revoked_not_in?: InputMaybe<Array<Scalars['Boolean']['input']>>;
+  subject?: InputMaybe<Scalars['Bytes']['input']>;
+  subject_not?: InputMaybe<Scalars['Bytes']['input']>;
+  subject_gt?: InputMaybe<Scalars['Bytes']['input']>;
+  subject_lt?: InputMaybe<Scalars['Bytes']['input']>;
+  subject_gte?: InputMaybe<Scalars['Bytes']['input']>;
+  subject_lte?: InputMaybe<Scalars['Bytes']['input']>;
+  subject_in?: InputMaybe<Array<Scalars['Bytes']['input']>>;
+  subject_not_in?: InputMaybe<Array<Scalars['Bytes']['input']>>;
+  subject_contains?: InputMaybe<Scalars['Bytes']['input']>;
+  subject_not_contains?: InputMaybe<Scalars['Bytes']['input']>;
+  encodedSubject?: InputMaybe<Scalars['Bytes']['input']>;
+  encodedSubject_not?: InputMaybe<Scalars['Bytes']['input']>;
+  encodedSubject_gt?: InputMaybe<Scalars['Bytes']['input']>;
+  encodedSubject_lt?: InputMaybe<Scalars['Bytes']['input']>;
+  encodedSubject_gte?: InputMaybe<Scalars['Bytes']['input']>;
+  encodedSubject_lte?: InputMaybe<Scalars['Bytes']['input']>;
+  encodedSubject_in?: InputMaybe<Array<Scalars['Bytes']['input']>>;
+  encodedSubject_not_in?: InputMaybe<Array<Scalars['Bytes']['input']>>;
+  encodedSubject_contains?: InputMaybe<Scalars['Bytes']['input']>;
+  encodedSubject_not_contains?: InputMaybe<Scalars['Bytes']['input']>;
+  attestationData?: InputMaybe<Scalars['Bytes']['input']>;
+  attestationData_not?: InputMaybe<Scalars['Bytes']['input']>;
+  attestationData_gt?: InputMaybe<Scalars['Bytes']['input']>;
+  attestationData_lt?: InputMaybe<Scalars['Bytes']['input']>;
+  attestationData_gte?: InputMaybe<Scalars['Bytes']['input']>;
+  attestationData_lte?: InputMaybe<Scalars['Bytes']['input']>;
+  attestationData_in?: InputMaybe<Array<Scalars['Bytes']['input']>>;
+  attestationData_not_in?: InputMaybe<Array<Scalars['Bytes']['input']>>;
+  attestationData_contains?: InputMaybe<Scalars['Bytes']['input']>;
+  attestationData_not_contains?: InputMaybe<Scalars['Bytes']['input']>;
+  schemaString?: InputMaybe<Scalars['String']['input']>;
+  schemaString_not?: InputMaybe<Scalars['String']['input']>;
+  schemaString_gt?: InputMaybe<Scalars['String']['input']>;
+  schemaString_lt?: InputMaybe<Scalars['String']['input']>;
+  schemaString_gte?: InputMaybe<Scalars['String']['input']>;
+  schemaString_lte?: InputMaybe<Scalars['String']['input']>;
+  schemaString_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  schemaString_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  schemaString_contains?: InputMaybe<Scalars['String']['input']>;
+  schemaString_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  schemaString_not_contains?: InputMaybe<Scalars['String']['input']>;
+  schemaString_not_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  schemaString_starts_with?: InputMaybe<Scalars['String']['input']>;
+  schemaString_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  schemaString_not_starts_with?: InputMaybe<Scalars['String']['input']>;
+  schemaString_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  schemaString_ends_with?: InputMaybe<Scalars['String']['input']>;
+  schemaString_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  schemaString_not_ends_with?: InputMaybe<Scalars['String']['input']>;
+  schemaString_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  decodedData?: InputMaybe<Array<Scalars['String']['input']>>;
+  decodedData_not?: InputMaybe<Array<Scalars['String']['input']>>;
+  decodedData_contains?: InputMaybe<Array<Scalars['String']['input']>>;
+  decodedData_contains_nocase?: InputMaybe<Array<Scalars['String']['input']>>;
+  decodedData_not_contains?: InputMaybe<Array<Scalars['String']['input']>>;
+  decodedData_not_contains_nocase?: InputMaybe<Array<Scalars['String']['input']>>;
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<Attestation_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<Attestation_filter>>>;
 };
 
 export type Attestation_orderBy =
@@ -161,71 +206,74 @@ export type Attestation_orderBy =
   | 'version'
   | 'revoked'
   | 'subject'
+  | 'encodedSubject'
   | 'attestationData'
   | 'schemaString'
   | 'decodedData';
 
 export type BlockChangedFilter = {
-  number_gte: Scalars['Int'];
+  number_gte: Scalars['Int']['input'];
 };
 
 export type Block_height = {
-  hash?: InputMaybe<Scalars['Bytes']>;
-  number?: InputMaybe<Scalars['Int']>;
-  number_gte?: InputMaybe<Scalars['Int']>;
+  hash?: InputMaybe<Scalars['Bytes']['input']>;
+  number?: InputMaybe<Scalars['Int']['input']>;
+  number_gte?: InputMaybe<Scalars['Int']['input']>;
 };
 
 export type Counter = {
-  id: Scalars['ID'];
-  attestations?: Maybe<Scalars['Int']>;
-  modules?: Maybe<Scalars['Int']>;
-  portals?: Maybe<Scalars['Int']>;
-  schemas?: Maybe<Scalars['Int']>;
+  id: Scalars['ID']['output'];
+  attestations?: Maybe<Scalars['Int']['output']>;
+  modules?: Maybe<Scalars['Int']['output']>;
+  portals?: Maybe<Scalars['Int']['output']>;
+  schemas?: Maybe<Scalars['Int']['output']>;
 };
 
 export type Counter_filter = {
-  id?: InputMaybe<Scalars['ID']>;
-  id_not?: InputMaybe<Scalars['ID']>;
-  id_gt?: InputMaybe<Scalars['ID']>;
-  id_lt?: InputMaybe<Scalars['ID']>;
-  id_gte?: InputMaybe<Scalars['ID']>;
-  id_lte?: InputMaybe<Scalars['ID']>;
-  id_in?: InputMaybe<Array<Scalars['ID']>>;
-  id_not_in?: InputMaybe<Array<Scalars['ID']>>;
-  attestations?: InputMaybe<Scalars['Int']>;
-  attestations_not?: InputMaybe<Scalars['Int']>;
-  attestations_gt?: InputMaybe<Scalars['Int']>;
-  attestations_lt?: InputMaybe<Scalars['Int']>;
-  attestations_gte?: InputMaybe<Scalars['Int']>;
-  attestations_lte?: InputMaybe<Scalars['Int']>;
-  attestations_in?: InputMaybe<Array<Scalars['Int']>>;
-  attestations_not_in?: InputMaybe<Array<Scalars['Int']>>;
-  modules?: InputMaybe<Scalars['Int']>;
-  modules_not?: InputMaybe<Scalars['Int']>;
-  modules_gt?: InputMaybe<Scalars['Int']>;
-  modules_lt?: InputMaybe<Scalars['Int']>;
-  modules_gte?: InputMaybe<Scalars['Int']>;
-  modules_lte?: InputMaybe<Scalars['Int']>;
-  modules_in?: InputMaybe<Array<Scalars['Int']>>;
-  modules_not_in?: InputMaybe<Array<Scalars['Int']>>;
-  portals?: InputMaybe<Scalars['Int']>;
-  portals_not?: InputMaybe<Scalars['Int']>;
-  portals_gt?: InputMaybe<Scalars['Int']>;
-  portals_lt?: InputMaybe<Scalars['Int']>;
-  portals_gte?: InputMaybe<Scalars['Int']>;
-  portals_lte?: InputMaybe<Scalars['Int']>;
-  portals_in?: InputMaybe<Array<Scalars['Int']>>;
-  portals_not_in?: InputMaybe<Array<Scalars['Int']>>;
-  schemas?: InputMaybe<Scalars['Int']>;
-  schemas_not?: InputMaybe<Scalars['Int']>;
-  schemas_gt?: InputMaybe<Scalars['Int']>;
-  schemas_lt?: InputMaybe<Scalars['Int']>;
-  schemas_gte?: InputMaybe<Scalars['Int']>;
-  schemas_lte?: InputMaybe<Scalars['Int']>;
-  schemas_in?: InputMaybe<Array<Scalars['Int']>>;
-  schemas_not_in?: InputMaybe<Array<Scalars['Int']>>;
+  id?: InputMaybe<Scalars['ID']['input']>;
+  id_not?: InputMaybe<Scalars['ID']['input']>;
+  id_gt?: InputMaybe<Scalars['ID']['input']>;
+  id_lt?: InputMaybe<Scalars['ID']['input']>;
+  id_gte?: InputMaybe<Scalars['ID']['input']>;
+  id_lte?: InputMaybe<Scalars['ID']['input']>;
+  id_in?: InputMaybe<Array<Scalars['ID']['input']>>;
+  id_not_in?: InputMaybe<Array<Scalars['ID']['input']>>;
+  attestations?: InputMaybe<Scalars['Int']['input']>;
+  attestations_not?: InputMaybe<Scalars['Int']['input']>;
+  attestations_gt?: InputMaybe<Scalars['Int']['input']>;
+  attestations_lt?: InputMaybe<Scalars['Int']['input']>;
+  attestations_gte?: InputMaybe<Scalars['Int']['input']>;
+  attestations_lte?: InputMaybe<Scalars['Int']['input']>;
+  attestations_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  attestations_not_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  modules?: InputMaybe<Scalars['Int']['input']>;
+  modules_not?: InputMaybe<Scalars['Int']['input']>;
+  modules_gt?: InputMaybe<Scalars['Int']['input']>;
+  modules_lt?: InputMaybe<Scalars['Int']['input']>;
+  modules_gte?: InputMaybe<Scalars['Int']['input']>;
+  modules_lte?: InputMaybe<Scalars['Int']['input']>;
+  modules_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  modules_not_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  portals?: InputMaybe<Scalars['Int']['input']>;
+  portals_not?: InputMaybe<Scalars['Int']['input']>;
+  portals_gt?: InputMaybe<Scalars['Int']['input']>;
+  portals_lt?: InputMaybe<Scalars['Int']['input']>;
+  portals_gte?: InputMaybe<Scalars['Int']['input']>;
+  portals_lte?: InputMaybe<Scalars['Int']['input']>;
+  portals_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  portals_not_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  schemas?: InputMaybe<Scalars['Int']['input']>;
+  schemas_not?: InputMaybe<Scalars['Int']['input']>;
+  schemas_gt?: InputMaybe<Scalars['Int']['input']>;
+  schemas_lt?: InputMaybe<Scalars['Int']['input']>;
+  schemas_gte?: InputMaybe<Scalars['Int']['input']>;
+  schemas_lte?: InputMaybe<Scalars['Int']['input']>;
+  schemas_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  schemas_not_in?: InputMaybe<Array<Scalars['Int']['input']>>;
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<Counter_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<Counter_filter>>>;
 };
 
 export type Counter_orderBy =
@@ -235,70 +283,98 @@ export type Counter_orderBy =
   | 'portals'
   | 'schemas';
 
+export type Issuer = {
+  id: Scalars['ID']['output'];
+};
+
+export type Issuer_filter = {
+  id?: InputMaybe<Scalars['ID']['input']>;
+  id_not?: InputMaybe<Scalars['ID']['input']>;
+  id_gt?: InputMaybe<Scalars['ID']['input']>;
+  id_lt?: InputMaybe<Scalars['ID']['input']>;
+  id_gte?: InputMaybe<Scalars['ID']['input']>;
+  id_lte?: InputMaybe<Scalars['ID']['input']>;
+  id_in?: InputMaybe<Array<Scalars['ID']['input']>>;
+  id_not_in?: InputMaybe<Array<Scalars['ID']['input']>>;
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<Issuer_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<Issuer_filter>>>;
+};
+
+export type Issuer_orderBy =
+  | 'id';
+
 export type Module = {
-  id: Scalars['ID'];
-  moduleAddress: Scalars['Bytes'];
-  name: Scalars['String'];
-  description: Scalars['String'];
+  id: Scalars['ID']['output'];
+  moduleAddress: Scalars['Bytes']['output'];
+  name: Scalars['String']['output'];
+  description: Scalars['String']['output'];
 };
 
 export type Module_filter = {
-  id?: InputMaybe<Scalars['ID']>;
-  id_not?: InputMaybe<Scalars['ID']>;
-  id_gt?: InputMaybe<Scalars['ID']>;
-  id_lt?: InputMaybe<Scalars['ID']>;
-  id_gte?: InputMaybe<Scalars['ID']>;
-  id_lte?: InputMaybe<Scalars['ID']>;
-  id_in?: InputMaybe<Array<Scalars['ID']>>;
-  id_not_in?: InputMaybe<Array<Scalars['ID']>>;
-  moduleAddress?: InputMaybe<Scalars['Bytes']>;
-  moduleAddress_not?: InputMaybe<Scalars['Bytes']>;
-  moduleAddress_in?: InputMaybe<Array<Scalars['Bytes']>>;
-  moduleAddress_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
-  moduleAddress_contains?: InputMaybe<Scalars['Bytes']>;
-  moduleAddress_not_contains?: InputMaybe<Scalars['Bytes']>;
-  name?: InputMaybe<Scalars['String']>;
-  name_not?: InputMaybe<Scalars['String']>;
-  name_gt?: InputMaybe<Scalars['String']>;
-  name_lt?: InputMaybe<Scalars['String']>;
-  name_gte?: InputMaybe<Scalars['String']>;
-  name_lte?: InputMaybe<Scalars['String']>;
-  name_in?: InputMaybe<Array<Scalars['String']>>;
-  name_not_in?: InputMaybe<Array<Scalars['String']>>;
-  name_contains?: InputMaybe<Scalars['String']>;
-  name_contains_nocase?: InputMaybe<Scalars['String']>;
-  name_not_contains?: InputMaybe<Scalars['String']>;
-  name_not_contains_nocase?: InputMaybe<Scalars['String']>;
-  name_starts_with?: InputMaybe<Scalars['String']>;
-  name_starts_with_nocase?: InputMaybe<Scalars['String']>;
-  name_not_starts_with?: InputMaybe<Scalars['String']>;
-  name_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
-  name_ends_with?: InputMaybe<Scalars['String']>;
-  name_ends_with_nocase?: InputMaybe<Scalars['String']>;
-  name_not_ends_with?: InputMaybe<Scalars['String']>;
-  name_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
-  description?: InputMaybe<Scalars['String']>;
-  description_not?: InputMaybe<Scalars['String']>;
-  description_gt?: InputMaybe<Scalars['String']>;
-  description_lt?: InputMaybe<Scalars['String']>;
-  description_gte?: InputMaybe<Scalars['String']>;
-  description_lte?: InputMaybe<Scalars['String']>;
-  description_in?: InputMaybe<Array<Scalars['String']>>;
-  description_not_in?: InputMaybe<Array<Scalars['String']>>;
-  description_contains?: InputMaybe<Scalars['String']>;
-  description_contains_nocase?: InputMaybe<Scalars['String']>;
-  description_not_contains?: InputMaybe<Scalars['String']>;
-  description_not_contains_nocase?: InputMaybe<Scalars['String']>;
-  description_starts_with?: InputMaybe<Scalars['String']>;
-  description_starts_with_nocase?: InputMaybe<Scalars['String']>;
-  description_not_starts_with?: InputMaybe<Scalars['String']>;
-  description_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
-  description_ends_with?: InputMaybe<Scalars['String']>;
-  description_ends_with_nocase?: InputMaybe<Scalars['String']>;
-  description_not_ends_with?: InputMaybe<Scalars['String']>;
-  description_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  id?: InputMaybe<Scalars['ID']['input']>;
+  id_not?: InputMaybe<Scalars['ID']['input']>;
+  id_gt?: InputMaybe<Scalars['ID']['input']>;
+  id_lt?: InputMaybe<Scalars['ID']['input']>;
+  id_gte?: InputMaybe<Scalars['ID']['input']>;
+  id_lte?: InputMaybe<Scalars['ID']['input']>;
+  id_in?: InputMaybe<Array<Scalars['ID']['input']>>;
+  id_not_in?: InputMaybe<Array<Scalars['ID']['input']>>;
+  moduleAddress?: InputMaybe<Scalars['Bytes']['input']>;
+  moduleAddress_not?: InputMaybe<Scalars['Bytes']['input']>;
+  moduleAddress_gt?: InputMaybe<Scalars['Bytes']['input']>;
+  moduleAddress_lt?: InputMaybe<Scalars['Bytes']['input']>;
+  moduleAddress_gte?: InputMaybe<Scalars['Bytes']['input']>;
+  moduleAddress_lte?: InputMaybe<Scalars['Bytes']['input']>;
+  moduleAddress_in?: InputMaybe<Array<Scalars['Bytes']['input']>>;
+  moduleAddress_not_in?: InputMaybe<Array<Scalars['Bytes']['input']>>;
+  moduleAddress_contains?: InputMaybe<Scalars['Bytes']['input']>;
+  moduleAddress_not_contains?: InputMaybe<Scalars['Bytes']['input']>;
+  name?: InputMaybe<Scalars['String']['input']>;
+  name_not?: InputMaybe<Scalars['String']['input']>;
+  name_gt?: InputMaybe<Scalars['String']['input']>;
+  name_lt?: InputMaybe<Scalars['String']['input']>;
+  name_gte?: InputMaybe<Scalars['String']['input']>;
+  name_lte?: InputMaybe<Scalars['String']['input']>;
+  name_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  name_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  name_contains?: InputMaybe<Scalars['String']['input']>;
+  name_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  name_not_contains?: InputMaybe<Scalars['String']['input']>;
+  name_not_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  name_starts_with?: InputMaybe<Scalars['String']['input']>;
+  name_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  name_not_starts_with?: InputMaybe<Scalars['String']['input']>;
+  name_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  name_ends_with?: InputMaybe<Scalars['String']['input']>;
+  name_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  name_not_ends_with?: InputMaybe<Scalars['String']['input']>;
+  name_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  description_not?: InputMaybe<Scalars['String']['input']>;
+  description_gt?: InputMaybe<Scalars['String']['input']>;
+  description_lt?: InputMaybe<Scalars['String']['input']>;
+  description_gte?: InputMaybe<Scalars['String']['input']>;
+  description_lte?: InputMaybe<Scalars['String']['input']>;
+  description_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  description_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  description_contains?: InputMaybe<Scalars['String']['input']>;
+  description_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  description_not_contains?: InputMaybe<Scalars['String']['input']>;
+  description_not_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  description_starts_with?: InputMaybe<Scalars['String']['input']>;
+  description_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  description_not_starts_with?: InputMaybe<Scalars['String']['input']>;
+  description_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  description_ends_with?: InputMaybe<Scalars['String']['input']>;
+  description_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  description_not_ends_with?: InputMaybe<Scalars['String']['input']>;
+  description_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<Module_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<Module_filter>>>;
 };
 
 export type Module_orderBy =
@@ -313,102 +389,117 @@ export type OrderDirection =
   | 'desc';
 
 export type Portal = {
-  id: Scalars['ID'];
-  ownerAddress: Scalars['Bytes'];
-  modules?: Maybe<Array<Scalars['Bytes']>>;
-  isRevocable: Scalars['Boolean'];
-  name: Scalars['String'];
-  description: Scalars['String'];
-  ownerName: Scalars['String'];
+  id: Scalars['ID']['output'];
+  ownerAddress: Scalars['Bytes']['output'];
+  modules?: Maybe<Array<Scalars['Bytes']['output']>>;
+  isRevocable: Scalars['Boolean']['output'];
+  name: Scalars['String']['output'];
+  description: Scalars['String']['output'];
+  ownerName: Scalars['String']['output'];
+  attestationCounter?: Maybe<Scalars['Int']['output']>;
 };
 
 export type Portal_filter = {
-  id?: InputMaybe<Scalars['ID']>;
-  id_not?: InputMaybe<Scalars['ID']>;
-  id_gt?: InputMaybe<Scalars['ID']>;
-  id_lt?: InputMaybe<Scalars['ID']>;
-  id_gte?: InputMaybe<Scalars['ID']>;
-  id_lte?: InputMaybe<Scalars['ID']>;
-  id_in?: InputMaybe<Array<Scalars['ID']>>;
-  id_not_in?: InputMaybe<Array<Scalars['ID']>>;
-  ownerAddress?: InputMaybe<Scalars['Bytes']>;
-  ownerAddress_not?: InputMaybe<Scalars['Bytes']>;
-  ownerAddress_in?: InputMaybe<Array<Scalars['Bytes']>>;
-  ownerAddress_not_in?: InputMaybe<Array<Scalars['Bytes']>>;
-  ownerAddress_contains?: InputMaybe<Scalars['Bytes']>;
-  ownerAddress_not_contains?: InputMaybe<Scalars['Bytes']>;
-  modules?: InputMaybe<Array<Scalars['Bytes']>>;
-  modules_not?: InputMaybe<Array<Scalars['Bytes']>>;
-  modules_contains?: InputMaybe<Array<Scalars['Bytes']>>;
-  modules_contains_nocase?: InputMaybe<Array<Scalars['Bytes']>>;
-  modules_not_contains?: InputMaybe<Array<Scalars['Bytes']>>;
-  modules_not_contains_nocase?: InputMaybe<Array<Scalars['Bytes']>>;
-  isRevocable?: InputMaybe<Scalars['Boolean']>;
-  isRevocable_not?: InputMaybe<Scalars['Boolean']>;
-  isRevocable_in?: InputMaybe<Array<Scalars['Boolean']>>;
-  isRevocable_not_in?: InputMaybe<Array<Scalars['Boolean']>>;
-  name?: InputMaybe<Scalars['String']>;
-  name_not?: InputMaybe<Scalars['String']>;
-  name_gt?: InputMaybe<Scalars['String']>;
-  name_lt?: InputMaybe<Scalars['String']>;
-  name_gte?: InputMaybe<Scalars['String']>;
-  name_lte?: InputMaybe<Scalars['String']>;
-  name_in?: InputMaybe<Array<Scalars['String']>>;
-  name_not_in?: InputMaybe<Array<Scalars['String']>>;
-  name_contains?: InputMaybe<Scalars['String']>;
-  name_contains_nocase?: InputMaybe<Scalars['String']>;
-  name_not_contains?: InputMaybe<Scalars['String']>;
-  name_not_contains_nocase?: InputMaybe<Scalars['String']>;
-  name_starts_with?: InputMaybe<Scalars['String']>;
-  name_starts_with_nocase?: InputMaybe<Scalars['String']>;
-  name_not_starts_with?: InputMaybe<Scalars['String']>;
-  name_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
-  name_ends_with?: InputMaybe<Scalars['String']>;
-  name_ends_with_nocase?: InputMaybe<Scalars['String']>;
-  name_not_ends_with?: InputMaybe<Scalars['String']>;
-  name_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
-  description?: InputMaybe<Scalars['String']>;
-  description_not?: InputMaybe<Scalars['String']>;
-  description_gt?: InputMaybe<Scalars['String']>;
-  description_lt?: InputMaybe<Scalars['String']>;
-  description_gte?: InputMaybe<Scalars['String']>;
-  description_lte?: InputMaybe<Scalars['String']>;
-  description_in?: InputMaybe<Array<Scalars['String']>>;
-  description_not_in?: InputMaybe<Array<Scalars['String']>>;
-  description_contains?: InputMaybe<Scalars['String']>;
-  description_contains_nocase?: InputMaybe<Scalars['String']>;
-  description_not_contains?: InputMaybe<Scalars['String']>;
-  description_not_contains_nocase?: InputMaybe<Scalars['String']>;
-  description_starts_with?: InputMaybe<Scalars['String']>;
-  description_starts_with_nocase?: InputMaybe<Scalars['String']>;
-  description_not_starts_with?: InputMaybe<Scalars['String']>;
-  description_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
-  description_ends_with?: InputMaybe<Scalars['String']>;
-  description_ends_with_nocase?: InputMaybe<Scalars['String']>;
-  description_not_ends_with?: InputMaybe<Scalars['String']>;
-  description_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
-  ownerName?: InputMaybe<Scalars['String']>;
-  ownerName_not?: InputMaybe<Scalars['String']>;
-  ownerName_gt?: InputMaybe<Scalars['String']>;
-  ownerName_lt?: InputMaybe<Scalars['String']>;
-  ownerName_gte?: InputMaybe<Scalars['String']>;
-  ownerName_lte?: InputMaybe<Scalars['String']>;
-  ownerName_in?: InputMaybe<Array<Scalars['String']>>;
-  ownerName_not_in?: InputMaybe<Array<Scalars['String']>>;
-  ownerName_contains?: InputMaybe<Scalars['String']>;
-  ownerName_contains_nocase?: InputMaybe<Scalars['String']>;
-  ownerName_not_contains?: InputMaybe<Scalars['String']>;
-  ownerName_not_contains_nocase?: InputMaybe<Scalars['String']>;
-  ownerName_starts_with?: InputMaybe<Scalars['String']>;
-  ownerName_starts_with_nocase?: InputMaybe<Scalars['String']>;
-  ownerName_not_starts_with?: InputMaybe<Scalars['String']>;
-  ownerName_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
-  ownerName_ends_with?: InputMaybe<Scalars['String']>;
-  ownerName_ends_with_nocase?: InputMaybe<Scalars['String']>;
-  ownerName_not_ends_with?: InputMaybe<Scalars['String']>;
-  ownerName_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  id?: InputMaybe<Scalars['ID']['input']>;
+  id_not?: InputMaybe<Scalars['ID']['input']>;
+  id_gt?: InputMaybe<Scalars['ID']['input']>;
+  id_lt?: InputMaybe<Scalars['ID']['input']>;
+  id_gte?: InputMaybe<Scalars['ID']['input']>;
+  id_lte?: InputMaybe<Scalars['ID']['input']>;
+  id_in?: InputMaybe<Array<Scalars['ID']['input']>>;
+  id_not_in?: InputMaybe<Array<Scalars['ID']['input']>>;
+  ownerAddress?: InputMaybe<Scalars['Bytes']['input']>;
+  ownerAddress_not?: InputMaybe<Scalars['Bytes']['input']>;
+  ownerAddress_gt?: InputMaybe<Scalars['Bytes']['input']>;
+  ownerAddress_lt?: InputMaybe<Scalars['Bytes']['input']>;
+  ownerAddress_gte?: InputMaybe<Scalars['Bytes']['input']>;
+  ownerAddress_lte?: InputMaybe<Scalars['Bytes']['input']>;
+  ownerAddress_in?: InputMaybe<Array<Scalars['Bytes']['input']>>;
+  ownerAddress_not_in?: InputMaybe<Array<Scalars['Bytes']['input']>>;
+  ownerAddress_contains?: InputMaybe<Scalars['Bytes']['input']>;
+  ownerAddress_not_contains?: InputMaybe<Scalars['Bytes']['input']>;
+  modules?: InputMaybe<Array<Scalars['Bytes']['input']>>;
+  modules_not?: InputMaybe<Array<Scalars['Bytes']['input']>>;
+  modules_contains?: InputMaybe<Array<Scalars['Bytes']['input']>>;
+  modules_contains_nocase?: InputMaybe<Array<Scalars['Bytes']['input']>>;
+  modules_not_contains?: InputMaybe<Array<Scalars['Bytes']['input']>>;
+  modules_not_contains_nocase?: InputMaybe<Array<Scalars['Bytes']['input']>>;
+  isRevocable?: InputMaybe<Scalars['Boolean']['input']>;
+  isRevocable_not?: InputMaybe<Scalars['Boolean']['input']>;
+  isRevocable_in?: InputMaybe<Array<Scalars['Boolean']['input']>>;
+  isRevocable_not_in?: InputMaybe<Array<Scalars['Boolean']['input']>>;
+  name?: InputMaybe<Scalars['String']['input']>;
+  name_not?: InputMaybe<Scalars['String']['input']>;
+  name_gt?: InputMaybe<Scalars['String']['input']>;
+  name_lt?: InputMaybe<Scalars['String']['input']>;
+  name_gte?: InputMaybe<Scalars['String']['input']>;
+  name_lte?: InputMaybe<Scalars['String']['input']>;
+  name_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  name_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  name_contains?: InputMaybe<Scalars['String']['input']>;
+  name_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  name_not_contains?: InputMaybe<Scalars['String']['input']>;
+  name_not_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  name_starts_with?: InputMaybe<Scalars['String']['input']>;
+  name_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  name_not_starts_with?: InputMaybe<Scalars['String']['input']>;
+  name_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  name_ends_with?: InputMaybe<Scalars['String']['input']>;
+  name_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  name_not_ends_with?: InputMaybe<Scalars['String']['input']>;
+  name_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  description_not?: InputMaybe<Scalars['String']['input']>;
+  description_gt?: InputMaybe<Scalars['String']['input']>;
+  description_lt?: InputMaybe<Scalars['String']['input']>;
+  description_gte?: InputMaybe<Scalars['String']['input']>;
+  description_lte?: InputMaybe<Scalars['String']['input']>;
+  description_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  description_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  description_contains?: InputMaybe<Scalars['String']['input']>;
+  description_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  description_not_contains?: InputMaybe<Scalars['String']['input']>;
+  description_not_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  description_starts_with?: InputMaybe<Scalars['String']['input']>;
+  description_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  description_not_starts_with?: InputMaybe<Scalars['String']['input']>;
+  description_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  description_ends_with?: InputMaybe<Scalars['String']['input']>;
+  description_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  description_not_ends_with?: InputMaybe<Scalars['String']['input']>;
+  description_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  ownerName?: InputMaybe<Scalars['String']['input']>;
+  ownerName_not?: InputMaybe<Scalars['String']['input']>;
+  ownerName_gt?: InputMaybe<Scalars['String']['input']>;
+  ownerName_lt?: InputMaybe<Scalars['String']['input']>;
+  ownerName_gte?: InputMaybe<Scalars['String']['input']>;
+  ownerName_lte?: InputMaybe<Scalars['String']['input']>;
+  ownerName_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  ownerName_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  ownerName_contains?: InputMaybe<Scalars['String']['input']>;
+  ownerName_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  ownerName_not_contains?: InputMaybe<Scalars['String']['input']>;
+  ownerName_not_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  ownerName_starts_with?: InputMaybe<Scalars['String']['input']>;
+  ownerName_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  ownerName_not_starts_with?: InputMaybe<Scalars['String']['input']>;
+  ownerName_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  ownerName_ends_with?: InputMaybe<Scalars['String']['input']>;
+  ownerName_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  ownerName_not_ends_with?: InputMaybe<Scalars['String']['input']>;
+  ownerName_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  attestationCounter?: InputMaybe<Scalars['Int']['input']>;
+  attestationCounter_not?: InputMaybe<Scalars['Int']['input']>;
+  attestationCounter_gt?: InputMaybe<Scalars['Int']['input']>;
+  attestationCounter_lt?: InputMaybe<Scalars['Int']['input']>;
+  attestationCounter_gte?: InputMaybe<Scalars['Int']['input']>;
+  attestationCounter_lte?: InputMaybe<Scalars['Int']['input']>;
+  attestationCounter_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  attestationCounter_not_in?: InputMaybe<Array<Scalars['Int']['input']>>;
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<Portal_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<Portal_filter>>>;
 };
 
 export type Portal_orderBy =
@@ -418,7 +509,8 @@ export type Portal_orderBy =
   | 'isRevocable'
   | 'name'
   | 'description'
-  | 'ownerName';
+  | 'ownerName'
+  | 'attestationCounter';
 
 export type Query = {
   attestation?: Maybe<Attestation>;
@@ -431,21 +523,25 @@ export type Query = {
   schemas: Array<Schema>;
   counter?: Maybe<Counter>;
   counters: Array<Counter>;
+  issuer?: Maybe<Issuer>;
+  issuers: Array<Issuer>;
+  registryVersion?: Maybe<RegistryVersion>;
+  registryVersions: Array<RegistryVersion>;
   /** Access to subgraph metadata */
   _meta?: Maybe<_Meta_>;
 };
 
 
 export type QueryattestationArgs = {
-  id: Scalars['ID'];
+  id: Scalars['ID']['input'];
   block?: InputMaybe<Block_height>;
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
 
 export type QueryattestationsArgs = {
-  skip?: InputMaybe<Scalars['Int']>;
-  first?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Attestation_orderBy>;
   orderDirection?: InputMaybe<OrderDirection>;
   where?: InputMaybe<Attestation_filter>;
@@ -455,15 +551,15 @@ export type QueryattestationsArgs = {
 
 
 export type QuerymoduleArgs = {
-  id: Scalars['ID'];
+  id: Scalars['ID']['input'];
   block?: InputMaybe<Block_height>;
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
 
 export type QuerymodulesArgs = {
-  skip?: InputMaybe<Scalars['Int']>;
-  first?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Module_orderBy>;
   orderDirection?: InputMaybe<OrderDirection>;
   where?: InputMaybe<Module_filter>;
@@ -473,15 +569,15 @@ export type QuerymodulesArgs = {
 
 
 export type QueryportalArgs = {
-  id: Scalars['ID'];
+  id: Scalars['ID']['input'];
   block?: InputMaybe<Block_height>;
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
 
 export type QueryportalsArgs = {
-  skip?: InputMaybe<Scalars['Int']>;
-  first?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Portal_orderBy>;
   orderDirection?: InputMaybe<OrderDirection>;
   where?: InputMaybe<Portal_filter>;
@@ -491,15 +587,15 @@ export type QueryportalsArgs = {
 
 
 export type QueryschemaArgs = {
-  id: Scalars['ID'];
+  id: Scalars['ID']['input'];
   block?: InputMaybe<Block_height>;
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
 
 export type QueryschemasArgs = {
-  skip?: InputMaybe<Scalars['Int']>;
-  first?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Schema_orderBy>;
   orderDirection?: InputMaybe<OrderDirection>;
   where?: InputMaybe<Schema_filter>;
@@ -509,18 +605,54 @@ export type QueryschemasArgs = {
 
 
 export type QuerycounterArgs = {
-  id: Scalars['ID'];
+  id: Scalars['ID']['input'];
   block?: InputMaybe<Block_height>;
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
 
 export type QuerycountersArgs = {
-  skip?: InputMaybe<Scalars['Int']>;
-  first?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Counter_orderBy>;
   orderDirection?: InputMaybe<OrderDirection>;
   where?: InputMaybe<Counter_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryissuerArgs = {
+  id: Scalars['ID']['input'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryissuersArgs = {
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<Issuer_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<Issuer_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryregistryVersionArgs = {
+  id: Scalars['ID']['input'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryregistryVersionsArgs = {
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<RegistryVersion_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<RegistryVersion_filter>;
   block?: InputMaybe<Block_height>;
   subgraphError?: _SubgraphErrorPolicy_;
 };
@@ -530,105 +662,158 @@ export type Query_metaArgs = {
   block?: InputMaybe<Block_height>;
 };
 
+export type RegistryVersion = {
+  id: Scalars['ID']['output'];
+  versionNumber?: Maybe<Scalars['Int']['output']>;
+  timestamp?: Maybe<Scalars['BigInt']['output']>;
+};
+
+export type RegistryVersion_filter = {
+  id?: InputMaybe<Scalars['ID']['input']>;
+  id_not?: InputMaybe<Scalars['ID']['input']>;
+  id_gt?: InputMaybe<Scalars['ID']['input']>;
+  id_lt?: InputMaybe<Scalars['ID']['input']>;
+  id_gte?: InputMaybe<Scalars['ID']['input']>;
+  id_lte?: InputMaybe<Scalars['ID']['input']>;
+  id_in?: InputMaybe<Array<Scalars['ID']['input']>>;
+  id_not_in?: InputMaybe<Array<Scalars['ID']['input']>>;
+  versionNumber?: InputMaybe<Scalars['Int']['input']>;
+  versionNumber_not?: InputMaybe<Scalars['Int']['input']>;
+  versionNumber_gt?: InputMaybe<Scalars['Int']['input']>;
+  versionNumber_lt?: InputMaybe<Scalars['Int']['input']>;
+  versionNumber_gte?: InputMaybe<Scalars['Int']['input']>;
+  versionNumber_lte?: InputMaybe<Scalars['Int']['input']>;
+  versionNumber_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  versionNumber_not_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  timestamp?: InputMaybe<Scalars['BigInt']['input']>;
+  timestamp_not?: InputMaybe<Scalars['BigInt']['input']>;
+  timestamp_gt?: InputMaybe<Scalars['BigInt']['input']>;
+  timestamp_lt?: InputMaybe<Scalars['BigInt']['input']>;
+  timestamp_gte?: InputMaybe<Scalars['BigInt']['input']>;
+  timestamp_lte?: InputMaybe<Scalars['BigInt']['input']>;
+  timestamp_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  timestamp_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<RegistryVersion_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<RegistryVersion_filter>>>;
+};
+
+export type RegistryVersion_orderBy =
+  | 'id'
+  | 'versionNumber'
+  | 'timestamp';
+
 export type Schema = {
-  id: Scalars['ID'];
-  name: Scalars['String'];
-  description: Scalars['String'];
-  context: Scalars['String'];
-  schema: Scalars['String'];
+  id: Scalars['ID']['output'];
+  name: Scalars['String']['output'];
+  description: Scalars['String']['output'];
+  context: Scalars['String']['output'];
+  schema: Scalars['String']['output'];
+  attestationCounter?: Maybe<Scalars['Int']['output']>;
 };
 
 export type Schema_filter = {
-  id?: InputMaybe<Scalars['ID']>;
-  id_not?: InputMaybe<Scalars['ID']>;
-  id_gt?: InputMaybe<Scalars['ID']>;
-  id_lt?: InputMaybe<Scalars['ID']>;
-  id_gte?: InputMaybe<Scalars['ID']>;
-  id_lte?: InputMaybe<Scalars['ID']>;
-  id_in?: InputMaybe<Array<Scalars['ID']>>;
-  id_not_in?: InputMaybe<Array<Scalars['ID']>>;
-  name?: InputMaybe<Scalars['String']>;
-  name_not?: InputMaybe<Scalars['String']>;
-  name_gt?: InputMaybe<Scalars['String']>;
-  name_lt?: InputMaybe<Scalars['String']>;
-  name_gte?: InputMaybe<Scalars['String']>;
-  name_lte?: InputMaybe<Scalars['String']>;
-  name_in?: InputMaybe<Array<Scalars['String']>>;
-  name_not_in?: InputMaybe<Array<Scalars['String']>>;
-  name_contains?: InputMaybe<Scalars['String']>;
-  name_contains_nocase?: InputMaybe<Scalars['String']>;
-  name_not_contains?: InputMaybe<Scalars['String']>;
-  name_not_contains_nocase?: InputMaybe<Scalars['String']>;
-  name_starts_with?: InputMaybe<Scalars['String']>;
-  name_starts_with_nocase?: InputMaybe<Scalars['String']>;
-  name_not_starts_with?: InputMaybe<Scalars['String']>;
-  name_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
-  name_ends_with?: InputMaybe<Scalars['String']>;
-  name_ends_with_nocase?: InputMaybe<Scalars['String']>;
-  name_not_ends_with?: InputMaybe<Scalars['String']>;
-  name_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
-  description?: InputMaybe<Scalars['String']>;
-  description_not?: InputMaybe<Scalars['String']>;
-  description_gt?: InputMaybe<Scalars['String']>;
-  description_lt?: InputMaybe<Scalars['String']>;
-  description_gte?: InputMaybe<Scalars['String']>;
-  description_lte?: InputMaybe<Scalars['String']>;
-  description_in?: InputMaybe<Array<Scalars['String']>>;
-  description_not_in?: InputMaybe<Array<Scalars['String']>>;
-  description_contains?: InputMaybe<Scalars['String']>;
-  description_contains_nocase?: InputMaybe<Scalars['String']>;
-  description_not_contains?: InputMaybe<Scalars['String']>;
-  description_not_contains_nocase?: InputMaybe<Scalars['String']>;
-  description_starts_with?: InputMaybe<Scalars['String']>;
-  description_starts_with_nocase?: InputMaybe<Scalars['String']>;
-  description_not_starts_with?: InputMaybe<Scalars['String']>;
-  description_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
-  description_ends_with?: InputMaybe<Scalars['String']>;
-  description_ends_with_nocase?: InputMaybe<Scalars['String']>;
-  description_not_ends_with?: InputMaybe<Scalars['String']>;
-  description_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
-  context?: InputMaybe<Scalars['String']>;
-  context_not?: InputMaybe<Scalars['String']>;
-  context_gt?: InputMaybe<Scalars['String']>;
-  context_lt?: InputMaybe<Scalars['String']>;
-  context_gte?: InputMaybe<Scalars['String']>;
-  context_lte?: InputMaybe<Scalars['String']>;
-  context_in?: InputMaybe<Array<Scalars['String']>>;
-  context_not_in?: InputMaybe<Array<Scalars['String']>>;
-  context_contains?: InputMaybe<Scalars['String']>;
-  context_contains_nocase?: InputMaybe<Scalars['String']>;
-  context_not_contains?: InputMaybe<Scalars['String']>;
-  context_not_contains_nocase?: InputMaybe<Scalars['String']>;
-  context_starts_with?: InputMaybe<Scalars['String']>;
-  context_starts_with_nocase?: InputMaybe<Scalars['String']>;
-  context_not_starts_with?: InputMaybe<Scalars['String']>;
-  context_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
-  context_ends_with?: InputMaybe<Scalars['String']>;
-  context_ends_with_nocase?: InputMaybe<Scalars['String']>;
-  context_not_ends_with?: InputMaybe<Scalars['String']>;
-  context_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
-  schema?: InputMaybe<Scalars['String']>;
-  schema_not?: InputMaybe<Scalars['String']>;
-  schema_gt?: InputMaybe<Scalars['String']>;
-  schema_lt?: InputMaybe<Scalars['String']>;
-  schema_gte?: InputMaybe<Scalars['String']>;
-  schema_lte?: InputMaybe<Scalars['String']>;
-  schema_in?: InputMaybe<Array<Scalars['String']>>;
-  schema_not_in?: InputMaybe<Array<Scalars['String']>>;
-  schema_contains?: InputMaybe<Scalars['String']>;
-  schema_contains_nocase?: InputMaybe<Scalars['String']>;
-  schema_not_contains?: InputMaybe<Scalars['String']>;
-  schema_not_contains_nocase?: InputMaybe<Scalars['String']>;
-  schema_starts_with?: InputMaybe<Scalars['String']>;
-  schema_starts_with_nocase?: InputMaybe<Scalars['String']>;
-  schema_not_starts_with?: InputMaybe<Scalars['String']>;
-  schema_not_starts_with_nocase?: InputMaybe<Scalars['String']>;
-  schema_ends_with?: InputMaybe<Scalars['String']>;
-  schema_ends_with_nocase?: InputMaybe<Scalars['String']>;
-  schema_not_ends_with?: InputMaybe<Scalars['String']>;
-  schema_not_ends_with_nocase?: InputMaybe<Scalars['String']>;
+  id?: InputMaybe<Scalars['ID']['input']>;
+  id_not?: InputMaybe<Scalars['ID']['input']>;
+  id_gt?: InputMaybe<Scalars['ID']['input']>;
+  id_lt?: InputMaybe<Scalars['ID']['input']>;
+  id_gte?: InputMaybe<Scalars['ID']['input']>;
+  id_lte?: InputMaybe<Scalars['ID']['input']>;
+  id_in?: InputMaybe<Array<Scalars['ID']['input']>>;
+  id_not_in?: InputMaybe<Array<Scalars['ID']['input']>>;
+  name?: InputMaybe<Scalars['String']['input']>;
+  name_not?: InputMaybe<Scalars['String']['input']>;
+  name_gt?: InputMaybe<Scalars['String']['input']>;
+  name_lt?: InputMaybe<Scalars['String']['input']>;
+  name_gte?: InputMaybe<Scalars['String']['input']>;
+  name_lte?: InputMaybe<Scalars['String']['input']>;
+  name_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  name_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  name_contains?: InputMaybe<Scalars['String']['input']>;
+  name_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  name_not_contains?: InputMaybe<Scalars['String']['input']>;
+  name_not_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  name_starts_with?: InputMaybe<Scalars['String']['input']>;
+  name_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  name_not_starts_with?: InputMaybe<Scalars['String']['input']>;
+  name_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  name_ends_with?: InputMaybe<Scalars['String']['input']>;
+  name_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  name_not_ends_with?: InputMaybe<Scalars['String']['input']>;
+  name_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  description_not?: InputMaybe<Scalars['String']['input']>;
+  description_gt?: InputMaybe<Scalars['String']['input']>;
+  description_lt?: InputMaybe<Scalars['String']['input']>;
+  description_gte?: InputMaybe<Scalars['String']['input']>;
+  description_lte?: InputMaybe<Scalars['String']['input']>;
+  description_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  description_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  description_contains?: InputMaybe<Scalars['String']['input']>;
+  description_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  description_not_contains?: InputMaybe<Scalars['String']['input']>;
+  description_not_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  description_starts_with?: InputMaybe<Scalars['String']['input']>;
+  description_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  description_not_starts_with?: InputMaybe<Scalars['String']['input']>;
+  description_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  description_ends_with?: InputMaybe<Scalars['String']['input']>;
+  description_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  description_not_ends_with?: InputMaybe<Scalars['String']['input']>;
+  description_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  context?: InputMaybe<Scalars['String']['input']>;
+  context_not?: InputMaybe<Scalars['String']['input']>;
+  context_gt?: InputMaybe<Scalars['String']['input']>;
+  context_lt?: InputMaybe<Scalars['String']['input']>;
+  context_gte?: InputMaybe<Scalars['String']['input']>;
+  context_lte?: InputMaybe<Scalars['String']['input']>;
+  context_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  context_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  context_contains?: InputMaybe<Scalars['String']['input']>;
+  context_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  context_not_contains?: InputMaybe<Scalars['String']['input']>;
+  context_not_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  context_starts_with?: InputMaybe<Scalars['String']['input']>;
+  context_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  context_not_starts_with?: InputMaybe<Scalars['String']['input']>;
+  context_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  context_ends_with?: InputMaybe<Scalars['String']['input']>;
+  context_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  context_not_ends_with?: InputMaybe<Scalars['String']['input']>;
+  context_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  schema?: InputMaybe<Scalars['String']['input']>;
+  schema_not?: InputMaybe<Scalars['String']['input']>;
+  schema_gt?: InputMaybe<Scalars['String']['input']>;
+  schema_lt?: InputMaybe<Scalars['String']['input']>;
+  schema_gte?: InputMaybe<Scalars['String']['input']>;
+  schema_lte?: InputMaybe<Scalars['String']['input']>;
+  schema_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  schema_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  schema_contains?: InputMaybe<Scalars['String']['input']>;
+  schema_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  schema_not_contains?: InputMaybe<Scalars['String']['input']>;
+  schema_not_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  schema_starts_with?: InputMaybe<Scalars['String']['input']>;
+  schema_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  schema_not_starts_with?: InputMaybe<Scalars['String']['input']>;
+  schema_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  schema_ends_with?: InputMaybe<Scalars['String']['input']>;
+  schema_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  schema_not_ends_with?: InputMaybe<Scalars['String']['input']>;
+  schema_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  attestationCounter?: InputMaybe<Scalars['Int']['input']>;
+  attestationCounter_not?: InputMaybe<Scalars['Int']['input']>;
+  attestationCounter_gt?: InputMaybe<Scalars['Int']['input']>;
+  attestationCounter_lt?: InputMaybe<Scalars['Int']['input']>;
+  attestationCounter_gte?: InputMaybe<Scalars['Int']['input']>;
+  attestationCounter_lte?: InputMaybe<Scalars['Int']['input']>;
+  attestationCounter_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  attestationCounter_not_in?: InputMaybe<Array<Scalars['Int']['input']>>;
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<Schema_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<Schema_filter>>>;
 };
 
 export type Schema_orderBy =
@@ -636,7 +821,8 @@ export type Schema_orderBy =
   | 'name'
   | 'description'
   | 'context'
-  | 'schema';
+  | 'schema'
+  | 'attestationCounter';
 
 export type Subscription = {
   attestation?: Maybe<Attestation>;
@@ -649,21 +835,25 @@ export type Subscription = {
   schemas: Array<Schema>;
   counter?: Maybe<Counter>;
   counters: Array<Counter>;
+  issuer?: Maybe<Issuer>;
+  issuers: Array<Issuer>;
+  registryVersion?: Maybe<RegistryVersion>;
+  registryVersions: Array<RegistryVersion>;
   /** Access to subgraph metadata */
   _meta?: Maybe<_Meta_>;
 };
 
 
 export type SubscriptionattestationArgs = {
-  id: Scalars['ID'];
+  id: Scalars['ID']['input'];
   block?: InputMaybe<Block_height>;
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
 
 export type SubscriptionattestationsArgs = {
-  skip?: InputMaybe<Scalars['Int']>;
-  first?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Attestation_orderBy>;
   orderDirection?: InputMaybe<OrderDirection>;
   where?: InputMaybe<Attestation_filter>;
@@ -673,15 +863,15 @@ export type SubscriptionattestationsArgs = {
 
 
 export type SubscriptionmoduleArgs = {
-  id: Scalars['ID'];
+  id: Scalars['ID']['input'];
   block?: InputMaybe<Block_height>;
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
 
 export type SubscriptionmodulesArgs = {
-  skip?: InputMaybe<Scalars['Int']>;
-  first?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Module_orderBy>;
   orderDirection?: InputMaybe<OrderDirection>;
   where?: InputMaybe<Module_filter>;
@@ -691,15 +881,15 @@ export type SubscriptionmodulesArgs = {
 
 
 export type SubscriptionportalArgs = {
-  id: Scalars['ID'];
+  id: Scalars['ID']['input'];
   block?: InputMaybe<Block_height>;
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
 
 export type SubscriptionportalsArgs = {
-  skip?: InputMaybe<Scalars['Int']>;
-  first?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Portal_orderBy>;
   orderDirection?: InputMaybe<OrderDirection>;
   where?: InputMaybe<Portal_filter>;
@@ -709,15 +899,15 @@ export type SubscriptionportalsArgs = {
 
 
 export type SubscriptionschemaArgs = {
-  id: Scalars['ID'];
+  id: Scalars['ID']['input'];
   block?: InputMaybe<Block_height>;
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
 
 export type SubscriptionschemasArgs = {
-  skip?: InputMaybe<Scalars['Int']>;
-  first?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Schema_orderBy>;
   orderDirection?: InputMaybe<OrderDirection>;
   where?: InputMaybe<Schema_filter>;
@@ -727,18 +917,54 @@ export type SubscriptionschemasArgs = {
 
 
 export type SubscriptioncounterArgs = {
-  id: Scalars['ID'];
+  id: Scalars['ID']['input'];
   block?: InputMaybe<Block_height>;
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
 
 export type SubscriptioncountersArgs = {
-  skip?: InputMaybe<Scalars['Int']>;
-  first?: InputMaybe<Scalars['Int']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Counter_orderBy>;
   orderDirection?: InputMaybe<OrderDirection>;
   where?: InputMaybe<Counter_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionissuerArgs = {
+  id: Scalars['ID']['input'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionissuersArgs = {
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<Issuer_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<Issuer_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionregistryVersionArgs = {
+  id: Scalars['ID']['input'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionregistryVersionsArgs = {
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<RegistryVersion_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<RegistryVersion_filter>;
   block?: InputMaybe<Block_height>;
   subgraphError?: _SubgraphErrorPolicy_;
 };
@@ -750,11 +976,13 @@ export type Subscription_metaArgs = {
 
 export type _Block_ = {
   /** The hash of the block */
-  hash?: Maybe<Scalars['Bytes']>;
+  hash?: Maybe<Scalars['Bytes']['output']>;
   /** The block number */
-  number: Scalars['Int'];
+  number: Scalars['Int']['output'];
   /** Integer representation of the timestamp stored in blocks for the chain */
-  timestamp?: Maybe<Scalars['Int']>;
+  timestamp?: Maybe<Scalars['Int']['output']>;
+  /** The hash of the parent block */
+  parentHash?: Maybe<Scalars['Bytes']['output']>;
 };
 
 /** The type for the top-level _meta field */
@@ -768,9 +996,9 @@ export type _Meta_ = {
    */
   block: _Block_;
   /** The deployment ID */
-  deployment: Scalars['String'];
+  deployment: Scalars['String']['output'];
   /** If `true`, the subgraph encountered indexing errors at some past block */
-  hasIndexingErrors: Scalars['Boolean'];
+  hasIndexingErrors: Scalars['Boolean']['output'];
 };
 
 export type _SubgraphErrorPolicy_ =
@@ -800,6 +1028,14 @@ export type _SubgraphErrorPolicy_ =
   counter: InContextSdkMethod<Query['counter'], QuerycounterArgs, MeshContext>,
   /** null **/
   counters: InContextSdkMethod<Query['counters'], QuerycountersArgs, MeshContext>,
+  /** null **/
+  issuer: InContextSdkMethod<Query['issuer'], QueryissuerArgs, MeshContext>,
+  /** null **/
+  issuers: InContextSdkMethod<Query['issuers'], QueryissuersArgs, MeshContext>,
+  /** null **/
+  registryVersion: InContextSdkMethod<Query['registryVersion'], QueryregistryVersionArgs, MeshContext>,
+  /** null **/
+  registryVersions: InContextSdkMethod<Query['registryVersions'], QueryregistryVersionsArgs, MeshContext>,
   /** Access to subgraph metadata **/
   _meta: InContextSdkMethod<Query['_meta'], Query_metaArgs, MeshContext>
   };
@@ -829,6 +1065,14 @@ export type _SubgraphErrorPolicy_ =
   counter: InContextSdkMethod<Subscription['counter'], SubscriptioncounterArgs, MeshContext>,
   /** null **/
   counters: InContextSdkMethod<Subscription['counters'], SubscriptioncountersArgs, MeshContext>,
+  /** null **/
+  issuer: InContextSdkMethod<Subscription['issuer'], SubscriptionissuerArgs, MeshContext>,
+  /** null **/
+  issuers: InContextSdkMethod<Subscription['issuers'], SubscriptionissuersArgs, MeshContext>,
+  /** null **/
+  registryVersion: InContextSdkMethod<Subscription['registryVersion'], SubscriptionregistryVersionArgs, MeshContext>,
+  /** null **/
+  registryVersions: InContextSdkMethod<Subscription['registryVersions'], SubscriptionregistryVersionsArgs, MeshContext>,
   /** Access to subgraph metadata **/
   _meta: InContextSdkMethod<Subscription['_meta'], Subscription_metaArgs, MeshContext>
   };

--- a/sdk/.graphclientrc.yml
+++ b/sdk/.graphclientrc.yml
@@ -3,4 +3,4 @@ sources:
   - name: linea-attestation-registry
     handler:
       graphql:
-        endpoint: https://graph-query.linea.build/subgraphs/name/Consensys/linea-attestation-registry
+        endpoint: https://api.studio.thegraph.com/query/67521/verax-v1-linea/v0.0.1

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verax-attestation-registry/verax-sdk",
-  "version": "1.10.1",
+  "version": "1.11.1",
   "description": "Verax Attestation Registry SDK to interact with the subgraph and the contracts",
   "keywords": [
     "linea-attestation-registry",
@@ -15,19 +15,20 @@
   "license": "MIT",
   "author": "Consensys",
   "type": "commonjs",
+  "main": "./lib/src/VeraxSdk.js",
+  "types": "./lib/types/src/VeraxSdk.d.ts",
   "files": [
     "lib/**/*"
   ],
-  "types": "./lib/types/src/VeraxSdk.d.ts",
-  "main": "./lib/src/VeraxSdk.js",
   "scripts": {
     "attestation": "ts-node examples/attestation/index.ts",
-    "clean": "rm -rf ./lib",
     "build": "pnpm run clean && tsc --p ./tsconfig.build.json",
-    "prepack": "npm run build",
-    "publish:public": "pnpm publish --access public --no-git-checks",
+    "clean": "rm -rf ./lib",
+    "generate": "graphclient build",
     "module": "ts-node examples/module/index.ts",
+    "prepack": "npm run build",
     "portal": "ts-node examples/portal/index.ts",
+    "publish:public": "pnpm publish --access public --no-git-checks",
     "schema": "ts-node examples/schema/index.ts",
     "test": "jest",
     "test:ci": "cp .env.example .env && pnpm run test",
@@ -37,7 +38,6 @@
     "test:unit:ci": "cp .env.example .env && pnpm run test:unit"
   },
   "dependencies": {
-    "@graphprotocol/client-cli": "^3.0.0",
     "@graphql-mesh/cache-localforage": "^0.95.8",
     "@graphql-mesh/cross-helpers": "^0.4.1",
     "@graphql-mesh/graphql": "^0.95.8",
@@ -56,6 +56,7 @@
     "@babel/plugin-transform-runtime": "^7.23.3",
     "@babel/preset-env": "^7.23.3",
     "@babel/preset-typescript": "^7.23.3",
+    "@graphprotocol/client-cli": "^3.0.0",
     "@types/jest": "^29.5.8",
     "@types/node": "^20.9.0",
     "babel-jest": "^29.7.0",

--- a/sdk/src/VeraxSdk.ts
+++ b/sdk/src/VeraxSdk.ts
@@ -26,8 +26,8 @@ export class VeraxSdk {
   static DEFAULT_LINEA_MAINNET: Conf = {
     chain: linea,
     mode: SDKMode.BACKEND,
-    subgraphUrl: "https://graph-query.linea.build/subgraphs/name/Consensys/linea-attestation-registry",
-    // Backup URL: subgraphUrl: "https://api.studio.thegraph.com/query/67521/verax-v1-linea/v0.0.1",
+    subgraphUrl: "https://api.studio.thegraph.com/query/67521/verax-v1-linea/v0.0.1",
+    // Backup URL: subgraphUrl: "https://graph-query.linea.build/subgraphs/name/Consensys/linea-attestation-registry",
     portalRegistryAddress: "0xd5d61e4ECDf6d46A63BfdC262af92544DFc19083",
     moduleRegistryAddress: "0xf851513A732996F22542226341748f3C9978438f",
     schemaRegistryAddress: "0x0f95dCec4c7a93F2637eb13b655F2223ea036B59",

--- a/sdk/src/dataMapper/PortalDataMapper.ts
+++ b/sdk/src/dataMapper/PortalDataMapper.ts
@@ -19,6 +19,7 @@ export default class PortalDataMapper extends BaseDataMapper<Portal, Portal_filt
         name
         description
         ownerName
+        attestationCounter
   }`;
 
   async simulateAttest(

--- a/sdk/src/dataMapper/SchemaDataMapper.ts
+++ b/sdk/src/dataMapper/SchemaDataMapper.ts
@@ -15,6 +15,7 @@ export default class SchemaDataMapper extends BaseDataMapper<Schema, Schema_filt
         description
         context
         schema
+        attestationCounter
   }`;
 
   async simulateUpdateRouter(routerAddress: Address) {

--- a/sdk/src/types/index.ts
+++ b/sdk/src/types/index.ts
@@ -39,7 +39,8 @@ export type OnChainAttestation = {
   revocationDate: number | null; // The date when the attestation was revoked.
   version: number; // Version of the registry when the attestation was created.
   revoked: boolean; // Whether the attestation is revoked or not.
-  subject: string; // The ID of the attestee, EVM address, DID, URL etc.
+  subject: string; // The ID of the attestee, EVM address, DID, URL, etc., tentatively decoded as an ETH address.
+  encodedSubject: string; // The raw version of the subject, as it was registered on-chain.
   attestationData: string; // The attestation data.
 };
 
@@ -49,6 +50,7 @@ export type Schema = {
   description: string; // A description of the schema.
   context: string; // The context of the schema.
   schema: string; // The schema definition.
+  attestationCounter: number; // The number of attestations issued with this schema.
 };
 
 export type Portal = {
@@ -59,6 +61,7 @@ export type Portal = {
   name: string; // The name of the portal.
   description: string; // A description of the portal.
   ownerName: string; // The name of the owner of this portal.
+  attestationCounter: number; // The number of attestations issued by the portal.
 };
 
 export type Module = OnChainModule & { id: string };

--- a/sdk/test/integration/Portal.integration.test.ts
+++ b/sdk/test/integration/Portal.integration.test.ts
@@ -21,6 +21,7 @@ describe("PortalDataMapper", () => {
       expect(result?.name).toEqual("eFrogs Portal");
       expect(result?.description).toEqual("eFrogs attestations");
       expect(result?.ownerName).toEqual("alainnicolas.eth");
+      expect(result?.attestationCounter).toBeGreaterThanOrEqual(26);
     });
   });
 

--- a/sdk/test/integration/Schema.integration.test.ts
+++ b/sdk/test/integration/Schema.integration.test.ts
@@ -21,6 +21,7 @@ describe("SchemaDataMapper", () => {
         "Describes a token balance owned on a contract (ERC-20, ERC-721, ERC-1155, etc.)",
       );
       expect(result?.schema).toEqual("(address contract, uint256 balance)");
+      expect(result?.attestationCounter).toBeGreaterThanOrEqual(27);
     });
   });
 

--- a/sdk/tsconfig.build.json
+++ b/sdk/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["test"]
+  "exclude": ["test", "examples"]
 }


### PR DESCRIPTION
## What does this PR do?

1. Makes the SDK able to return the Attestation count for Portals and Schemas
2. Adds an `encodedSubject` field to the Attestation object
3. Switches from self-hosted Graph Nodes to TheGraph for the default Linea subgraph
4. Releases v 1.11.0 of the SDK
5. Upgrades the SDK for the Explorer

### Related ticket

Fixes #677 

### Type of change

- [ ] Chore
- [ ] Bug fix
- [X] New feature
- [ ] Documentation update

## Check list

- [ ] Unit tests for any smart contract change
- [ ] Contracts and functions are documented
