### PR TITLE
fix(explorer): Unable to go back far in the Attestations history

### DIFF
--- a/explorer/src/pages/Attestations/index.tsx
+++ b/explorer/src/pages/Attestations/index.tsx
@@ -44,7 +44,7 @@ export const Attestations: React.FC = () => {
       sdk.attestation.findBy(
         itemsPerPage,
         undefined,
-        (sortByDateDirection as OrderDirection) === null ||
+        (sortByDateDirection as OrderDirection) === undefined ||
           (sortByDateDirection as OrderDirection) === ETableSorting.DESC
           ? { id_lt: numberToHex(totalItems - (page - 1) * itemsPerPage, { size: 32 }) }
           : { id_gt: numberToHex(lastID, { size: 32 }) },

--- a/explorer/src/pages/Attestations/index.tsx
+++ b/explorer/src/pages/Attestations/index.tsx
@@ -39,12 +39,15 @@ export const Attestations: React.FC = () => {
   const [lastID, setLastID] = useState<number>(getItemsByPage(page, itemsPerPage));
 
   const { data: attestationsList, isLoading } = useSWR(
-    `${SWRKeys.GET_ATTESTATION_LIST}/${itemsPerPage}/${lastID}/${sortByDateDirection}/${chain.id}`,
+    totalItems > 0
+      ? `${SWRKeys.GET_ATTESTATION_LIST}/${itemsPerPage}/${lastID}/${sortByDateDirection}/${chain.id}`
+      : null,
     () =>
       sdk.attestation.findBy(
         itemsPerPage,
         undefined,
-        (sortByDateDirection as OrderDirection) === undefined ||
+        (sortByDateDirection as OrderDirection) === null ||
+          (sortByDateDirection as OrderDirection) === undefined ||
           (sortByDateDirection as OrderDirection) === ETableSorting.DESC
           ? { id_lt: numberToHex(totalItems - (page - 1) * itemsPerPage, { size: 32 }) }
           : { id_gt: numberToHex(lastID, { size: 32 }) },

--- a/explorer/src/pages/Attestations/index.tsx
+++ b/explorer/src/pages/Attestations/index.tsx
@@ -2,6 +2,7 @@ import { OrderDirection } from "@verax-attestation-registry/verax-sdk/lib/types/
 import { useRef, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import useSWR from "swr";
+import { numberToHex } from "viem/utils";
 
 import { DataTable } from "@/components/DataTable";
 import { Pagination } from "@/components/Pagination";
@@ -35,22 +36,25 @@ export const Attestations: React.FC = () => {
   const sortByDateDirection = searchParams.get(EQueryParams.SORT_BY_DATE);
   const itemsPerPage = Number(searchParams.get(EQueryParams.ITEMS_PER_PAGE)) || ITEMS_PER_PAGE_DEFAULT;
 
-  const [skip, setSkip] = useState<number>(getItemsByPage(page, itemsPerPage));
+  const [lastID, setLastID] = useState<number>(getItemsByPage(page, itemsPerPage));
 
   const { data: attestationsList, isLoading } = useSWR(
-    `${SWRKeys.GET_ATTESTATION_LIST}/${itemsPerPage}/${skip}/${sortByDateDirection}/${chain.id}`,
+    `${SWRKeys.GET_ATTESTATION_LIST}/${itemsPerPage}/${lastID}/${sortByDateDirection}/${chain.id}`,
     () =>
       sdk.attestation.findBy(
         itemsPerPage,
-        skip,
         undefined,
+        (sortByDateDirection as OrderDirection) === null ||
+          (sortByDateDirection as OrderDirection) === ETableSorting.DESC
+          ? { id_lt: numberToHex(totalItems - (page - 1) * itemsPerPage, { size: 32 }) }
+          : { id_gt: numberToHex(lastID, { size: 32 }) },
         "attestedDate",
         (sortByDateDirection as OrderDirection) || ETableSorting.DESC,
       ),
   );
 
   const handlePage = (retrievedPage: number) => {
-    setSkip(getItemsByPage(retrievedPage, itemsPerPage));
+    setLastID(getItemsByPage(retrievedPage, itemsPerPage));
   };
 
   const columnsSkeletonRef = useRef(columnsSkeleton(columns(), attestationColumnsOption));


### PR DESCRIPTION
## What does this PR do?

This PR changes the way results are loaded on pagination. It uses id where clause rather than skip parameter.

In this way it fixes the limitation of skip parameter being not returning results for large number of pages.

### Related ticket

Fixes #685 

### Type of change

- [ ] Chore
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update

## Check list

- [ ] Unit tests for any smart contract change
- [ ] Contracts and functions are documented
