### PR TITLE
feat(sdk): As a Developer, I want the SDK to be compatible with the new version of the subgraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ Here are the addresses on those networks:
 
 - [Linea Sepolia](https://api.studio.thegraph.com/query/67521/verax-v2-linea-sepolia/v0.0.2)
 - [Linea Mainnet](https://api.studio.thegraph.com/query/67521/verax-v2-linea/v0.0.1)
-- [Linea Mainnet (Backup)](https://api.goldsky.com/api/public/project_cm06hsedxpgls01xm39r67el8/subgraphs/verax-v2-arbitrum-nova/0.0.1/gn)
+- [Linea Mainnet (Backup)](https://api.goldsky.com/api/public/project_clxx488osyuf501vygg71f86w/subgraphs/verax-v2-linea/0.0.1/gn)
 - [Arbitrum Sepolia](https://api.studio.thegraph.com/query/67521/verax-v2-arbitrum-sepolia/v0.0.1)
 - [Arbitrum Mainnet](https://api.studio.thegraph.com/query/67521/verax-v2-arbitrum/v0.0.1)
 - [Arbitrum Nova](https://api.goldsky.com/api/public/project_cm06hsedxpgls01xm39r67el8/subgraphs/verax-v2-arbitrum-nova/0.0.1/gn)

--- a/explorer/package.json
+++ b/explorer/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@radix-ui/react-dropdown-menu": "^2.0.6",
     "@tanstack/react-table": "^8.10.7",
-    "@verax-attestation-registry/verax-sdk": "1.11.0",
+    "@verax-attestation-registry/verax-sdk": "2.0.0-beta.3",
     "@wagmi/core": "^1.4.7",
     "abitype": "^0.10.3",
     "class-variance-authority": "^0.7.0",

--- a/explorer/src/constants/columns/attestation.tsx
+++ b/explorer/src/constants/columns/attestation.tsx
@@ -1,5 +1,5 @@
 import { ColumnDef } from "@tanstack/react-table";
-import { Attestation, VeraxSdk } from "@verax-attestation-registry/verax-sdk";
+import { Attestation, Portal, Schema } from "@verax-attestation-registry/verax-sdk";
 import { t } from "i18next";
 import moment from "moment";
 import { Chain, Hex } from "viem";
@@ -10,22 +10,20 @@ import { HelperIndicator } from "@/components/HelperIndicator";
 import { Link } from "@/components/Link";
 import { SortByDate } from "@/components/SortByDate";
 import { ColumnsOptions } from "@/interfaces/components";
-import { SWRKeys } from "@/interfaces/swr/enum";
 import { SWRCell } from "@/pages/Attestations/components/SWRCell";
 import { toAttestationById, toPortalById, toSchemaById } from "@/routes/constants";
 import { getBlockExplorerLink } from "@/utils";
 import { displayAmountWithComma } from "@/utils/amountUtils";
 import { cropString } from "@/utils/stringUtils";
 
-import { EMPTY_STRING, ITEMS_PER_PAGE_DEFAULT } from "../index";
+import { EMPTY_0X_STRING, EMPTY_STRING, ITEMS_PER_PAGE_DEFAULT } from "../index";
 
 interface ColumnsProps {
   sortByDate: boolean;
-  sdk: VeraxSdk;
   chain: Chain;
 }
 
-export const columns = ({ sortByDate = true, sdk, chain }: Partial<ColumnsProps> = {}): ColumnDef<Attestation>[] => [
+export const columns = ({ sortByDate = true, chain }: Partial<ColumnsProps> = {}): ColumnDef<Attestation>[] => [
   {
     accessorKey: "id",
     header: () => (
@@ -52,18 +50,13 @@ export const columns = ({ sortByDate = true, sdk, chain }: Partial<ColumnsProps>
       </div>
     ),
     cell: ({ row }) => {
-      if (!sdk) return null;
+      const portal = row.getValue("portal") as Portal;
 
-      const portalId = row.getValue("portal") as string;
-      const fetcher = () => sdk.portal.findOneById(portalId || EMPTY_STRING);
-
-      return (
-        <SWRCell swrKey={`${SWRKeys.GET_PORTAL_BY_ID}/${portalId}`} fetcher={fetcher} to={toPortalById(portalId)} />
-      );
+      return <SWRCell data={portal} to={toPortalById(portal.id)} />;
     },
   },
   {
-    accessorKey: "schemaId",
+    accessorKey: "schema",
     header: () => (
       <div className="flex items-center gap-2.5">
         <HelperIndicator type="schema" />
@@ -71,14 +64,9 @@ export const columns = ({ sortByDate = true, sdk, chain }: Partial<ColumnsProps>
       </div>
     ),
     cell: ({ row }) => {
-      if (!sdk) return null;
+      const schema = row.getValue("schema") as Schema;
 
-      const schemaId = row.getValue("schemaId") as string;
-      const fetcher = () => sdk.schema.findOneById(schemaId || EMPTY_STRING);
-
-      return (
-        <SWRCell swrKey={`${SWRKeys.GET_SCHEMA_BY_ID}/${schemaId}`} fetcher={fetcher} to={toSchemaById(schemaId)} />
-      );
+      return <SWRCell data={schema} to={toSchemaById(schema.id)} />;
     },
   },
   {
@@ -120,10 +108,26 @@ export const skeletonAttestations = (itemPerPage = ITEMS_PER_PAGE_DEFAULT): Arra
       decodedData: [EMPTY_STRING],
       decodedPayload: [EMPTY_STRING],
       attestationId: EMPTY_STRING,
-      schemaId: EMPTY_STRING,
+      schema: {
+        id: EMPTY_0X_STRING,
+        name: EMPTY_STRING,
+        description: EMPTY_STRING,
+        context: EMPTY_STRING,
+        schema: EMPTY_STRING,
+        attestationCounter: 0,
+      },
       replacedBy: EMPTY_STRING,
       attester: `0x${index}`,
-      portal: `0x${index}`,
+      portal: {
+        id: EMPTY_0X_STRING,
+        ownerAddress: EMPTY_0X_STRING,
+        modules: [EMPTY_0X_STRING],
+        isRevocable: false,
+        name: EMPTY_STRING,
+        description: EMPTY_STRING,
+        ownerName: EMPTY_STRING,
+        attestationCounter: 0,
+      },
       attestedDate: 0,
       expirationDate: 0,
       revocationDate: 0,

--- a/explorer/src/constants/index.ts
+++ b/explorer/src/constants/index.ts
@@ -3,6 +3,7 @@ import { arbitrum, arbitrumNova, arbitrumSepolia, base, baseSepolia, bsc, bscTes
 import { lineaSepolia } from "@/config";
 
 export const EMPTY_STRING = "";
+export const EMPTY_0X_STRING = "0x";
 export const SPACE_STRING = " ";
 export const COMMA_STRING = ",";
 export const DASH = "-";

--- a/explorer/src/pages/Attestation/components/AttestationInfo/index.tsx
+++ b/explorer/src/pages/Attestation/components/AttestationInfo/index.tsx
@@ -36,8 +36,8 @@ export const AttestationInfo: React.FC<Attestation> = ({ ...attestation }) => {
     },
     {
       title: t("attestation.info.portal"),
-      value: cropString(portal),
-      to: toPortalById(portal),
+      value: cropString(portal.name),
+      to: toPortalById(portal.id),
     },
     {
       title: t("attestation.info.subject"),

--- a/explorer/src/pages/Attestation/index.tsx
+++ b/explorer/src/pages/Attestation/index.tsx
@@ -44,7 +44,7 @@ export const Attestation = () => {
           <AttestationInfo {...attestation} />
         </div>
         <div className="flex flex-col p-6 gap-12 w-full">
-          <AttestationSchemaCard schemaId={attestation.schemaId} />
+          <AttestationSchemaCard schemaId={attestation.schema.id} />
           <AttestationData {...attestation} />
           {/* TODO: uncomment when correct data will be available */}
           {/* <RelatedAttestations mutate={mutate} /> */}

--- a/explorer/src/pages/Attestations/components/SWRCell/index.tsx
+++ b/explorer/src/pages/Attestations/components/SWRCell/index.tsx
@@ -1,19 +1,11 @@
 import { Portal, Schema } from "@verax-attestation-registry/verax-sdk";
-import useSWR from "swr";
 
 import { Link } from "@/components/Link";
-import { EMPTY_STRING } from "@/constants";
 
-export const SWRCell: React.FC<{ swrKey: string; fetcher: () => Promise<Schema | Portal | undefined>; to: string }> = ({
-  swrKey,
-  fetcher,
-  to,
-}) => {
-  const { data } = useSWR(swrKey, fetcher);
-
+export const SWRCell: React.FC<{ data: Portal | Schema; to: string }> = ({ data, to }) => {
   return (
     <Link className="hover:underline transition" to={to} onClick={(e) => e.stopPropagation()}>
-      {data?.name || EMPTY_STRING}
+      {data.name}
     </Link>
   );
 };

--- a/explorer/src/pages/Attestations/index.tsx
+++ b/explorer/src/pages/Attestations/index.tsx
@@ -60,7 +60,7 @@ export const Attestations: React.FC = () => {
 
   const data = isLoading
     ? { columns: columnsSkeletonRef.current, list: skeletonAttestations(itemsPerPage) }
-    : { columns: columns({ sdk, chain: network.chain }), list: attestationsList || [] };
+    : { columns: columns({ chain: network.chain }), list: attestationsList || [] };
 
   return (
     <TitleAndSwitcher>

--- a/explorer/src/pages/MyAttestations/index.tsx
+++ b/explorer/src/pages/MyAttestations/index.tsx
@@ -91,7 +91,7 @@ export const MyAttestations: React.FC = () => {
       ) : !attestationsList || !attestationsList.length ? (
         <InfoBlock icon={<ArchiveIcon />} message={t("attestation.messages.emptyList")} />
       ) : (
-        <DataTable columns={columns({ sdk, chain })} data={attestationsList} link={APP_ROUTES.ATTESTATION_BY_ID} />
+        <DataTable columns={columns({ chain })} data={attestationsList} link={APP_ROUTES.ATTESTATION_BY_ID} />
       )}
     </TitleAndSwitcher>
   );

--- a/explorer/src/pages/Schema/components/RecentAttestations/index.tsx
+++ b/explorer/src/pages/Schema/components/RecentAttestations/index.tsx
@@ -17,7 +17,7 @@ export const RecentAttestations: React.FC<{ schemaId: string }> = ({ schemaId })
 
   const { data: attestations, isLoading } = useSWR(
     `${SWRKeys.GET_RECENT_ATTESTATION}/${schemaId}/${chain.id}`,
-    () => sdk.attestation.findBy(5, 0, { schemaId }, "attestedDate", "desc"),
+    () => sdk.attestation.findBy(5, 0, { schema: schemaId }, "attestedDate", "desc"),
     {
       shouldRetryOnError: false,
     },
@@ -27,7 +27,7 @@ export const RecentAttestations: React.FC<{ schemaId: string }> = ({ schemaId })
   const data = isLoading
     ? { columns: columnsSkeletonRef.current, list: skeletonAttestations(5) }
     : {
-        columns: columns({ sortByDate: false, sdk, chain }),
+        columns: columns({ sortByDate: false, chain }),
         list: attestations || [],
       };
 

--- a/explorer/src/pages/Search/components/SearchAttestationsReceived/index.tsx
+++ b/explorer/src/pages/Search/components/SearchAttestationsReceived/index.tsx
@@ -31,7 +31,7 @@ export const SearchAttestationsReceived: React.FC<SearchComponentProps> = ({ get
   if (!data || !data.length) return null;
   return (
     <SearchWrapper title={t("attestation.received")} items={data.length}>
-      <DataTable columns={columns({ sdk, chain })} data={data} link={APP_ROUTES.ATTESTATION_BY_ID} />
+      <DataTable columns={columns({ chain })} data={data} link={APP_ROUTES.ATTESTATION_BY_ID} />
     </SearchWrapper>
   );
 };

--- a/explorer/src/pages/Search/components/SearchAttestationsReceived/loadAttestationReceivedList.ts
+++ b/explorer/src/pages/Search/components/SearchAttestationsReceived/loadAttestationReceivedList.ts
@@ -26,7 +26,7 @@ export const loadAttestationReceivedList = async (
   ).filter(isNotNullOrUndefined);
 
   const listBySchemaString = parsedString.schemaString
-    ? await attestation.findBy(ITEMS_SEARCHED_DEFAULT, undefined, { schemaString: parsedString.schemaString })
+    ? await attestation.findBy(ITEMS_SEARCHED_DEFAULT, undefined, { schema: parsedString.schemaString })
     : [];
 
   const results = [...(listByIds || []), ...(listBySubject || []), ...(listBySchemaString || [])];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,8 +90,8 @@ importers:
         specifier: ^8.10.7
         version: 8.17.3(react-dom@18.3.1)(react@18.3.1)
       '@verax-attestation-registry/verax-sdk':
-        specifier: 1.11.0
-        version: 1.11.0(@graphql-mesh/types@0.95.8)(@graphql-tools/utils@10.2.0)(@types/node@20.12.12)(@types/react@18.3.2)(react-dom@18.3.1)(react@18.3.1)(tslib@2.6.2)(typescript@5.2.2)
+        specifier: 2.0.0-beta.3
+        version: 2.0.0-beta.3(@graphql-mesh/types@0.95.8)(@graphql-tools/utils@10.2.0)(@types/node@20.12.12)(@types/react@18.3.2)(react-dom@18.3.1)(react@18.3.1)(tslib@2.6.2)(typescript@5.2.2)
       '@wagmi/core':
         specifier: ^1.4.7
         version: 1.4.13(@types/react@18.3.2)(react@18.3.1)(typescript@5.2.2)(viem@1.18.9)
@@ -3489,7 +3489,7 @@ packages:
       tsconfig-paths: 4.2.0
       tslib: 2.6.2
       typescript: 5.4.5
-      uWebSockets.js: github.com/uNetworking/uWebSockets.js/6f4b450fc642abba540535f0755c990b42a16026
+      uWebSockets.js: github.com/uNetworking/uWebSockets.js/51ae1d1fd92dff77cbbdc7c431021f85578da1a6
       yargs: 17.7.2
     optionalDependencies:
       node-libcurl: 4.0.0
@@ -9740,8 +9740,8 @@ packages:
     resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
     dev: true
 
-  /@verax-attestation-registry/verax-sdk@1.11.0(@graphql-mesh/types@0.95.8)(@graphql-tools/utils@10.2.0)(@types/node@20.12.12)(@types/react@18.3.2)(react-dom@18.3.1)(react@18.3.1)(tslib@2.6.2)(typescript@5.2.2):
-    resolution: {integrity: sha512-rewR7ZvBLeKkGOAXUCfQpIKSMa7XTQPbGmy0DbA2xJs0qIf39I3BfP6GKNeire+KrNRiTGpP6E8C8JU3SrSa3w==}
+  /@verax-attestation-registry/verax-sdk@2.0.0-beta.3(@graphql-mesh/types@0.95.8)(@graphql-tools/utils@10.2.0)(@types/node@20.12.12)(@types/react@18.3.2)(react-dom@18.3.1)(react@18.3.1)(tslib@2.6.2)(typescript@5.2.2):
+    resolution: {integrity: sha512-War1eN9HxqUNflOSUhmT6LvAj3FIeK9emCV14If5fxCB2nVX80h9rMGjSz/pB/lIzQAykGoDDb4dM+po7kw1UQ==}
     dependencies:
       '@graphql-mesh/cache-localforage': 0.95.8(@graphql-mesh/types@0.95.8)(@graphql-mesh/utils@0.95.8)(graphql@16.8.1)(tslib@2.6.2)
       '@graphql-mesh/cross-helpers': 0.4.2(@graphql-tools/utils@10.2.0)(graphql@16.8.1)
@@ -26290,8 +26290,8 @@ packages:
       use-sync-external-store: 1.2.0(react@18.3.1)
     dev: false
 
-  github.com/uNetworking/uWebSockets.js/6f4b450fc642abba540535f0755c990b42a16026:
-    resolution: {tarball: https://codeload.github.com/uNetworking/uWebSockets.js/tar.gz/6f4b450fc642abba540535f0755c990b42a16026}
+  github.com/uNetworking/uWebSockets.js/51ae1d1fd92dff77cbbdc7c431021f85578da1a6:
+    resolution: {tarball: https://codeload.github.com/uNetworking/uWebSockets.js/tar.gz/51ae1d1fd92dff77cbbdc7c431021f85578da1a6}
     name: uWebSockets.js
-    version: 20.47.0
+    version: 20.48.0
     dev: true

--- a/sdk/.graphclient/index.ts
+++ b/sdk/.graphclient/index.ts
@@ -49,10 +49,10 @@ export type Aggregation_interval =
 
 export type Attestation = {
   id: Scalars['ID']['output'];
-  schemaId: Scalars['Bytes']['output'];
+  schema: Schema;
   replacedBy: Scalars['Bytes']['output'];
   attester: Scalars['Bytes']['output'];
-  portal: Scalars['Bytes']['output'];
+  portal: Portal;
   attestedDate: Scalars['BigInt']['output'];
   expirationDate: Scalars['BigInt']['output'];
   revocationDate: Scalars['BigInt']['output'];
@@ -61,8 +61,8 @@ export type Attestation = {
   subject: Scalars['Bytes']['output'];
   encodedSubject: Scalars['Bytes']['output'];
   attestationData: Scalars['Bytes']['output'];
-  schemaString?: Maybe<Scalars['String']['output']>;
   decodedData?: Maybe<Array<Scalars['String']['output']>>;
+  auditInformation: AuditInformation;
 };
 
 export type Attestation_filter = {
@@ -74,16 +74,27 @@ export type Attestation_filter = {
   id_lte?: InputMaybe<Scalars['ID']['input']>;
   id_in?: InputMaybe<Array<Scalars['ID']['input']>>;
   id_not_in?: InputMaybe<Array<Scalars['ID']['input']>>;
-  schemaId?: InputMaybe<Scalars['Bytes']['input']>;
-  schemaId_not?: InputMaybe<Scalars['Bytes']['input']>;
-  schemaId_gt?: InputMaybe<Scalars['Bytes']['input']>;
-  schemaId_lt?: InputMaybe<Scalars['Bytes']['input']>;
-  schemaId_gte?: InputMaybe<Scalars['Bytes']['input']>;
-  schemaId_lte?: InputMaybe<Scalars['Bytes']['input']>;
-  schemaId_in?: InputMaybe<Array<Scalars['Bytes']['input']>>;
-  schemaId_not_in?: InputMaybe<Array<Scalars['Bytes']['input']>>;
-  schemaId_contains?: InputMaybe<Scalars['Bytes']['input']>;
-  schemaId_not_contains?: InputMaybe<Scalars['Bytes']['input']>;
+  schema?: InputMaybe<Scalars['String']['input']>;
+  schema_not?: InputMaybe<Scalars['String']['input']>;
+  schema_gt?: InputMaybe<Scalars['String']['input']>;
+  schema_lt?: InputMaybe<Scalars['String']['input']>;
+  schema_gte?: InputMaybe<Scalars['String']['input']>;
+  schema_lte?: InputMaybe<Scalars['String']['input']>;
+  schema_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  schema_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  schema_contains?: InputMaybe<Scalars['String']['input']>;
+  schema_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  schema_not_contains?: InputMaybe<Scalars['String']['input']>;
+  schema_not_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  schema_starts_with?: InputMaybe<Scalars['String']['input']>;
+  schema_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  schema_not_starts_with?: InputMaybe<Scalars['String']['input']>;
+  schema_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  schema_ends_with?: InputMaybe<Scalars['String']['input']>;
+  schema_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  schema_not_ends_with?: InputMaybe<Scalars['String']['input']>;
+  schema_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  schema_?: InputMaybe<Schema_filter>;
   replacedBy?: InputMaybe<Scalars['Bytes']['input']>;
   replacedBy_not?: InputMaybe<Scalars['Bytes']['input']>;
   replacedBy_gt?: InputMaybe<Scalars['Bytes']['input']>;
@@ -104,16 +115,27 @@ export type Attestation_filter = {
   attester_not_in?: InputMaybe<Array<Scalars['Bytes']['input']>>;
   attester_contains?: InputMaybe<Scalars['Bytes']['input']>;
   attester_not_contains?: InputMaybe<Scalars['Bytes']['input']>;
-  portal?: InputMaybe<Scalars['Bytes']['input']>;
-  portal_not?: InputMaybe<Scalars['Bytes']['input']>;
-  portal_gt?: InputMaybe<Scalars['Bytes']['input']>;
-  portal_lt?: InputMaybe<Scalars['Bytes']['input']>;
-  portal_gte?: InputMaybe<Scalars['Bytes']['input']>;
-  portal_lte?: InputMaybe<Scalars['Bytes']['input']>;
-  portal_in?: InputMaybe<Array<Scalars['Bytes']['input']>>;
-  portal_not_in?: InputMaybe<Array<Scalars['Bytes']['input']>>;
-  portal_contains?: InputMaybe<Scalars['Bytes']['input']>;
-  portal_not_contains?: InputMaybe<Scalars['Bytes']['input']>;
+  portal?: InputMaybe<Scalars['String']['input']>;
+  portal_not?: InputMaybe<Scalars['String']['input']>;
+  portal_gt?: InputMaybe<Scalars['String']['input']>;
+  portal_lt?: InputMaybe<Scalars['String']['input']>;
+  portal_gte?: InputMaybe<Scalars['String']['input']>;
+  portal_lte?: InputMaybe<Scalars['String']['input']>;
+  portal_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  portal_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  portal_contains?: InputMaybe<Scalars['String']['input']>;
+  portal_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  portal_not_contains?: InputMaybe<Scalars['String']['input']>;
+  portal_not_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  portal_starts_with?: InputMaybe<Scalars['String']['input']>;
+  portal_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  portal_not_starts_with?: InputMaybe<Scalars['String']['input']>;
+  portal_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  portal_ends_with?: InputMaybe<Scalars['String']['input']>;
+  portal_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  portal_not_ends_with?: InputMaybe<Scalars['String']['input']>;
+  portal_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  portal_?: InputMaybe<Portal_filter>;
   attestedDate?: InputMaybe<Scalars['BigInt']['input']>;
   attestedDate_not?: InputMaybe<Scalars['BigInt']['input']>;
   attestedDate_gt?: InputMaybe<Scalars['BigInt']['input']>;
@@ -180,32 +202,33 @@ export type Attestation_filter = {
   attestationData_not_in?: InputMaybe<Array<Scalars['Bytes']['input']>>;
   attestationData_contains?: InputMaybe<Scalars['Bytes']['input']>;
   attestationData_not_contains?: InputMaybe<Scalars['Bytes']['input']>;
-  schemaString?: InputMaybe<Scalars['String']['input']>;
-  schemaString_not?: InputMaybe<Scalars['String']['input']>;
-  schemaString_gt?: InputMaybe<Scalars['String']['input']>;
-  schemaString_lt?: InputMaybe<Scalars['String']['input']>;
-  schemaString_gte?: InputMaybe<Scalars['String']['input']>;
-  schemaString_lte?: InputMaybe<Scalars['String']['input']>;
-  schemaString_in?: InputMaybe<Array<Scalars['String']['input']>>;
-  schemaString_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
-  schemaString_contains?: InputMaybe<Scalars['String']['input']>;
-  schemaString_contains_nocase?: InputMaybe<Scalars['String']['input']>;
-  schemaString_not_contains?: InputMaybe<Scalars['String']['input']>;
-  schemaString_not_contains_nocase?: InputMaybe<Scalars['String']['input']>;
-  schemaString_starts_with?: InputMaybe<Scalars['String']['input']>;
-  schemaString_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
-  schemaString_not_starts_with?: InputMaybe<Scalars['String']['input']>;
-  schemaString_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
-  schemaString_ends_with?: InputMaybe<Scalars['String']['input']>;
-  schemaString_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
-  schemaString_not_ends_with?: InputMaybe<Scalars['String']['input']>;
-  schemaString_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
   decodedData?: InputMaybe<Array<Scalars['String']['input']>>;
   decodedData_not?: InputMaybe<Array<Scalars['String']['input']>>;
   decodedData_contains?: InputMaybe<Array<Scalars['String']['input']>>;
   decodedData_contains_nocase?: InputMaybe<Array<Scalars['String']['input']>>;
   decodedData_not_contains?: InputMaybe<Array<Scalars['String']['input']>>;
   decodedData_not_contains_nocase?: InputMaybe<Array<Scalars['String']['input']>>;
+  auditInformation?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_not?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_gt?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_lt?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_gte?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_lte?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  auditInformation_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  auditInformation_contains?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_not_contains?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_not_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_starts_with?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_not_starts_with?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_ends_with?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_not_ends_with?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_?: InputMaybe<AuditInformation_filter>;
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
   and?: InputMaybe<Array<InputMaybe<Attestation_filter>>>;
@@ -214,10 +237,23 @@ export type Attestation_filter = {
 
 export type Attestation_orderBy =
   | 'id'
-  | 'schemaId'
+  | 'schema'
+  | 'schema__id'
+  | 'schema__name'
+  | 'schema__description'
+  | 'schema__context'
+  | 'schema__schema'
+  | 'schema__attestationCounter'
   | 'replacedBy'
   | 'attester'
   | 'portal'
+  | 'portal__id'
+  | 'portal__ownerAddress'
+  | 'portal__isRevocable'
+  | 'portal__name'
+  | 'portal__description'
+  | 'portal__ownerName'
+  | 'portal__attestationCounter'
   | 'attestedDate'
   | 'expirationDate'
   | 'revocationDate'
@@ -226,8 +262,209 @@ export type Attestation_orderBy =
   | 'subject'
   | 'encodedSubject'
   | 'attestationData'
-  | 'schemaString'
-  | 'decodedData';
+  | 'decodedData'
+  | 'auditInformation'
+  | 'auditInformation__id';
+
+export type Audit = {
+  id: Scalars['ID']['output'];
+  blockNumber: Scalars['BigInt']['output'];
+  transactionHash: Scalars['Bytes']['output'];
+  transactionTimestamp: Scalars['BigInt']['output'];
+  fromAddress: Scalars['Bytes']['output'];
+  toAddress?: Maybe<Scalars['Bytes']['output']>;
+  valueTransferred?: Maybe<Scalars['BigInt']['output']>;
+  gasPrice?: Maybe<Scalars['BigInt']['output']>;
+};
+
+export type AuditInformation = {
+  id: Scalars['ID']['output'];
+  creation: Audit;
+  lastModification: Audit;
+  modifications: Array<Audit>;
+};
+
+
+export type AuditInformationmodificationsArgs = {
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<Audit_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<Audit_filter>;
+};
+
+export type AuditInformation_filter = {
+  id?: InputMaybe<Scalars['ID']['input']>;
+  id_not?: InputMaybe<Scalars['ID']['input']>;
+  id_gt?: InputMaybe<Scalars['ID']['input']>;
+  id_lt?: InputMaybe<Scalars['ID']['input']>;
+  id_gte?: InputMaybe<Scalars['ID']['input']>;
+  id_lte?: InputMaybe<Scalars['ID']['input']>;
+  id_in?: InputMaybe<Array<Scalars['ID']['input']>>;
+  id_not_in?: InputMaybe<Array<Scalars['ID']['input']>>;
+  creation?: InputMaybe<Scalars['String']['input']>;
+  creation_not?: InputMaybe<Scalars['String']['input']>;
+  creation_gt?: InputMaybe<Scalars['String']['input']>;
+  creation_lt?: InputMaybe<Scalars['String']['input']>;
+  creation_gte?: InputMaybe<Scalars['String']['input']>;
+  creation_lte?: InputMaybe<Scalars['String']['input']>;
+  creation_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  creation_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  creation_contains?: InputMaybe<Scalars['String']['input']>;
+  creation_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  creation_not_contains?: InputMaybe<Scalars['String']['input']>;
+  creation_not_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  creation_starts_with?: InputMaybe<Scalars['String']['input']>;
+  creation_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  creation_not_starts_with?: InputMaybe<Scalars['String']['input']>;
+  creation_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  creation_ends_with?: InputMaybe<Scalars['String']['input']>;
+  creation_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  creation_not_ends_with?: InputMaybe<Scalars['String']['input']>;
+  creation_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  creation_?: InputMaybe<Audit_filter>;
+  lastModification?: InputMaybe<Scalars['String']['input']>;
+  lastModification_not?: InputMaybe<Scalars['String']['input']>;
+  lastModification_gt?: InputMaybe<Scalars['String']['input']>;
+  lastModification_lt?: InputMaybe<Scalars['String']['input']>;
+  lastModification_gte?: InputMaybe<Scalars['String']['input']>;
+  lastModification_lte?: InputMaybe<Scalars['String']['input']>;
+  lastModification_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  lastModification_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  lastModification_contains?: InputMaybe<Scalars['String']['input']>;
+  lastModification_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  lastModification_not_contains?: InputMaybe<Scalars['String']['input']>;
+  lastModification_not_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  lastModification_starts_with?: InputMaybe<Scalars['String']['input']>;
+  lastModification_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  lastModification_not_starts_with?: InputMaybe<Scalars['String']['input']>;
+  lastModification_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  lastModification_ends_with?: InputMaybe<Scalars['String']['input']>;
+  lastModification_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  lastModification_not_ends_with?: InputMaybe<Scalars['String']['input']>;
+  lastModification_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  lastModification_?: InputMaybe<Audit_filter>;
+  modifications?: InputMaybe<Array<Scalars['String']['input']>>;
+  modifications_not?: InputMaybe<Array<Scalars['String']['input']>>;
+  modifications_contains?: InputMaybe<Array<Scalars['String']['input']>>;
+  modifications_contains_nocase?: InputMaybe<Array<Scalars['String']['input']>>;
+  modifications_not_contains?: InputMaybe<Array<Scalars['String']['input']>>;
+  modifications_not_contains_nocase?: InputMaybe<Array<Scalars['String']['input']>>;
+  modifications_?: InputMaybe<Audit_filter>;
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<AuditInformation_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<AuditInformation_filter>>>;
+};
+
+export type AuditInformation_orderBy =
+  | 'id'
+  | 'creation'
+  | 'creation__id'
+  | 'creation__blockNumber'
+  | 'creation__transactionHash'
+  | 'creation__transactionTimestamp'
+  | 'creation__fromAddress'
+  | 'creation__toAddress'
+  | 'creation__valueTransferred'
+  | 'creation__gasPrice'
+  | 'lastModification'
+  | 'lastModification__id'
+  | 'lastModification__blockNumber'
+  | 'lastModification__transactionHash'
+  | 'lastModification__transactionTimestamp'
+  | 'lastModification__fromAddress'
+  | 'lastModification__toAddress'
+  | 'lastModification__valueTransferred'
+  | 'lastModification__gasPrice'
+  | 'modifications';
+
+export type Audit_filter = {
+  id?: InputMaybe<Scalars['ID']['input']>;
+  id_not?: InputMaybe<Scalars['ID']['input']>;
+  id_gt?: InputMaybe<Scalars['ID']['input']>;
+  id_lt?: InputMaybe<Scalars['ID']['input']>;
+  id_gte?: InputMaybe<Scalars['ID']['input']>;
+  id_lte?: InputMaybe<Scalars['ID']['input']>;
+  id_in?: InputMaybe<Array<Scalars['ID']['input']>>;
+  id_not_in?: InputMaybe<Array<Scalars['ID']['input']>>;
+  blockNumber?: InputMaybe<Scalars['BigInt']['input']>;
+  blockNumber_not?: InputMaybe<Scalars['BigInt']['input']>;
+  blockNumber_gt?: InputMaybe<Scalars['BigInt']['input']>;
+  blockNumber_lt?: InputMaybe<Scalars['BigInt']['input']>;
+  blockNumber_gte?: InputMaybe<Scalars['BigInt']['input']>;
+  blockNumber_lte?: InputMaybe<Scalars['BigInt']['input']>;
+  blockNumber_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  blockNumber_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  transactionHash?: InputMaybe<Scalars['Bytes']['input']>;
+  transactionHash_not?: InputMaybe<Scalars['Bytes']['input']>;
+  transactionHash_gt?: InputMaybe<Scalars['Bytes']['input']>;
+  transactionHash_lt?: InputMaybe<Scalars['Bytes']['input']>;
+  transactionHash_gte?: InputMaybe<Scalars['Bytes']['input']>;
+  transactionHash_lte?: InputMaybe<Scalars['Bytes']['input']>;
+  transactionHash_in?: InputMaybe<Array<Scalars['Bytes']['input']>>;
+  transactionHash_not_in?: InputMaybe<Array<Scalars['Bytes']['input']>>;
+  transactionHash_contains?: InputMaybe<Scalars['Bytes']['input']>;
+  transactionHash_not_contains?: InputMaybe<Scalars['Bytes']['input']>;
+  transactionTimestamp?: InputMaybe<Scalars['BigInt']['input']>;
+  transactionTimestamp_not?: InputMaybe<Scalars['BigInt']['input']>;
+  transactionTimestamp_gt?: InputMaybe<Scalars['BigInt']['input']>;
+  transactionTimestamp_lt?: InputMaybe<Scalars['BigInt']['input']>;
+  transactionTimestamp_gte?: InputMaybe<Scalars['BigInt']['input']>;
+  transactionTimestamp_lte?: InputMaybe<Scalars['BigInt']['input']>;
+  transactionTimestamp_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  transactionTimestamp_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  fromAddress?: InputMaybe<Scalars['Bytes']['input']>;
+  fromAddress_not?: InputMaybe<Scalars['Bytes']['input']>;
+  fromAddress_gt?: InputMaybe<Scalars['Bytes']['input']>;
+  fromAddress_lt?: InputMaybe<Scalars['Bytes']['input']>;
+  fromAddress_gte?: InputMaybe<Scalars['Bytes']['input']>;
+  fromAddress_lte?: InputMaybe<Scalars['Bytes']['input']>;
+  fromAddress_in?: InputMaybe<Array<Scalars['Bytes']['input']>>;
+  fromAddress_not_in?: InputMaybe<Array<Scalars['Bytes']['input']>>;
+  fromAddress_contains?: InputMaybe<Scalars['Bytes']['input']>;
+  fromAddress_not_contains?: InputMaybe<Scalars['Bytes']['input']>;
+  toAddress?: InputMaybe<Scalars['Bytes']['input']>;
+  toAddress_not?: InputMaybe<Scalars['Bytes']['input']>;
+  toAddress_gt?: InputMaybe<Scalars['Bytes']['input']>;
+  toAddress_lt?: InputMaybe<Scalars['Bytes']['input']>;
+  toAddress_gte?: InputMaybe<Scalars['Bytes']['input']>;
+  toAddress_lte?: InputMaybe<Scalars['Bytes']['input']>;
+  toAddress_in?: InputMaybe<Array<Scalars['Bytes']['input']>>;
+  toAddress_not_in?: InputMaybe<Array<Scalars['Bytes']['input']>>;
+  toAddress_contains?: InputMaybe<Scalars['Bytes']['input']>;
+  toAddress_not_contains?: InputMaybe<Scalars['Bytes']['input']>;
+  valueTransferred?: InputMaybe<Scalars['BigInt']['input']>;
+  valueTransferred_not?: InputMaybe<Scalars['BigInt']['input']>;
+  valueTransferred_gt?: InputMaybe<Scalars['BigInt']['input']>;
+  valueTransferred_lt?: InputMaybe<Scalars['BigInt']['input']>;
+  valueTransferred_gte?: InputMaybe<Scalars['BigInt']['input']>;
+  valueTransferred_lte?: InputMaybe<Scalars['BigInt']['input']>;
+  valueTransferred_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  valueTransferred_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  gasPrice?: InputMaybe<Scalars['BigInt']['input']>;
+  gasPrice_not?: InputMaybe<Scalars['BigInt']['input']>;
+  gasPrice_gt?: InputMaybe<Scalars['BigInt']['input']>;
+  gasPrice_lt?: InputMaybe<Scalars['BigInt']['input']>;
+  gasPrice_gte?: InputMaybe<Scalars['BigInt']['input']>;
+  gasPrice_lte?: InputMaybe<Scalars['BigInt']['input']>;
+  gasPrice_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  gasPrice_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<Audit_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<Audit_filter>>>;
+};
+
+export type Audit_orderBy =
+  | 'id'
+  | 'blockNumber'
+  | 'transactionHash'
+  | 'transactionTimestamp'
+  | 'fromAddress'
+  | 'toAddress'
+  | 'valueTransferred'
+  | 'gasPrice';
 
 export type BlockChangedFilter = {
   number_gte: Scalars['Int']['input'];
@@ -303,6 +540,7 @@ export type Counter_orderBy =
 
 export type Issuer = {
   id: Scalars['ID']['output'];
+  auditInformation: AuditInformation;
 };
 
 export type Issuer_filter = {
@@ -314,6 +552,27 @@ export type Issuer_filter = {
   id_lte?: InputMaybe<Scalars['ID']['input']>;
   id_in?: InputMaybe<Array<Scalars['ID']['input']>>;
   id_not_in?: InputMaybe<Array<Scalars['ID']['input']>>;
+  auditInformation?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_not?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_gt?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_lt?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_gte?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_lte?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  auditInformation_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  auditInformation_contains?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_not_contains?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_not_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_starts_with?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_not_starts_with?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_ends_with?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_not_ends_with?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_?: InputMaybe<AuditInformation_filter>;
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
   and?: InputMaybe<Array<InputMaybe<Issuer_filter>>>;
@@ -321,13 +580,16 @@ export type Issuer_filter = {
 };
 
 export type Issuer_orderBy =
-  | 'id';
+  | 'id'
+  | 'auditInformation'
+  | 'auditInformation__id';
 
 export type Module = {
   id: Scalars['ID']['output'];
   moduleAddress: Scalars['Bytes']['output'];
   name: Scalars['String']['output'];
   description: Scalars['String']['output'];
+  auditInformation: AuditInformation;
 };
 
 export type Module_filter = {
@@ -389,6 +651,27 @@ export type Module_filter = {
   description_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
   description_not_ends_with?: InputMaybe<Scalars['String']['input']>;
   description_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  auditInformation?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_not?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_gt?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_lt?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_gte?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_lte?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  auditInformation_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  auditInformation_contains?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_not_contains?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_not_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_starts_with?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_not_starts_with?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_ends_with?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_not_ends_with?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_?: InputMaybe<AuditInformation_filter>;
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
   and?: InputMaybe<Array<InputMaybe<Module_filter>>>;
@@ -399,7 +682,9 @@ export type Module_orderBy =
   | 'id'
   | 'moduleAddress'
   | 'name'
-  | 'description';
+  | 'description'
+  | 'auditInformation'
+  | 'auditInformation__id';
 
 /** Defines the order direction, either ascending or descending */
 export type OrderDirection =
@@ -415,6 +700,7 @@ export type Portal = {
   description: Scalars['String']['output'];
   ownerName: Scalars['String']['output'];
   attestationCounter?: Maybe<Scalars['Int']['output']>;
+  auditInformation: AuditInformation;
 };
 
 export type Portal_filter = {
@@ -514,6 +800,27 @@ export type Portal_filter = {
   attestationCounter_lte?: InputMaybe<Scalars['Int']['input']>;
   attestationCounter_in?: InputMaybe<Array<Scalars['Int']['input']>>;
   attestationCounter_not_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  auditInformation?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_not?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_gt?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_lt?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_gte?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_lte?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  auditInformation_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  auditInformation_contains?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_not_contains?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_not_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_starts_with?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_not_starts_with?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_ends_with?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_not_ends_with?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_?: InputMaybe<AuditInformation_filter>;
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
   and?: InputMaybe<Array<InputMaybe<Portal_filter>>>;
@@ -528,7 +835,9 @@ export type Portal_orderBy =
   | 'name'
   | 'description'
   | 'ownerName'
-  | 'attestationCounter';
+  | 'attestationCounter'
+  | 'auditInformation'
+  | 'auditInformation__id';
 
 export type Query = {
   attestation?: Maybe<Attestation>;
@@ -545,6 +854,10 @@ export type Query = {
   issuers: Array<Issuer>;
   registryVersion?: Maybe<RegistryVersion>;
   registryVersions: Array<RegistryVersion>;
+  auditInformation?: Maybe<AuditInformation>;
+  auditInformations: Array<AuditInformation>;
+  audit?: Maybe<Audit>;
+  audits: Array<Audit>;
   /** Access to subgraph metadata */
   _meta?: Maybe<_Meta_>;
 };
@@ -676,6 +989,42 @@ export type QueryregistryVersionsArgs = {
 };
 
 
+export type QueryauditInformationArgs = {
+  id: Scalars['ID']['input'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryauditInformationsArgs = {
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<AuditInformation_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<AuditInformation_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryauditArgs = {
+  id: Scalars['ID']['input'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryauditsArgs = {
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<Audit_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<Audit_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
 export type Query_metaArgs = {
   block?: InputMaybe<Block_height>;
 };
@@ -684,6 +1033,7 @@ export type RegistryVersion = {
   id: Scalars['ID']['output'];
   versionNumber?: Maybe<Scalars['Int']['output']>;
   timestamp?: Maybe<Scalars['BigInt']['output']>;
+  auditInformation: AuditInformation;
 };
 
 export type RegistryVersion_filter = {
@@ -711,6 +1061,27 @@ export type RegistryVersion_filter = {
   timestamp_lte?: InputMaybe<Scalars['BigInt']['input']>;
   timestamp_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
   timestamp_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  auditInformation?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_not?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_gt?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_lt?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_gte?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_lte?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  auditInformation_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  auditInformation_contains?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_not_contains?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_not_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_starts_with?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_not_starts_with?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_ends_with?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_not_ends_with?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_?: InputMaybe<AuditInformation_filter>;
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
   and?: InputMaybe<Array<InputMaybe<RegistryVersion_filter>>>;
@@ -720,7 +1091,9 @@ export type RegistryVersion_filter = {
 export type RegistryVersion_orderBy =
   | 'id'
   | 'versionNumber'
-  | 'timestamp';
+  | 'timestamp'
+  | 'auditInformation'
+  | 'auditInformation__id';
 
 export type Schema = {
   id: Scalars['ID']['output'];
@@ -729,6 +1102,7 @@ export type Schema = {
   context: Scalars['String']['output'];
   schema: Scalars['String']['output'];
   attestationCounter?: Maybe<Scalars['Int']['output']>;
+  auditInformation: AuditInformation;
 };
 
 export type Schema_filter = {
@@ -828,6 +1202,27 @@ export type Schema_filter = {
   attestationCounter_lte?: InputMaybe<Scalars['Int']['input']>;
   attestationCounter_in?: InputMaybe<Array<Scalars['Int']['input']>>;
   attestationCounter_not_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  auditInformation?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_not?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_gt?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_lt?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_gte?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_lte?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  auditInformation_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  auditInformation_contains?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_not_contains?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_not_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_starts_with?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_not_starts_with?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_ends_with?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_not_ends_with?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_?: InputMaybe<AuditInformation_filter>;
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
   and?: InputMaybe<Array<InputMaybe<Schema_filter>>>;
@@ -840,7 +1235,9 @@ export type Schema_orderBy =
   | 'description'
   | 'context'
   | 'schema'
-  | 'attestationCounter';
+  | 'attestationCounter'
+  | 'auditInformation'
+  | 'auditInformation__id';
 
 export type Subscription = {
   attestation?: Maybe<Attestation>;
@@ -857,6 +1254,10 @@ export type Subscription = {
   issuers: Array<Issuer>;
   registryVersion?: Maybe<RegistryVersion>;
   registryVersions: Array<RegistryVersion>;
+  auditInformation?: Maybe<AuditInformation>;
+  auditInformations: Array<AuditInformation>;
+  audit?: Maybe<Audit>;
+  audits: Array<Audit>;
   /** Access to subgraph metadata */
   _meta?: Maybe<_Meta_>;
 };
@@ -983,6 +1384,42 @@ export type SubscriptionregistryVersionsArgs = {
   orderBy?: InputMaybe<RegistryVersion_orderBy>;
   orderDirection?: InputMaybe<OrderDirection>;
   where?: InputMaybe<RegistryVersion_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionauditInformationArgs = {
+  id: Scalars['ID']['input'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionauditInformationsArgs = {
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<AuditInformation_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<AuditInformation_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionauditArgs = {
+  id: Scalars['ID']['input'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionauditsArgs = {
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<Audit_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<Audit_filter>;
   block?: InputMaybe<Block_height>;
   subgraphError?: _SubgraphErrorPolicy_;
 };
@@ -1115,6 +1552,12 @@ export type ResolversTypes = ResolversObject<{
   Attestation: ResolverTypeWrapper<Attestation>;
   Attestation_filter: Attestation_filter;
   Attestation_orderBy: Attestation_orderBy;
+  Audit: ResolverTypeWrapper<Audit>;
+  AuditInformation: ResolverTypeWrapper<AuditInformation>;
+  AuditInformation_filter: AuditInformation_filter;
+  AuditInformation_orderBy: AuditInformation_orderBy;
+  Audit_filter: Audit_filter;
+  Audit_orderBy: Audit_orderBy;
   BigDecimal: ResolverTypeWrapper<Scalars['BigDecimal']['output']>;
   BigInt: ResolverTypeWrapper<Scalars['BigInt']['output']>;
   BlockChangedFilter: BlockChangedFilter;
@@ -1157,6 +1600,10 @@ export type ResolversTypes = ResolversObject<{
 export type ResolversParentTypes = ResolversObject<{
   Attestation: Attestation;
   Attestation_filter: Attestation_filter;
+  Audit: Audit;
+  AuditInformation: AuditInformation;
+  AuditInformation_filter: AuditInformation_filter;
+  Audit_filter: Audit_filter;
   BigDecimal: Scalars['BigDecimal']['output'];
   BigInt: Scalars['BigInt']['output'];
   BlockChangedFilter: BlockChangedFilter;
@@ -1205,10 +1652,10 @@ export type derivedFromDirectiveResolver<Result, Parent, ContextType = MeshConte
 
 export type AttestationResolvers<ContextType = MeshContext, ParentType extends ResolversParentTypes['Attestation'] = ResolversParentTypes['Attestation']> = ResolversObject<{
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
-  schemaId?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
+  schema?: Resolver<ResolversTypes['Schema'], ParentType, ContextType>;
   replacedBy?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
   attester?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
-  portal?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
+  portal?: Resolver<ResolversTypes['Portal'], ParentType, ContextType>;
   attestedDate?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
   expirationDate?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
   revocationDate?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
@@ -1217,8 +1664,28 @@ export type AttestationResolvers<ContextType = MeshContext, ParentType extends R
   subject?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
   encodedSubject?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
   attestationData?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
-  schemaString?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   decodedData?: Resolver<Maybe<Array<ResolversTypes['String']>>, ParentType, ContextType>;
+  auditInformation?: Resolver<ResolversTypes['AuditInformation'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type AuditResolvers<ContextType = MeshContext, ParentType extends ResolversParentTypes['Audit'] = ResolversParentTypes['Audit']> = ResolversObject<{
+  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  blockNumber?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  transactionHash?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
+  transactionTimestamp?: Resolver<ResolversTypes['BigInt'], ParentType, ContextType>;
+  fromAddress?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
+  toAddress?: Resolver<Maybe<ResolversTypes['Bytes']>, ParentType, ContextType>;
+  valueTransferred?: Resolver<Maybe<ResolversTypes['BigInt']>, ParentType, ContextType>;
+  gasPrice?: Resolver<Maybe<ResolversTypes['BigInt']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type AuditInformationResolvers<ContextType = MeshContext, ParentType extends ResolversParentTypes['AuditInformation'] = ResolversParentTypes['AuditInformation']> = ResolversObject<{
+  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  creation?: Resolver<ResolversTypes['Audit'], ParentType, ContextType>;
+  lastModification?: Resolver<ResolversTypes['Audit'], ParentType, ContextType>;
+  modifications?: Resolver<Array<ResolversTypes['Audit']>, ParentType, ContextType, RequireFields<AuditInformationmodificationsArgs, 'skip' | 'first'>>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
@@ -1249,6 +1716,7 @@ export interface Int8ScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes
 
 export type IssuerResolvers<ContextType = MeshContext, ParentType extends ResolversParentTypes['Issuer'] = ResolversParentTypes['Issuer']> = ResolversObject<{
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  auditInformation?: Resolver<ResolversTypes['AuditInformation'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
@@ -1257,6 +1725,7 @@ export type ModuleResolvers<ContextType = MeshContext, ParentType extends Resolv
   moduleAddress?: Resolver<ResolversTypes['Bytes'], ParentType, ContextType>;
   name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   description?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  auditInformation?: Resolver<ResolversTypes['AuditInformation'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
@@ -1269,6 +1738,7 @@ export type PortalResolvers<ContextType = MeshContext, ParentType extends Resolv
   description?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   ownerName?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   attestationCounter?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  auditInformation?: Resolver<ResolversTypes['AuditInformation'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
@@ -1287,6 +1757,10 @@ export type QueryResolvers<ContextType = MeshContext, ParentType extends Resolve
   issuers?: Resolver<Array<ResolversTypes['Issuer']>, ParentType, ContextType, RequireFields<QueryissuersArgs, 'skip' | 'first' | 'subgraphError'>>;
   registryVersion?: Resolver<Maybe<ResolversTypes['RegistryVersion']>, ParentType, ContextType, RequireFields<QueryregistryVersionArgs, 'id' | 'subgraphError'>>;
   registryVersions?: Resolver<Array<ResolversTypes['RegistryVersion']>, ParentType, ContextType, RequireFields<QueryregistryVersionsArgs, 'skip' | 'first' | 'subgraphError'>>;
+  auditInformation?: Resolver<Maybe<ResolversTypes['AuditInformation']>, ParentType, ContextType, RequireFields<QueryauditInformationArgs, 'id' | 'subgraphError'>>;
+  auditInformations?: Resolver<Array<ResolversTypes['AuditInformation']>, ParentType, ContextType, RequireFields<QueryauditInformationsArgs, 'skip' | 'first' | 'subgraphError'>>;
+  audit?: Resolver<Maybe<ResolversTypes['Audit']>, ParentType, ContextType, RequireFields<QueryauditArgs, 'id' | 'subgraphError'>>;
+  audits?: Resolver<Array<ResolversTypes['Audit']>, ParentType, ContextType, RequireFields<QueryauditsArgs, 'skip' | 'first' | 'subgraphError'>>;
   _meta?: Resolver<Maybe<ResolversTypes['_Meta_']>, ParentType, ContextType, Partial<Query_metaArgs>>;
 }>;
 
@@ -1294,6 +1768,7 @@ export type RegistryVersionResolvers<ContextType = MeshContext, ParentType exten
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   versionNumber?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   timestamp?: Resolver<Maybe<ResolversTypes['BigInt']>, ParentType, ContextType>;
+  auditInformation?: Resolver<ResolversTypes['AuditInformation'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
@@ -1304,6 +1779,7 @@ export type SchemaResolvers<ContextType = MeshContext, ParentType extends Resolv
   context?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   schema?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   attestationCounter?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  auditInformation?: Resolver<ResolversTypes['AuditInformation'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
@@ -1322,6 +1798,10 @@ export type SubscriptionResolvers<ContextType = MeshContext, ParentType extends 
   issuers?: SubscriptionResolver<Array<ResolversTypes['Issuer']>, "issuers", ParentType, ContextType, RequireFields<SubscriptionissuersArgs, 'skip' | 'first' | 'subgraphError'>>;
   registryVersion?: SubscriptionResolver<Maybe<ResolversTypes['RegistryVersion']>, "registryVersion", ParentType, ContextType, RequireFields<SubscriptionregistryVersionArgs, 'id' | 'subgraphError'>>;
   registryVersions?: SubscriptionResolver<Array<ResolversTypes['RegistryVersion']>, "registryVersions", ParentType, ContextType, RequireFields<SubscriptionregistryVersionsArgs, 'skip' | 'first' | 'subgraphError'>>;
+  auditInformation?: SubscriptionResolver<Maybe<ResolversTypes['AuditInformation']>, "auditInformation", ParentType, ContextType, RequireFields<SubscriptionauditInformationArgs, 'id' | 'subgraphError'>>;
+  auditInformations?: SubscriptionResolver<Array<ResolversTypes['AuditInformation']>, "auditInformations", ParentType, ContextType, RequireFields<SubscriptionauditInformationsArgs, 'skip' | 'first' | 'subgraphError'>>;
+  audit?: SubscriptionResolver<Maybe<ResolversTypes['Audit']>, "audit", ParentType, ContextType, RequireFields<SubscriptionauditArgs, 'id' | 'subgraphError'>>;
+  audits?: SubscriptionResolver<Array<ResolversTypes['Audit']>, "audits", ParentType, ContextType, RequireFields<SubscriptionauditsArgs, 'skip' | 'first' | 'subgraphError'>>;
   _meta?: SubscriptionResolver<Maybe<ResolversTypes['_Meta_']>, "_meta", ParentType, ContextType, Partial<Subscription_metaArgs>>;
 }>;
 
@@ -1346,6 +1826,8 @@ export type _Meta_Resolvers<ContextType = MeshContext, ParentType extends Resolv
 
 export type Resolvers<ContextType = MeshContext> = ResolversObject<{
   Attestation?: AttestationResolvers<ContextType>;
+  Audit?: AuditResolvers<ContextType>;
+  AuditInformation?: AuditInformationResolvers<ContextType>;
   BigDecimal?: GraphQLScalarType;
   BigInt?: GraphQLScalarType;
   Bytes?: GraphQLScalarType;
@@ -1414,7 +1896,7 @@ const lineaAttestationRegistryTransforms = [];
 const additionalTypeDefs = [] as any[];
 const lineaAttestationRegistryHandler = new GraphqlHandler({
               name: "linea-attestation-registry",
-              config: {"endpoint":"https://api.studio.thegraph.com/query/67521/verax-v1-linea/v0.0.1"},
+              config: {"endpoint":"https://api.studio.thegraph.com/query/67521/verax-v2-linea/v0.0.1"},
               baseDir,
               cache,
               pubsub,

--- a/sdk/.graphclient/schema.graphql
+++ b/sdk/.graphclient/schema.graphql
@@ -23,10 +23,10 @@ enum Aggregation_interval {
 
 type Attestation {
   id: ID!
-  schemaId: Bytes!
+  schema: Schema!
   replacedBy: Bytes!
   attester: Bytes!
-  portal: Bytes!
+  portal: Portal!
   attestedDate: BigInt!
   expirationDate: BigInt!
   revocationDate: BigInt!
@@ -35,8 +35,8 @@ type Attestation {
   subject: Bytes!
   encodedSubject: Bytes!
   attestationData: Bytes!
-  schemaString: String
   decodedData: [String!]
+  auditInformation: AuditInformation!
 }
 
 input Attestation_filter {
@@ -48,16 +48,27 @@ input Attestation_filter {
   id_lte: ID
   id_in: [ID!]
   id_not_in: [ID!]
-  schemaId: Bytes
-  schemaId_not: Bytes
-  schemaId_gt: Bytes
-  schemaId_lt: Bytes
-  schemaId_gte: Bytes
-  schemaId_lte: Bytes
-  schemaId_in: [Bytes!]
-  schemaId_not_in: [Bytes!]
-  schemaId_contains: Bytes
-  schemaId_not_contains: Bytes
+  schema: String
+  schema_not: String
+  schema_gt: String
+  schema_lt: String
+  schema_gte: String
+  schema_lte: String
+  schema_in: [String!]
+  schema_not_in: [String!]
+  schema_contains: String
+  schema_contains_nocase: String
+  schema_not_contains: String
+  schema_not_contains_nocase: String
+  schema_starts_with: String
+  schema_starts_with_nocase: String
+  schema_not_starts_with: String
+  schema_not_starts_with_nocase: String
+  schema_ends_with: String
+  schema_ends_with_nocase: String
+  schema_not_ends_with: String
+  schema_not_ends_with_nocase: String
+  schema_: Schema_filter
   replacedBy: Bytes
   replacedBy_not: Bytes
   replacedBy_gt: Bytes
@@ -78,16 +89,27 @@ input Attestation_filter {
   attester_not_in: [Bytes!]
   attester_contains: Bytes
   attester_not_contains: Bytes
-  portal: Bytes
-  portal_not: Bytes
-  portal_gt: Bytes
-  portal_lt: Bytes
-  portal_gte: Bytes
-  portal_lte: Bytes
-  portal_in: [Bytes!]
-  portal_not_in: [Bytes!]
-  portal_contains: Bytes
-  portal_not_contains: Bytes
+  portal: String
+  portal_not: String
+  portal_gt: String
+  portal_lt: String
+  portal_gte: String
+  portal_lte: String
+  portal_in: [String!]
+  portal_not_in: [String!]
+  portal_contains: String
+  portal_contains_nocase: String
+  portal_not_contains: String
+  portal_not_contains_nocase: String
+  portal_starts_with: String
+  portal_starts_with_nocase: String
+  portal_not_starts_with: String
+  portal_not_starts_with_nocase: String
+  portal_ends_with: String
+  portal_ends_with_nocase: String
+  portal_not_ends_with: String
+  portal_not_ends_with_nocase: String
+  portal_: Portal_filter
   attestedDate: BigInt
   attestedDate_not: BigInt
   attestedDate_gt: BigInt
@@ -154,32 +176,33 @@ input Attestation_filter {
   attestationData_not_in: [Bytes!]
   attestationData_contains: Bytes
   attestationData_not_contains: Bytes
-  schemaString: String
-  schemaString_not: String
-  schemaString_gt: String
-  schemaString_lt: String
-  schemaString_gte: String
-  schemaString_lte: String
-  schemaString_in: [String!]
-  schemaString_not_in: [String!]
-  schemaString_contains: String
-  schemaString_contains_nocase: String
-  schemaString_not_contains: String
-  schemaString_not_contains_nocase: String
-  schemaString_starts_with: String
-  schemaString_starts_with_nocase: String
-  schemaString_not_starts_with: String
-  schemaString_not_starts_with_nocase: String
-  schemaString_ends_with: String
-  schemaString_ends_with_nocase: String
-  schemaString_not_ends_with: String
-  schemaString_not_ends_with_nocase: String
   decodedData: [String!]
   decodedData_not: [String!]
   decodedData_contains: [String!]
   decodedData_contains_nocase: [String!]
   decodedData_not_contains: [String!]
   decodedData_not_contains_nocase: [String!]
+  auditInformation: String
+  auditInformation_not: String
+  auditInformation_gt: String
+  auditInformation_lt: String
+  auditInformation_gte: String
+  auditInformation_lte: String
+  auditInformation_in: [String!]
+  auditInformation_not_in: [String!]
+  auditInformation_contains: String
+  auditInformation_contains_nocase: String
+  auditInformation_not_contains: String
+  auditInformation_not_contains_nocase: String
+  auditInformation_starts_with: String
+  auditInformation_starts_with_nocase: String
+  auditInformation_not_starts_with: String
+  auditInformation_not_starts_with_nocase: String
+  auditInformation_ends_with: String
+  auditInformation_ends_with_nocase: String
+  auditInformation_not_ends_with: String
+  auditInformation_not_ends_with_nocase: String
+  auditInformation_: AuditInformation_filter
   """Filter for the block changed event."""
   _change_block: BlockChangedFilter
   and: [Attestation_filter]
@@ -188,10 +211,23 @@ input Attestation_filter {
 
 enum Attestation_orderBy {
   id
-  schemaId
+  schema
+  schema__id
+  schema__name
+  schema__description
+  schema__context
+  schema__schema
+  schema__attestationCounter
   replacedBy
   attester
   portal
+  portal__id
+  portal__ownerAddress
+  portal__isRevocable
+  portal__name
+  portal__description
+  portal__ownerName
+  portal__attestationCounter
   attestedDate
   expirationDate
   revocationDate
@@ -200,8 +236,202 @@ enum Attestation_orderBy {
   subject
   encodedSubject
   attestationData
-  schemaString
   decodedData
+  auditInformation
+  auditInformation__id
+}
+
+type Audit {
+  id: ID!
+  blockNumber: BigInt!
+  transactionHash: Bytes!
+  transactionTimestamp: BigInt!
+  fromAddress: Bytes!
+  toAddress: Bytes
+  valueTransferred: BigInt
+  gasPrice: BigInt
+}
+
+type AuditInformation {
+  id: ID!
+  creation: Audit!
+  lastModification: Audit!
+  modifications(skip: Int = 0, first: Int = 100, orderBy: Audit_orderBy, orderDirection: OrderDirection, where: Audit_filter): [Audit!]!
+}
+
+input AuditInformation_filter {
+  id: ID
+  id_not: ID
+  id_gt: ID
+  id_lt: ID
+  id_gte: ID
+  id_lte: ID
+  id_in: [ID!]
+  id_not_in: [ID!]
+  creation: String
+  creation_not: String
+  creation_gt: String
+  creation_lt: String
+  creation_gte: String
+  creation_lte: String
+  creation_in: [String!]
+  creation_not_in: [String!]
+  creation_contains: String
+  creation_contains_nocase: String
+  creation_not_contains: String
+  creation_not_contains_nocase: String
+  creation_starts_with: String
+  creation_starts_with_nocase: String
+  creation_not_starts_with: String
+  creation_not_starts_with_nocase: String
+  creation_ends_with: String
+  creation_ends_with_nocase: String
+  creation_not_ends_with: String
+  creation_not_ends_with_nocase: String
+  creation_: Audit_filter
+  lastModification: String
+  lastModification_not: String
+  lastModification_gt: String
+  lastModification_lt: String
+  lastModification_gte: String
+  lastModification_lte: String
+  lastModification_in: [String!]
+  lastModification_not_in: [String!]
+  lastModification_contains: String
+  lastModification_contains_nocase: String
+  lastModification_not_contains: String
+  lastModification_not_contains_nocase: String
+  lastModification_starts_with: String
+  lastModification_starts_with_nocase: String
+  lastModification_not_starts_with: String
+  lastModification_not_starts_with_nocase: String
+  lastModification_ends_with: String
+  lastModification_ends_with_nocase: String
+  lastModification_not_ends_with: String
+  lastModification_not_ends_with_nocase: String
+  lastModification_: Audit_filter
+  modifications: [String!]
+  modifications_not: [String!]
+  modifications_contains: [String!]
+  modifications_contains_nocase: [String!]
+  modifications_not_contains: [String!]
+  modifications_not_contains_nocase: [String!]
+  modifications_: Audit_filter
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [AuditInformation_filter]
+  or: [AuditInformation_filter]
+}
+
+enum AuditInformation_orderBy {
+  id
+  creation
+  creation__id
+  creation__blockNumber
+  creation__transactionHash
+  creation__transactionTimestamp
+  creation__fromAddress
+  creation__toAddress
+  creation__valueTransferred
+  creation__gasPrice
+  lastModification
+  lastModification__id
+  lastModification__blockNumber
+  lastModification__transactionHash
+  lastModification__transactionTimestamp
+  lastModification__fromAddress
+  lastModification__toAddress
+  lastModification__valueTransferred
+  lastModification__gasPrice
+  modifications
+}
+
+input Audit_filter {
+  id: ID
+  id_not: ID
+  id_gt: ID
+  id_lt: ID
+  id_gte: ID
+  id_lte: ID
+  id_in: [ID!]
+  id_not_in: [ID!]
+  blockNumber: BigInt
+  blockNumber_not: BigInt
+  blockNumber_gt: BigInt
+  blockNumber_lt: BigInt
+  blockNumber_gte: BigInt
+  blockNumber_lte: BigInt
+  blockNumber_in: [BigInt!]
+  blockNumber_not_in: [BigInt!]
+  transactionHash: Bytes
+  transactionHash_not: Bytes
+  transactionHash_gt: Bytes
+  transactionHash_lt: Bytes
+  transactionHash_gte: Bytes
+  transactionHash_lte: Bytes
+  transactionHash_in: [Bytes!]
+  transactionHash_not_in: [Bytes!]
+  transactionHash_contains: Bytes
+  transactionHash_not_contains: Bytes
+  transactionTimestamp: BigInt
+  transactionTimestamp_not: BigInt
+  transactionTimestamp_gt: BigInt
+  transactionTimestamp_lt: BigInt
+  transactionTimestamp_gte: BigInt
+  transactionTimestamp_lte: BigInt
+  transactionTimestamp_in: [BigInt!]
+  transactionTimestamp_not_in: [BigInt!]
+  fromAddress: Bytes
+  fromAddress_not: Bytes
+  fromAddress_gt: Bytes
+  fromAddress_lt: Bytes
+  fromAddress_gte: Bytes
+  fromAddress_lte: Bytes
+  fromAddress_in: [Bytes!]
+  fromAddress_not_in: [Bytes!]
+  fromAddress_contains: Bytes
+  fromAddress_not_contains: Bytes
+  toAddress: Bytes
+  toAddress_not: Bytes
+  toAddress_gt: Bytes
+  toAddress_lt: Bytes
+  toAddress_gte: Bytes
+  toAddress_lte: Bytes
+  toAddress_in: [Bytes!]
+  toAddress_not_in: [Bytes!]
+  toAddress_contains: Bytes
+  toAddress_not_contains: Bytes
+  valueTransferred: BigInt
+  valueTransferred_not: BigInt
+  valueTransferred_gt: BigInt
+  valueTransferred_lt: BigInt
+  valueTransferred_gte: BigInt
+  valueTransferred_lte: BigInt
+  valueTransferred_in: [BigInt!]
+  valueTransferred_not_in: [BigInt!]
+  gasPrice: BigInt
+  gasPrice_not: BigInt
+  gasPrice_gt: BigInt
+  gasPrice_lt: BigInt
+  gasPrice_gte: BigInt
+  gasPrice_lte: BigInt
+  gasPrice_in: [BigInt!]
+  gasPrice_not_in: [BigInt!]
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [Audit_filter]
+  or: [Audit_filter]
+}
+
+enum Audit_orderBy {
+  id
+  blockNumber
+  transactionHash
+  transactionTimestamp
+  fromAddress
+  toAddress
+  valueTransferred
+  gasPrice
 }
 
 scalar BigDecimal
@@ -291,6 +521,7 @@ scalar Int8
 
 type Issuer {
   id: ID!
+  auditInformation: AuditInformation!
 }
 
 input Issuer_filter {
@@ -302,6 +533,27 @@ input Issuer_filter {
   id_lte: ID
   id_in: [ID!]
   id_not_in: [ID!]
+  auditInformation: String
+  auditInformation_not: String
+  auditInformation_gt: String
+  auditInformation_lt: String
+  auditInformation_gte: String
+  auditInformation_lte: String
+  auditInformation_in: [String!]
+  auditInformation_not_in: [String!]
+  auditInformation_contains: String
+  auditInformation_contains_nocase: String
+  auditInformation_not_contains: String
+  auditInformation_not_contains_nocase: String
+  auditInformation_starts_with: String
+  auditInformation_starts_with_nocase: String
+  auditInformation_not_starts_with: String
+  auditInformation_not_starts_with_nocase: String
+  auditInformation_ends_with: String
+  auditInformation_ends_with_nocase: String
+  auditInformation_not_ends_with: String
+  auditInformation_not_ends_with_nocase: String
+  auditInformation_: AuditInformation_filter
   """Filter for the block changed event."""
   _change_block: BlockChangedFilter
   and: [Issuer_filter]
@@ -310,6 +562,8 @@ input Issuer_filter {
 
 enum Issuer_orderBy {
   id
+  auditInformation
+  auditInformation__id
 }
 
 type Module {
@@ -317,6 +571,7 @@ type Module {
   moduleAddress: Bytes!
   name: String!
   description: String!
+  auditInformation: AuditInformation!
 }
 
 input Module_filter {
@@ -378,6 +633,27 @@ input Module_filter {
   description_ends_with_nocase: String
   description_not_ends_with: String
   description_not_ends_with_nocase: String
+  auditInformation: String
+  auditInformation_not: String
+  auditInformation_gt: String
+  auditInformation_lt: String
+  auditInformation_gte: String
+  auditInformation_lte: String
+  auditInformation_in: [String!]
+  auditInformation_not_in: [String!]
+  auditInformation_contains: String
+  auditInformation_contains_nocase: String
+  auditInformation_not_contains: String
+  auditInformation_not_contains_nocase: String
+  auditInformation_starts_with: String
+  auditInformation_starts_with_nocase: String
+  auditInformation_not_starts_with: String
+  auditInformation_not_starts_with_nocase: String
+  auditInformation_ends_with: String
+  auditInformation_ends_with_nocase: String
+  auditInformation_not_ends_with: String
+  auditInformation_not_ends_with_nocase: String
+  auditInformation_: AuditInformation_filter
   """Filter for the block changed event."""
   _change_block: BlockChangedFilter
   and: [Module_filter]
@@ -389,6 +665,8 @@ enum Module_orderBy {
   moduleAddress
   name
   description
+  auditInformation
+  auditInformation__id
 }
 
 """Defines the order direction, either ascending or descending"""
@@ -406,6 +684,7 @@ type Portal {
   description: String!
   ownerName: String!
   attestationCounter: Int
+  auditInformation: AuditInformation!
 }
 
 input Portal_filter {
@@ -505,6 +784,27 @@ input Portal_filter {
   attestationCounter_lte: Int
   attestationCounter_in: [Int!]
   attestationCounter_not_in: [Int!]
+  auditInformation: String
+  auditInformation_not: String
+  auditInformation_gt: String
+  auditInformation_lt: String
+  auditInformation_gte: String
+  auditInformation_lte: String
+  auditInformation_in: [String!]
+  auditInformation_not_in: [String!]
+  auditInformation_contains: String
+  auditInformation_contains_nocase: String
+  auditInformation_not_contains: String
+  auditInformation_not_contains_nocase: String
+  auditInformation_starts_with: String
+  auditInformation_starts_with_nocase: String
+  auditInformation_not_starts_with: String
+  auditInformation_not_starts_with_nocase: String
+  auditInformation_ends_with: String
+  auditInformation_ends_with_nocase: String
+  auditInformation_not_ends_with: String
+  auditInformation_not_ends_with_nocase: String
+  auditInformation_: AuditInformation_filter
   """Filter for the block changed event."""
   _change_block: BlockChangedFilter
   and: [Portal_filter]
@@ -520,6 +820,8 @@ enum Portal_orderBy {
   description
   ownerName
   attestationCounter
+  auditInformation
+  auditInformation__id
 }
 
 type Query {
@@ -705,6 +1007,58 @@ type Query {
     """
     subgraphError: _SubgraphErrorPolicy_! = deny
   ): [RegistryVersion!]!
+  auditInformation(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): AuditInformation
+  auditInformations(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: AuditInformation_orderBy
+    orderDirection: OrderDirection
+    where: AuditInformation_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [AuditInformation!]!
+  audit(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): Audit
+  audits(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: Audit_orderBy
+    orderDirection: OrderDirection
+    where: Audit_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [Audit!]!
   """Access to subgraph metadata"""
   _meta(block: Block_height): _Meta_
 }
@@ -713,6 +1067,7 @@ type RegistryVersion {
   id: ID!
   versionNumber: Int
   timestamp: BigInt
+  auditInformation: AuditInformation!
 }
 
 input RegistryVersion_filter {
@@ -740,6 +1095,27 @@ input RegistryVersion_filter {
   timestamp_lte: BigInt
   timestamp_in: [BigInt!]
   timestamp_not_in: [BigInt!]
+  auditInformation: String
+  auditInformation_not: String
+  auditInformation_gt: String
+  auditInformation_lt: String
+  auditInformation_gte: String
+  auditInformation_lte: String
+  auditInformation_in: [String!]
+  auditInformation_not_in: [String!]
+  auditInformation_contains: String
+  auditInformation_contains_nocase: String
+  auditInformation_not_contains: String
+  auditInformation_not_contains_nocase: String
+  auditInformation_starts_with: String
+  auditInformation_starts_with_nocase: String
+  auditInformation_not_starts_with: String
+  auditInformation_not_starts_with_nocase: String
+  auditInformation_ends_with: String
+  auditInformation_ends_with_nocase: String
+  auditInformation_not_ends_with: String
+  auditInformation_not_ends_with_nocase: String
+  auditInformation_: AuditInformation_filter
   """Filter for the block changed event."""
   _change_block: BlockChangedFilter
   and: [RegistryVersion_filter]
@@ -750,6 +1126,8 @@ enum RegistryVersion_orderBy {
   id
   versionNumber
   timestamp
+  auditInformation
+  auditInformation__id
 }
 
 type Schema {
@@ -759,6 +1137,7 @@ type Schema {
   context: String!
   schema: String!
   attestationCounter: Int
+  auditInformation: AuditInformation!
 }
 
 input Schema_filter {
@@ -858,6 +1237,27 @@ input Schema_filter {
   attestationCounter_lte: Int
   attestationCounter_in: [Int!]
   attestationCounter_not_in: [Int!]
+  auditInformation: String
+  auditInformation_not: String
+  auditInformation_gt: String
+  auditInformation_lt: String
+  auditInformation_gte: String
+  auditInformation_lte: String
+  auditInformation_in: [String!]
+  auditInformation_not_in: [String!]
+  auditInformation_contains: String
+  auditInformation_contains_nocase: String
+  auditInformation_not_contains: String
+  auditInformation_not_contains_nocase: String
+  auditInformation_starts_with: String
+  auditInformation_starts_with_nocase: String
+  auditInformation_not_starts_with: String
+  auditInformation_not_starts_with_nocase: String
+  auditInformation_ends_with: String
+  auditInformation_ends_with_nocase: String
+  auditInformation_not_ends_with: String
+  auditInformation_not_ends_with_nocase: String
+  auditInformation_: AuditInformation_filter
   """Filter for the block changed event."""
   _change_block: BlockChangedFilter
   and: [Schema_filter]
@@ -871,6 +1271,8 @@ enum Schema_orderBy {
   context
   schema
   attestationCounter
+  auditInformation
+  auditInformation__id
 }
 
 type Subscription {
@@ -1056,6 +1458,58 @@ type Subscription {
     """
     subgraphError: _SubgraphErrorPolicy_! = deny
   ): [RegistryVersion!]!
+  auditInformation(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): AuditInformation
+  auditInformations(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: AuditInformation_orderBy
+    orderDirection: OrderDirection
+    where: AuditInformation_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [AuditInformation!]!
+  audit(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): Audit
+  audits(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: Audit_orderBy
+    orderDirection: OrderDirection
+    where: Audit_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [Audit!]!
   """Access to subgraph metadata"""
   _meta(block: Block_height): _Meta_
 }

--- a/sdk/.graphclient/sources/linea-attestation-registry/introspectionSchema.ts
+++ b/sdk/.graphclient/sources/linea-attestation-registry/introspectionSchema.ts
@@ -186,7 +186,7 @@ const schemaAST = {
           "kind": "FieldDefinition",
           "name": {
             "kind": "Name",
-            "value": "schemaId"
+            "value": "schema"
           },
           "arguments": [],
           "type": {
@@ -195,7 +195,7 @@ const schemaAST = {
               "kind": "NamedType",
               "name": {
                 "kind": "Name",
-                "value": "Bytes"
+                "value": "Schema"
               }
             }
           },
@@ -252,7 +252,7 @@ const schemaAST = {
               "kind": "NamedType",
               "name": {
                 "kind": "Name",
-                "value": "Bytes"
+                "value": "Portal"
               }
             }
           },
@@ -414,22 +414,6 @@ const schemaAST = {
           "kind": "FieldDefinition",
           "name": {
             "kind": "Name",
-            "value": "schemaString"
-          },
-          "arguments": [],
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "FieldDefinition",
-          "name": {
-            "kind": "Name",
             "value": "decodedData"
           },
           "arguments": [],
@@ -443,6 +427,25 @@ const schemaAST = {
                   "kind": "Name",
                   "value": "String"
                 }
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "FieldDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation"
+          },
+          "arguments": [],
+          "type": {
+            "kind": "NonNullType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "AuditInformation"
               }
             }
           },
@@ -595,13 +598,13 @@ const schemaAST = {
           "kind": "InputValueDefinition",
           "name": {
             "kind": "Name",
-            "value": "schemaId"
+            "value": "schema"
           },
           "type": {
             "kind": "NamedType",
             "name": {
               "kind": "Name",
-              "value": "Bytes"
+              "value": "String"
             }
           },
           "directives": []
@@ -610,13 +613,13 @@ const schemaAST = {
           "kind": "InputValueDefinition",
           "name": {
             "kind": "Name",
-            "value": "schemaId_not"
+            "value": "schema_not"
           },
           "type": {
             "kind": "NamedType",
             "name": {
               "kind": "Name",
-              "value": "Bytes"
+              "value": "String"
             }
           },
           "directives": []
@@ -625,13 +628,13 @@ const schemaAST = {
           "kind": "InputValueDefinition",
           "name": {
             "kind": "Name",
-            "value": "schemaId_gt"
+            "value": "schema_gt"
           },
           "type": {
             "kind": "NamedType",
             "name": {
               "kind": "Name",
-              "value": "Bytes"
+              "value": "String"
             }
           },
           "directives": []
@@ -640,13 +643,13 @@ const schemaAST = {
           "kind": "InputValueDefinition",
           "name": {
             "kind": "Name",
-            "value": "schemaId_lt"
+            "value": "schema_lt"
           },
           "type": {
             "kind": "NamedType",
             "name": {
               "kind": "Name",
-              "value": "Bytes"
+              "value": "String"
             }
           },
           "directives": []
@@ -655,13 +658,13 @@ const schemaAST = {
           "kind": "InputValueDefinition",
           "name": {
             "kind": "Name",
-            "value": "schemaId_gte"
+            "value": "schema_gte"
           },
           "type": {
             "kind": "NamedType",
             "name": {
               "kind": "Name",
-              "value": "Bytes"
+              "value": "String"
             }
           },
           "directives": []
@@ -670,13 +673,13 @@ const schemaAST = {
           "kind": "InputValueDefinition",
           "name": {
             "kind": "Name",
-            "value": "schemaId_lte"
+            "value": "schema_lte"
           },
           "type": {
             "kind": "NamedType",
             "name": {
               "kind": "Name",
-              "value": "Bytes"
+              "value": "String"
             }
           },
           "directives": []
@@ -685,7 +688,7 @@ const schemaAST = {
           "kind": "InputValueDefinition",
           "name": {
             "kind": "Name",
-            "value": "schemaId_in"
+            "value": "schema_in"
           },
           "type": {
             "kind": "ListType",
@@ -695,7 +698,7 @@ const schemaAST = {
                 "kind": "NamedType",
                 "name": {
                   "kind": "Name",
-                  "value": "Bytes"
+                  "value": "String"
                 }
               }
             }
@@ -706,7 +709,7 @@ const schemaAST = {
           "kind": "InputValueDefinition",
           "name": {
             "kind": "Name",
-            "value": "schemaId_not_in"
+            "value": "schema_not_in"
           },
           "type": {
             "kind": "ListType",
@@ -716,7 +719,7 @@ const schemaAST = {
                 "kind": "NamedType",
                 "name": {
                   "kind": "Name",
-                  "value": "Bytes"
+                  "value": "String"
                 }
               }
             }
@@ -727,13 +730,13 @@ const schemaAST = {
           "kind": "InputValueDefinition",
           "name": {
             "kind": "Name",
-            "value": "schemaId_contains"
+            "value": "schema_contains"
           },
           "type": {
             "kind": "NamedType",
             "name": {
               "kind": "Name",
-              "value": "Bytes"
+              "value": "String"
             }
           },
           "directives": []
@@ -742,13 +745,178 @@ const schemaAST = {
           "kind": "InputValueDefinition",
           "name": {
             "kind": "Name",
-            "value": "schemaId_not_contains"
+            "value": "schema_contains_nocase"
           },
           "type": {
             "kind": "NamedType",
             "name": {
               "kind": "Name",
-              "value": "Bytes"
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "schema_not_contains"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "schema_not_contains_nocase"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "schema_starts_with"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "schema_starts_with_nocase"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "schema_not_starts_with"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "schema_not_starts_with_nocase"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "schema_ends_with"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "schema_ends_with_nocase"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "schema_not_ends_with"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "schema_not_ends_with_nocase"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "schema_"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Schema_filter"
             }
           },
           "directives": []
@@ -1087,7 +1255,7 @@ const schemaAST = {
             "kind": "NamedType",
             "name": {
               "kind": "Name",
-              "value": "Bytes"
+              "value": "String"
             }
           },
           "directives": []
@@ -1102,7 +1270,7 @@ const schemaAST = {
             "kind": "NamedType",
             "name": {
               "kind": "Name",
-              "value": "Bytes"
+              "value": "String"
             }
           },
           "directives": []
@@ -1117,7 +1285,7 @@ const schemaAST = {
             "kind": "NamedType",
             "name": {
               "kind": "Name",
-              "value": "Bytes"
+              "value": "String"
             }
           },
           "directives": []
@@ -1132,7 +1300,7 @@ const schemaAST = {
             "kind": "NamedType",
             "name": {
               "kind": "Name",
-              "value": "Bytes"
+              "value": "String"
             }
           },
           "directives": []
@@ -1147,7 +1315,7 @@ const schemaAST = {
             "kind": "NamedType",
             "name": {
               "kind": "Name",
-              "value": "Bytes"
+              "value": "String"
             }
           },
           "directives": []
@@ -1162,7 +1330,7 @@ const schemaAST = {
             "kind": "NamedType",
             "name": {
               "kind": "Name",
-              "value": "Bytes"
+              "value": "String"
             }
           },
           "directives": []
@@ -1181,7 +1349,7 @@ const schemaAST = {
                 "kind": "NamedType",
                 "name": {
                   "kind": "Name",
-                  "value": "Bytes"
+                  "value": "String"
                 }
               }
             }
@@ -1202,7 +1370,7 @@ const schemaAST = {
                 "kind": "NamedType",
                 "name": {
                   "kind": "Name",
-                  "value": "Bytes"
+                  "value": "String"
                 }
               }
             }
@@ -1219,7 +1387,22 @@ const schemaAST = {
             "kind": "NamedType",
             "name": {
               "kind": "Name",
-              "value": "Bytes"
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "portal_contains_nocase"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
             }
           },
           "directives": []
@@ -1234,7 +1417,157 @@ const schemaAST = {
             "kind": "NamedType",
             "name": {
               "kind": "Name",
-              "value": "Bytes"
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "portal_not_contains_nocase"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "portal_starts_with"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "portal_starts_with_nocase"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "portal_not_starts_with"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "portal_not_starts_with_nocase"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "portal_ends_with"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "portal_ends_with_nocase"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "portal_not_ends_with"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "portal_not_ends_with_nocase"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "portal_"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Portal_filter"
             }
           },
           "directives": []
@@ -2329,318 +2662,6 @@ const schemaAST = {
           "kind": "InputValueDefinition",
           "name": {
             "kind": "Name",
-            "value": "schemaString"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "schemaString_not"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "schemaString_gt"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "schemaString_lt"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "schemaString_gte"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "schemaString_lte"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "schemaString_in"
-          },
-          "type": {
-            "kind": "ListType",
-            "type": {
-              "kind": "NonNullType",
-              "type": {
-                "kind": "NamedType",
-                "name": {
-                  "kind": "Name",
-                  "value": "String"
-                }
-              }
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "schemaString_not_in"
-          },
-          "type": {
-            "kind": "ListType",
-            "type": {
-              "kind": "NonNullType",
-              "type": {
-                "kind": "NamedType",
-                "name": {
-                  "kind": "Name",
-                  "value": "String"
-                }
-              }
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "schemaString_contains"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "schemaString_contains_nocase"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "schemaString_not_contains"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "schemaString_not_contains_nocase"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "schemaString_starts_with"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "schemaString_starts_with_nocase"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "schemaString_not_starts_with"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "schemaString_not_starts_with_nocase"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "schemaString_ends_with"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "schemaString_ends_with_nocase"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "schemaString_not_ends_with"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
-            "value": "schemaString_not_ends_with_nocase"
-          },
-          "type": {
-            "kind": "NamedType",
-            "name": {
-              "kind": "Name",
-              "value": "String"
-            }
-          },
-          "directives": []
-        },
-        {
-          "kind": "InputValueDefinition",
-          "name": {
-            "kind": "Name",
             "value": "decodedData"
           },
           "type": {
@@ -2765,6 +2786,333 @@ const schemaAST = {
         },
         {
           "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_not"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_gt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_lt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_gte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_lte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_in"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NonNullType",
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "String"
+                }
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_not_in"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NonNullType",
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "String"
+                }
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_contains"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_contains_nocase"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_not_contains"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_not_contains_nocase"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_starts_with"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_starts_with_nocase"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_not_starts_with"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_not_starts_with_nocase"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_ends_with"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_ends_with_nocase"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_not_ends_with"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_not_ends_with_nocase"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "AuditInformation_filter"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
           "description": {
             "kind": "StringValue",
             "value": "Filter for the block changed event.",
@@ -2841,7 +3189,55 @@ const schemaAST = {
           "kind": "EnumValueDefinition",
           "name": {
             "kind": "Name",
-            "value": "schemaId"
+            "value": "schema"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "schema__id"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "schema__name"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "schema__description"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "schema__context"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "schema__schema"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "schema__attestationCounter"
           },
           "directives": []
         },
@@ -2866,6 +3262,62 @@ const schemaAST = {
           "name": {
             "kind": "Name",
             "value": "portal"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "portal__id"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "portal__ownerAddress"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "portal__isRevocable"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "portal__name"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "portal__description"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "portal__ownerName"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "portal__attestationCounter"
           },
           "directives": []
         },
@@ -2937,7 +3389,7 @@ const schemaAST = {
           "kind": "EnumValueDefinition",
           "name": {
             "kind": "Name",
-            "value": "schemaString"
+            "value": "decodedData"
           },
           "directives": []
         },
@@ -2945,7 +3397,2795 @@ const schemaAST = {
           "kind": "EnumValueDefinition",
           "name": {
             "kind": "Name",
-            "value": "decodedData"
+            "value": "auditInformation"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation__id"
+          },
+          "directives": []
+        }
+      ],
+      "directives": []
+    },
+    {
+      "kind": "ObjectTypeDefinition",
+      "name": {
+        "kind": "Name",
+        "value": "Audit"
+      },
+      "fields": [
+        {
+          "kind": "FieldDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "id"
+          },
+          "arguments": [],
+          "type": {
+            "kind": "NonNullType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "ID"
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "FieldDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "blockNumber"
+          },
+          "arguments": [],
+          "type": {
+            "kind": "NonNullType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "BigInt"
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "FieldDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "transactionHash"
+          },
+          "arguments": [],
+          "type": {
+            "kind": "NonNullType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "Bytes"
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "FieldDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "transactionTimestamp"
+          },
+          "arguments": [],
+          "type": {
+            "kind": "NonNullType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "BigInt"
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "FieldDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "fromAddress"
+          },
+          "arguments": [],
+          "type": {
+            "kind": "NonNullType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "Bytes"
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "FieldDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "toAddress"
+          },
+          "arguments": [],
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "FieldDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "valueTransferred"
+          },
+          "arguments": [],
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "BigInt"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "FieldDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "gasPrice"
+          },
+          "arguments": [],
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "BigInt"
+            }
+          },
+          "directives": []
+        }
+      ],
+      "interfaces": [],
+      "directives": []
+    },
+    {
+      "kind": "ObjectTypeDefinition",
+      "name": {
+        "kind": "Name",
+        "value": "AuditInformation"
+      },
+      "fields": [
+        {
+          "kind": "FieldDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "id"
+          },
+          "arguments": [],
+          "type": {
+            "kind": "NonNullType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "ID"
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "FieldDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "creation"
+          },
+          "arguments": [],
+          "type": {
+            "kind": "NonNullType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "Audit"
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "FieldDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "lastModification"
+          },
+          "arguments": [],
+          "type": {
+            "kind": "NonNullType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "Audit"
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "FieldDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "modifications"
+          },
+          "arguments": [
+            {
+              "kind": "InputValueDefinition",
+              "name": {
+                "kind": "Name",
+                "value": "skip"
+              },
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "Int"
+                }
+              },
+              "defaultValue": {
+                "kind": "IntValue",
+                "value": "0"
+              },
+              "directives": []
+            },
+            {
+              "kind": "InputValueDefinition",
+              "name": {
+                "kind": "Name",
+                "value": "first"
+              },
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "Int"
+                }
+              },
+              "defaultValue": {
+                "kind": "IntValue",
+                "value": "100"
+              },
+              "directives": []
+            },
+            {
+              "kind": "InputValueDefinition",
+              "name": {
+                "kind": "Name",
+                "value": "orderBy"
+              },
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "Audit_orderBy"
+                }
+              },
+              "directives": []
+            },
+            {
+              "kind": "InputValueDefinition",
+              "name": {
+                "kind": "Name",
+                "value": "orderDirection"
+              },
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "OrderDirection"
+                }
+              },
+              "directives": []
+            },
+            {
+              "kind": "InputValueDefinition",
+              "name": {
+                "kind": "Name",
+                "value": "where"
+              },
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "Audit_filter"
+                }
+              },
+              "directives": []
+            }
+          ],
+          "type": {
+            "kind": "NonNullType",
+            "type": {
+              "kind": "ListType",
+              "type": {
+                "kind": "NonNullType",
+                "type": {
+                  "kind": "NamedType",
+                  "name": {
+                    "kind": "Name",
+                    "value": "Audit"
+                  }
+                }
+              }
+            }
+          },
+          "directives": []
+        }
+      ],
+      "interfaces": [],
+      "directives": []
+    },
+    {
+      "kind": "InputObjectTypeDefinition",
+      "name": {
+        "kind": "Name",
+        "value": "AuditInformation_filter"
+      },
+      "fields": [
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "id"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "ID"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "id_not"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "ID"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "id_gt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "ID"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "id_lt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "ID"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "id_gte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "ID"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "id_lte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "ID"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "id_in"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NonNullType",
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "ID"
+                }
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "id_not_in"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NonNullType",
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "ID"
+                }
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "creation"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "creation_not"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "creation_gt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "creation_lt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "creation_gte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "creation_lte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "creation_in"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NonNullType",
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "String"
+                }
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "creation_not_in"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NonNullType",
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "String"
+                }
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "creation_contains"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "creation_contains_nocase"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "creation_not_contains"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "creation_not_contains_nocase"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "creation_starts_with"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "creation_starts_with_nocase"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "creation_not_starts_with"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "creation_not_starts_with_nocase"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "creation_ends_with"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "creation_ends_with_nocase"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "creation_not_ends_with"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "creation_not_ends_with_nocase"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "creation_"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Audit_filter"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "lastModification"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "lastModification_not"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "lastModification_gt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "lastModification_lt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "lastModification_gte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "lastModification_lte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "lastModification_in"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NonNullType",
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "String"
+                }
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "lastModification_not_in"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NonNullType",
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "String"
+                }
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "lastModification_contains"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "lastModification_contains_nocase"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "lastModification_not_contains"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "lastModification_not_contains_nocase"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "lastModification_starts_with"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "lastModification_starts_with_nocase"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "lastModification_not_starts_with"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "lastModification_not_starts_with_nocase"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "lastModification_ends_with"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "lastModification_ends_with_nocase"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "lastModification_not_ends_with"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "lastModification_not_ends_with_nocase"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "lastModification_"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Audit_filter"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "modifications"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NonNullType",
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "String"
+                }
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "modifications_not"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NonNullType",
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "String"
+                }
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "modifications_contains"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NonNullType",
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "String"
+                }
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "modifications_contains_nocase"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NonNullType",
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "String"
+                }
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "modifications_not_contains"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NonNullType",
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "String"
+                }
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "modifications_not_contains_nocase"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NonNullType",
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "String"
+                }
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "modifications_"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Audit_filter"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "description": {
+            "kind": "StringValue",
+            "value": "Filter for the block changed event.",
+            "block": true
+          },
+          "name": {
+            "kind": "Name",
+            "value": "_change_block"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "BlockChangedFilter"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "and"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "AuditInformation_filter"
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "or"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "AuditInformation_filter"
+              }
+            }
+          },
+          "directives": []
+        }
+      ],
+      "directives": []
+    },
+    {
+      "kind": "EnumTypeDefinition",
+      "name": {
+        "kind": "Name",
+        "value": "AuditInformation_orderBy"
+      },
+      "values": [
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "id"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "creation"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "creation__id"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "creation__blockNumber"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "creation__transactionHash"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "creation__transactionTimestamp"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "creation__fromAddress"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "creation__toAddress"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "creation__valueTransferred"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "creation__gasPrice"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "lastModification"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "lastModification__id"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "lastModification__blockNumber"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "lastModification__transactionHash"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "lastModification__transactionTimestamp"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "lastModification__fromAddress"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "lastModification__toAddress"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "lastModification__valueTransferred"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "lastModification__gasPrice"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "modifications"
+          },
+          "directives": []
+        }
+      ],
+      "directives": []
+    },
+    {
+      "kind": "InputObjectTypeDefinition",
+      "name": {
+        "kind": "Name",
+        "value": "Audit_filter"
+      },
+      "fields": [
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "id"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "ID"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "id_not"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "ID"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "id_gt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "ID"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "id_lt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "ID"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "id_gte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "ID"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "id_lte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "ID"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "id_in"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NonNullType",
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "ID"
+                }
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "id_not_in"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NonNullType",
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "ID"
+                }
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "blockNumber"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "BigInt"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "blockNumber_not"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "BigInt"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "blockNumber_gt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "BigInt"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "blockNumber_lt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "BigInt"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "blockNumber_gte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "BigInt"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "blockNumber_lte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "BigInt"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "blockNumber_in"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NonNullType",
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "BigInt"
+                }
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "blockNumber_not_in"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NonNullType",
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "BigInt"
+                }
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "transactionHash"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "transactionHash_not"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "transactionHash_gt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "transactionHash_lt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "transactionHash_gte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "transactionHash_lte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "transactionHash_in"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NonNullType",
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "Bytes"
+                }
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "transactionHash_not_in"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NonNullType",
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "Bytes"
+                }
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "transactionHash_contains"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "transactionHash_not_contains"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "transactionTimestamp"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "BigInt"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "transactionTimestamp_not"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "BigInt"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "transactionTimestamp_gt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "BigInt"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "transactionTimestamp_lt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "BigInt"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "transactionTimestamp_gte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "BigInt"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "transactionTimestamp_lte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "BigInt"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "transactionTimestamp_in"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NonNullType",
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "BigInt"
+                }
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "transactionTimestamp_not_in"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NonNullType",
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "BigInt"
+                }
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "fromAddress"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "fromAddress_not"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "fromAddress_gt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "fromAddress_lt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "fromAddress_gte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "fromAddress_lte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "fromAddress_in"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NonNullType",
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "Bytes"
+                }
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "fromAddress_not_in"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NonNullType",
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "Bytes"
+                }
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "fromAddress_contains"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "fromAddress_not_contains"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "toAddress"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "toAddress_not"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "toAddress_gt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "toAddress_lt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "toAddress_gte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "toAddress_lte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "toAddress_in"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NonNullType",
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "Bytes"
+                }
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "toAddress_not_in"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NonNullType",
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "Bytes"
+                }
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "toAddress_contains"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "toAddress_not_contains"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Bytes"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "valueTransferred"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "BigInt"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "valueTransferred_not"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "BigInt"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "valueTransferred_gt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "BigInt"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "valueTransferred_lt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "BigInt"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "valueTransferred_gte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "BigInt"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "valueTransferred_lte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "BigInt"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "valueTransferred_in"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NonNullType",
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "BigInt"
+                }
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "valueTransferred_not_in"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NonNullType",
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "BigInt"
+                }
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "gasPrice"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "BigInt"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "gasPrice_not"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "BigInt"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "gasPrice_gt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "BigInt"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "gasPrice_lt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "BigInt"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "gasPrice_gte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "BigInt"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "gasPrice_lte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "BigInt"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "gasPrice_in"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NonNullType",
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "BigInt"
+                }
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "gasPrice_not_in"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NonNullType",
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "BigInt"
+                }
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "description": {
+            "kind": "StringValue",
+            "value": "Filter for the block changed event.",
+            "block": true
+          },
+          "name": {
+            "kind": "Name",
+            "value": "_change_block"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "BlockChangedFilter"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "and"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "Audit_filter"
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "or"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "Audit_filter"
+              }
+            }
+          },
+          "directives": []
+        }
+      ],
+      "directives": []
+    },
+    {
+      "kind": "EnumTypeDefinition",
+      "name": {
+        "kind": "Name",
+        "value": "Audit_orderBy"
+      },
+      "values": [
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "id"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "blockNumber"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "transactionHash"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "transactionTimestamp"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "fromAddress"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "toAddress"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "valueTransferred"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "gasPrice"
           },
           "directives": []
         }
@@ -3967,6 +7207,25 @@ const schemaAST = {
             }
           },
           "directives": []
+        },
+        {
+          "kind": "FieldDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation"
+          },
+          "arguments": [],
+          "type": {
+            "kind": "NonNullType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "AuditInformation"
+              }
+            }
+          },
+          "directives": []
         }
       ],
       "interfaces": [],
@@ -4113,6 +7372,333 @@ const schemaAST = {
         },
         {
           "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_not"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_gt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_lt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_gte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_lte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_in"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NonNullType",
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "String"
+                }
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_not_in"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NonNullType",
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "String"
+                }
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_contains"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_contains_nocase"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_not_contains"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_not_contains_nocase"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_starts_with"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_starts_with_nocase"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_not_starts_with"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_not_starts_with_nocase"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_ends_with"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_ends_with_nocase"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_not_ends_with"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_not_ends_with_nocase"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "AuditInformation_filter"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
           "description": {
             "kind": "StringValue",
             "value": "Filter for the block changed event.",
@@ -4182,6 +7768,22 @@ const schemaAST = {
           "name": {
             "kind": "Name",
             "value": "id"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation__id"
           },
           "directives": []
         }
@@ -4266,6 +7868,25 @@ const schemaAST = {
               "name": {
                 "kind": "Name",
                 "value": "String"
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "FieldDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation"
+          },
+          "arguments": [],
+          "type": {
+            "kind": "NonNullType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "AuditInformation"
               }
             }
           },
@@ -5202,6 +8823,333 @@ const schemaAST = {
         },
         {
           "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_not"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_gt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_lt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_gte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_lte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_in"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NonNullType",
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "String"
+                }
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_not_in"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NonNullType",
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "String"
+                }
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_contains"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_contains_nocase"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_not_contains"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_not_contains_nocase"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_starts_with"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_starts_with_nocase"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_not_starts_with"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_not_starts_with_nocase"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_ends_with"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_ends_with_nocase"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_not_ends_with"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_not_ends_with_nocase"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "AuditInformation_filter"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
           "description": {
             "kind": "StringValue",
             "value": "Filter for the block changed event.",
@@ -5295,6 +9243,22 @@ const schemaAST = {
           "name": {
             "kind": "Name",
             "value": "description"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation__id"
           },
           "directives": []
         }
@@ -5487,6 +9451,25 @@ const schemaAST = {
             "name": {
               "kind": "Name",
               "value": "Int"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "FieldDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation"
+          },
+          "arguments": [],
+          "type": {
+            "kind": "NonNullType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "AuditInformation"
+              }
             }
           },
           "directives": []
@@ -7064,6 +11047,333 @@ const schemaAST = {
         },
         {
           "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_not"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_gt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_lt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_gte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_lte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_in"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NonNullType",
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "String"
+                }
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_not_in"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NonNullType",
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "String"
+                }
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_contains"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_contains_nocase"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_not_contains"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_not_contains_nocase"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_starts_with"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_starts_with_nocase"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_not_starts_with"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_not_starts_with_nocase"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_ends_with"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_ends_with_nocase"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_not_ends_with"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_not_ends_with_nocase"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "AuditInformation_filter"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
           "description": {
             "kind": "StringValue",
             "value": "Filter for the block changed event.",
@@ -7189,6 +11499,22 @@ const schemaAST = {
           "name": {
             "kind": "Name",
             "value": "attestationCounter"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation__id"
           },
           "directives": []
         }
@@ -8870,6 +13196,482 @@ const schemaAST = {
         },
         {
           "kind": "FieldDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation"
+          },
+          "arguments": [
+            {
+              "kind": "InputValueDefinition",
+              "name": {
+                "kind": "Name",
+                "value": "id"
+              },
+              "type": {
+                "kind": "NonNullType",
+                "type": {
+                  "kind": "NamedType",
+                  "name": {
+                    "kind": "Name",
+                    "value": "ID"
+                  }
+                }
+              },
+              "directives": []
+            },
+            {
+              "kind": "InputValueDefinition",
+              "description": {
+                "kind": "StringValue",
+                "value": "The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.",
+                "block": true
+              },
+              "name": {
+                "kind": "Name",
+                "value": "block"
+              },
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "Block_height"
+                }
+              },
+              "directives": []
+            },
+            {
+              "kind": "InputValueDefinition",
+              "description": {
+                "kind": "StringValue",
+                "value": "Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.",
+                "block": true
+              },
+              "name": {
+                "kind": "Name",
+                "value": "subgraphError"
+              },
+              "type": {
+                "kind": "NonNullType",
+                "type": {
+                  "kind": "NamedType",
+                  "name": {
+                    "kind": "Name",
+                    "value": "_SubgraphErrorPolicy_"
+                  }
+                }
+              },
+              "defaultValue": {
+                "kind": "EnumValue",
+                "value": "deny"
+              },
+              "directives": []
+            }
+          ],
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "AuditInformation"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "FieldDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformations"
+          },
+          "arguments": [
+            {
+              "kind": "InputValueDefinition",
+              "name": {
+                "kind": "Name",
+                "value": "skip"
+              },
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "Int"
+                }
+              },
+              "defaultValue": {
+                "kind": "IntValue",
+                "value": "0"
+              },
+              "directives": []
+            },
+            {
+              "kind": "InputValueDefinition",
+              "name": {
+                "kind": "Name",
+                "value": "first"
+              },
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "Int"
+                }
+              },
+              "defaultValue": {
+                "kind": "IntValue",
+                "value": "100"
+              },
+              "directives": []
+            },
+            {
+              "kind": "InputValueDefinition",
+              "name": {
+                "kind": "Name",
+                "value": "orderBy"
+              },
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "AuditInformation_orderBy"
+                }
+              },
+              "directives": []
+            },
+            {
+              "kind": "InputValueDefinition",
+              "name": {
+                "kind": "Name",
+                "value": "orderDirection"
+              },
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "OrderDirection"
+                }
+              },
+              "directives": []
+            },
+            {
+              "kind": "InputValueDefinition",
+              "name": {
+                "kind": "Name",
+                "value": "where"
+              },
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "AuditInformation_filter"
+                }
+              },
+              "directives": []
+            },
+            {
+              "kind": "InputValueDefinition",
+              "description": {
+                "kind": "StringValue",
+                "value": "The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.",
+                "block": true
+              },
+              "name": {
+                "kind": "Name",
+                "value": "block"
+              },
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "Block_height"
+                }
+              },
+              "directives": []
+            },
+            {
+              "kind": "InputValueDefinition",
+              "description": {
+                "kind": "StringValue",
+                "value": "Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.",
+                "block": true
+              },
+              "name": {
+                "kind": "Name",
+                "value": "subgraphError"
+              },
+              "type": {
+                "kind": "NonNullType",
+                "type": {
+                  "kind": "NamedType",
+                  "name": {
+                    "kind": "Name",
+                    "value": "_SubgraphErrorPolicy_"
+                  }
+                }
+              },
+              "defaultValue": {
+                "kind": "EnumValue",
+                "value": "deny"
+              },
+              "directives": []
+            }
+          ],
+          "type": {
+            "kind": "NonNullType",
+            "type": {
+              "kind": "ListType",
+              "type": {
+                "kind": "NonNullType",
+                "type": {
+                  "kind": "NamedType",
+                  "name": {
+                    "kind": "Name",
+                    "value": "AuditInformation"
+                  }
+                }
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "FieldDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "audit"
+          },
+          "arguments": [
+            {
+              "kind": "InputValueDefinition",
+              "name": {
+                "kind": "Name",
+                "value": "id"
+              },
+              "type": {
+                "kind": "NonNullType",
+                "type": {
+                  "kind": "NamedType",
+                  "name": {
+                    "kind": "Name",
+                    "value": "ID"
+                  }
+                }
+              },
+              "directives": []
+            },
+            {
+              "kind": "InputValueDefinition",
+              "description": {
+                "kind": "StringValue",
+                "value": "The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.",
+                "block": true
+              },
+              "name": {
+                "kind": "Name",
+                "value": "block"
+              },
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "Block_height"
+                }
+              },
+              "directives": []
+            },
+            {
+              "kind": "InputValueDefinition",
+              "description": {
+                "kind": "StringValue",
+                "value": "Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.",
+                "block": true
+              },
+              "name": {
+                "kind": "Name",
+                "value": "subgraphError"
+              },
+              "type": {
+                "kind": "NonNullType",
+                "type": {
+                  "kind": "NamedType",
+                  "name": {
+                    "kind": "Name",
+                    "value": "_SubgraphErrorPolicy_"
+                  }
+                }
+              },
+              "defaultValue": {
+                "kind": "EnumValue",
+                "value": "deny"
+              },
+              "directives": []
+            }
+          ],
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Audit"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "FieldDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "audits"
+          },
+          "arguments": [
+            {
+              "kind": "InputValueDefinition",
+              "name": {
+                "kind": "Name",
+                "value": "skip"
+              },
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "Int"
+                }
+              },
+              "defaultValue": {
+                "kind": "IntValue",
+                "value": "0"
+              },
+              "directives": []
+            },
+            {
+              "kind": "InputValueDefinition",
+              "name": {
+                "kind": "Name",
+                "value": "first"
+              },
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "Int"
+                }
+              },
+              "defaultValue": {
+                "kind": "IntValue",
+                "value": "100"
+              },
+              "directives": []
+            },
+            {
+              "kind": "InputValueDefinition",
+              "name": {
+                "kind": "Name",
+                "value": "orderBy"
+              },
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "Audit_orderBy"
+                }
+              },
+              "directives": []
+            },
+            {
+              "kind": "InputValueDefinition",
+              "name": {
+                "kind": "Name",
+                "value": "orderDirection"
+              },
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "OrderDirection"
+                }
+              },
+              "directives": []
+            },
+            {
+              "kind": "InputValueDefinition",
+              "name": {
+                "kind": "Name",
+                "value": "where"
+              },
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "Audit_filter"
+                }
+              },
+              "directives": []
+            },
+            {
+              "kind": "InputValueDefinition",
+              "description": {
+                "kind": "StringValue",
+                "value": "The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.",
+                "block": true
+              },
+              "name": {
+                "kind": "Name",
+                "value": "block"
+              },
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "Block_height"
+                }
+              },
+              "directives": []
+            },
+            {
+              "kind": "InputValueDefinition",
+              "description": {
+                "kind": "StringValue",
+                "value": "Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.",
+                "block": true
+              },
+              "name": {
+                "kind": "Name",
+                "value": "subgraphError"
+              },
+              "type": {
+                "kind": "NonNullType",
+                "type": {
+                  "kind": "NamedType",
+                  "name": {
+                    "kind": "Name",
+                    "value": "_SubgraphErrorPolicy_"
+                  }
+                }
+              },
+              "defaultValue": {
+                "kind": "EnumValue",
+                "value": "deny"
+              },
+              "directives": []
+            }
+          ],
+          "type": {
+            "kind": "NonNullType",
+            "type": {
+              "kind": "ListType",
+              "type": {
+                "kind": "NonNullType",
+                "type": {
+                  "kind": "NamedType",
+                  "name": {
+                    "kind": "Name",
+                    "value": "Audit"
+                  }
+                }
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "FieldDefinition",
           "description": {
             "kind": "StringValue",
             "value": "Access to subgraph metadata",
@@ -8963,6 +13765,25 @@ const schemaAST = {
             "name": {
               "kind": "Name",
               "value": "BigInt"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "FieldDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation"
+          },
+          "arguments": [],
+          "type": {
+            "kind": "NonNullType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "AuditInformation"
+              }
             }
           },
           "directives": []
@@ -9376,6 +14197,333 @@ const schemaAST = {
         },
         {
           "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_not"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_gt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_lt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_gte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_lte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_in"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NonNullType",
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "String"
+                }
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_not_in"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NonNullType",
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "String"
+                }
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_contains"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_contains_nocase"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_not_contains"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_not_contains_nocase"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_starts_with"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_starts_with_nocase"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_not_starts_with"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_not_starts_with_nocase"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_ends_with"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_ends_with_nocase"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_not_ends_with"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_not_ends_with_nocase"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "AuditInformation_filter"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
           "description": {
             "kind": "StringValue",
             "value": "Filter for the block changed event.",
@@ -9461,6 +14609,22 @@ const schemaAST = {
           "name": {
             "kind": "Name",
             "value": "timestamp"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation__id"
           },
           "directives": []
         }
@@ -9581,6 +14745,25 @@ const schemaAST = {
             "name": {
               "kind": "Name",
               "value": "Int"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "FieldDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation"
+          },
+          "arguments": [],
+          "type": {
+            "kind": "NonNullType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "AuditInformation"
+              }
             }
           },
           "directives": []
@@ -11110,6 +16293,333 @@ const schemaAST = {
         },
         {
           "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_not"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_gt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_lt"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_gte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_lte"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_in"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NonNullType",
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "String"
+                }
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_not_in"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NonNullType",
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "String"
+                }
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_contains"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_contains_nocase"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_not_contains"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_not_contains_nocase"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_starts_with"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_starts_with_nocase"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_not_starts_with"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_not_starts_with_nocase"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_ends_with"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_ends_with_nocase"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_not_ends_with"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_not_ends_with_nocase"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation_"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "AuditInformation_filter"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "InputValueDefinition",
           "description": {
             "kind": "StringValue",
             "value": "Filter for the block changed event.",
@@ -11219,6 +16729,22 @@ const schemaAST = {
           "name": {
             "kind": "Name",
             "value": "attestationCounter"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation"
+          },
+          "directives": []
+        },
+        {
+          "kind": "EnumValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation__id"
           },
           "directives": []
         }
@@ -12891,6 +18417,482 @@ const schemaAST = {
                   "name": {
                     "kind": "Name",
                     "value": "RegistryVersion"
+                  }
+                }
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "FieldDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformation"
+          },
+          "arguments": [
+            {
+              "kind": "InputValueDefinition",
+              "name": {
+                "kind": "Name",
+                "value": "id"
+              },
+              "type": {
+                "kind": "NonNullType",
+                "type": {
+                  "kind": "NamedType",
+                  "name": {
+                    "kind": "Name",
+                    "value": "ID"
+                  }
+                }
+              },
+              "directives": []
+            },
+            {
+              "kind": "InputValueDefinition",
+              "description": {
+                "kind": "StringValue",
+                "value": "The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.",
+                "block": true
+              },
+              "name": {
+                "kind": "Name",
+                "value": "block"
+              },
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "Block_height"
+                }
+              },
+              "directives": []
+            },
+            {
+              "kind": "InputValueDefinition",
+              "description": {
+                "kind": "StringValue",
+                "value": "Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.",
+                "block": true
+              },
+              "name": {
+                "kind": "Name",
+                "value": "subgraphError"
+              },
+              "type": {
+                "kind": "NonNullType",
+                "type": {
+                  "kind": "NamedType",
+                  "name": {
+                    "kind": "Name",
+                    "value": "_SubgraphErrorPolicy_"
+                  }
+                }
+              },
+              "defaultValue": {
+                "kind": "EnumValue",
+                "value": "deny"
+              },
+              "directives": []
+            }
+          ],
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "AuditInformation"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "FieldDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "auditInformations"
+          },
+          "arguments": [
+            {
+              "kind": "InputValueDefinition",
+              "name": {
+                "kind": "Name",
+                "value": "skip"
+              },
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "Int"
+                }
+              },
+              "defaultValue": {
+                "kind": "IntValue",
+                "value": "0"
+              },
+              "directives": []
+            },
+            {
+              "kind": "InputValueDefinition",
+              "name": {
+                "kind": "Name",
+                "value": "first"
+              },
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "Int"
+                }
+              },
+              "defaultValue": {
+                "kind": "IntValue",
+                "value": "100"
+              },
+              "directives": []
+            },
+            {
+              "kind": "InputValueDefinition",
+              "name": {
+                "kind": "Name",
+                "value": "orderBy"
+              },
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "AuditInformation_orderBy"
+                }
+              },
+              "directives": []
+            },
+            {
+              "kind": "InputValueDefinition",
+              "name": {
+                "kind": "Name",
+                "value": "orderDirection"
+              },
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "OrderDirection"
+                }
+              },
+              "directives": []
+            },
+            {
+              "kind": "InputValueDefinition",
+              "name": {
+                "kind": "Name",
+                "value": "where"
+              },
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "AuditInformation_filter"
+                }
+              },
+              "directives": []
+            },
+            {
+              "kind": "InputValueDefinition",
+              "description": {
+                "kind": "StringValue",
+                "value": "The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.",
+                "block": true
+              },
+              "name": {
+                "kind": "Name",
+                "value": "block"
+              },
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "Block_height"
+                }
+              },
+              "directives": []
+            },
+            {
+              "kind": "InputValueDefinition",
+              "description": {
+                "kind": "StringValue",
+                "value": "Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.",
+                "block": true
+              },
+              "name": {
+                "kind": "Name",
+                "value": "subgraphError"
+              },
+              "type": {
+                "kind": "NonNullType",
+                "type": {
+                  "kind": "NamedType",
+                  "name": {
+                    "kind": "Name",
+                    "value": "_SubgraphErrorPolicy_"
+                  }
+                }
+              },
+              "defaultValue": {
+                "kind": "EnumValue",
+                "value": "deny"
+              },
+              "directives": []
+            }
+          ],
+          "type": {
+            "kind": "NonNullType",
+            "type": {
+              "kind": "ListType",
+              "type": {
+                "kind": "NonNullType",
+                "type": {
+                  "kind": "NamedType",
+                  "name": {
+                    "kind": "Name",
+                    "value": "AuditInformation"
+                  }
+                }
+              }
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "FieldDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "audit"
+          },
+          "arguments": [
+            {
+              "kind": "InputValueDefinition",
+              "name": {
+                "kind": "Name",
+                "value": "id"
+              },
+              "type": {
+                "kind": "NonNullType",
+                "type": {
+                  "kind": "NamedType",
+                  "name": {
+                    "kind": "Name",
+                    "value": "ID"
+                  }
+                }
+              },
+              "directives": []
+            },
+            {
+              "kind": "InputValueDefinition",
+              "description": {
+                "kind": "StringValue",
+                "value": "The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.",
+                "block": true
+              },
+              "name": {
+                "kind": "Name",
+                "value": "block"
+              },
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "Block_height"
+                }
+              },
+              "directives": []
+            },
+            {
+              "kind": "InputValueDefinition",
+              "description": {
+                "kind": "StringValue",
+                "value": "Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.",
+                "block": true
+              },
+              "name": {
+                "kind": "Name",
+                "value": "subgraphError"
+              },
+              "type": {
+                "kind": "NonNullType",
+                "type": {
+                  "kind": "NamedType",
+                  "name": {
+                    "kind": "Name",
+                    "value": "_SubgraphErrorPolicy_"
+                  }
+                }
+              },
+              "defaultValue": {
+                "kind": "EnumValue",
+                "value": "deny"
+              },
+              "directives": []
+            }
+          ],
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Audit"
+            }
+          },
+          "directives": []
+        },
+        {
+          "kind": "FieldDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "audits"
+          },
+          "arguments": [
+            {
+              "kind": "InputValueDefinition",
+              "name": {
+                "kind": "Name",
+                "value": "skip"
+              },
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "Int"
+                }
+              },
+              "defaultValue": {
+                "kind": "IntValue",
+                "value": "0"
+              },
+              "directives": []
+            },
+            {
+              "kind": "InputValueDefinition",
+              "name": {
+                "kind": "Name",
+                "value": "first"
+              },
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "Int"
+                }
+              },
+              "defaultValue": {
+                "kind": "IntValue",
+                "value": "100"
+              },
+              "directives": []
+            },
+            {
+              "kind": "InputValueDefinition",
+              "name": {
+                "kind": "Name",
+                "value": "orderBy"
+              },
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "Audit_orderBy"
+                }
+              },
+              "directives": []
+            },
+            {
+              "kind": "InputValueDefinition",
+              "name": {
+                "kind": "Name",
+                "value": "orderDirection"
+              },
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "OrderDirection"
+                }
+              },
+              "directives": []
+            },
+            {
+              "kind": "InputValueDefinition",
+              "name": {
+                "kind": "Name",
+                "value": "where"
+              },
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "Audit_filter"
+                }
+              },
+              "directives": []
+            },
+            {
+              "kind": "InputValueDefinition",
+              "description": {
+                "kind": "StringValue",
+                "value": "The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.",
+                "block": true
+              },
+              "name": {
+                "kind": "Name",
+                "value": "block"
+              },
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "Block_height"
+                }
+              },
+              "directives": []
+            },
+            {
+              "kind": "InputValueDefinition",
+              "description": {
+                "kind": "StringValue",
+                "value": "Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.",
+                "block": true
+              },
+              "name": {
+                "kind": "Name",
+                "value": "subgraphError"
+              },
+              "type": {
+                "kind": "NonNullType",
+                "type": {
+                  "kind": "NamedType",
+                  "name": {
+                    "kind": "Name",
+                    "value": "_SubgraphErrorPolicy_"
+                  }
+                }
+              },
+              "defaultValue": {
+                "kind": "EnumValue",
+                "value": "deny"
+              },
+              "directives": []
+            }
+          ],
+          "type": {
+            "kind": "NonNullType",
+            "type": {
+              "kind": "ListType",
+              "type": {
+                "kind": "NonNullType",
+                "type": {
+                  "kind": "NamedType",
+                  "name": {
+                    "kind": "Name",
+                    "value": "Audit"
                   }
                 }
               }

--- a/sdk/.graphclient/sources/linea-attestation-registry/schema.graphql
+++ b/sdk/.graphclient/sources/linea-attestation-registry/schema.graphql
@@ -23,10 +23,10 @@ enum Aggregation_interval {
 
 type Attestation {
   id: ID!
-  schemaId: Bytes!
+  schema: Schema!
   replacedBy: Bytes!
   attester: Bytes!
-  portal: Bytes!
+  portal: Portal!
   attestedDate: BigInt!
   expirationDate: BigInt!
   revocationDate: BigInt!
@@ -35,8 +35,8 @@ type Attestation {
   subject: Bytes!
   encodedSubject: Bytes!
   attestationData: Bytes!
-  schemaString: String
   decodedData: [String!]
+  auditInformation: AuditInformation!
 }
 
 input Attestation_filter {
@@ -48,16 +48,27 @@ input Attestation_filter {
   id_lte: ID
   id_in: [ID!]
   id_not_in: [ID!]
-  schemaId: Bytes
-  schemaId_not: Bytes
-  schemaId_gt: Bytes
-  schemaId_lt: Bytes
-  schemaId_gte: Bytes
-  schemaId_lte: Bytes
-  schemaId_in: [Bytes!]
-  schemaId_not_in: [Bytes!]
-  schemaId_contains: Bytes
-  schemaId_not_contains: Bytes
+  schema: String
+  schema_not: String
+  schema_gt: String
+  schema_lt: String
+  schema_gte: String
+  schema_lte: String
+  schema_in: [String!]
+  schema_not_in: [String!]
+  schema_contains: String
+  schema_contains_nocase: String
+  schema_not_contains: String
+  schema_not_contains_nocase: String
+  schema_starts_with: String
+  schema_starts_with_nocase: String
+  schema_not_starts_with: String
+  schema_not_starts_with_nocase: String
+  schema_ends_with: String
+  schema_ends_with_nocase: String
+  schema_not_ends_with: String
+  schema_not_ends_with_nocase: String
+  schema_: Schema_filter
   replacedBy: Bytes
   replacedBy_not: Bytes
   replacedBy_gt: Bytes
@@ -78,16 +89,27 @@ input Attestation_filter {
   attester_not_in: [Bytes!]
   attester_contains: Bytes
   attester_not_contains: Bytes
-  portal: Bytes
-  portal_not: Bytes
-  portal_gt: Bytes
-  portal_lt: Bytes
-  portal_gte: Bytes
-  portal_lte: Bytes
-  portal_in: [Bytes!]
-  portal_not_in: [Bytes!]
-  portal_contains: Bytes
-  portal_not_contains: Bytes
+  portal: String
+  portal_not: String
+  portal_gt: String
+  portal_lt: String
+  portal_gte: String
+  portal_lte: String
+  portal_in: [String!]
+  portal_not_in: [String!]
+  portal_contains: String
+  portal_contains_nocase: String
+  portal_not_contains: String
+  portal_not_contains_nocase: String
+  portal_starts_with: String
+  portal_starts_with_nocase: String
+  portal_not_starts_with: String
+  portal_not_starts_with_nocase: String
+  portal_ends_with: String
+  portal_ends_with_nocase: String
+  portal_not_ends_with: String
+  portal_not_ends_with_nocase: String
+  portal_: Portal_filter
   attestedDate: BigInt
   attestedDate_not: BigInt
   attestedDate_gt: BigInt
@@ -154,32 +176,33 @@ input Attestation_filter {
   attestationData_not_in: [Bytes!]
   attestationData_contains: Bytes
   attestationData_not_contains: Bytes
-  schemaString: String
-  schemaString_not: String
-  schemaString_gt: String
-  schemaString_lt: String
-  schemaString_gte: String
-  schemaString_lte: String
-  schemaString_in: [String!]
-  schemaString_not_in: [String!]
-  schemaString_contains: String
-  schemaString_contains_nocase: String
-  schemaString_not_contains: String
-  schemaString_not_contains_nocase: String
-  schemaString_starts_with: String
-  schemaString_starts_with_nocase: String
-  schemaString_not_starts_with: String
-  schemaString_not_starts_with_nocase: String
-  schemaString_ends_with: String
-  schemaString_ends_with_nocase: String
-  schemaString_not_ends_with: String
-  schemaString_not_ends_with_nocase: String
   decodedData: [String!]
   decodedData_not: [String!]
   decodedData_contains: [String!]
   decodedData_contains_nocase: [String!]
   decodedData_not_contains: [String!]
   decodedData_not_contains_nocase: [String!]
+  auditInformation: String
+  auditInformation_not: String
+  auditInformation_gt: String
+  auditInformation_lt: String
+  auditInformation_gte: String
+  auditInformation_lte: String
+  auditInformation_in: [String!]
+  auditInformation_not_in: [String!]
+  auditInformation_contains: String
+  auditInformation_contains_nocase: String
+  auditInformation_not_contains: String
+  auditInformation_not_contains_nocase: String
+  auditInformation_starts_with: String
+  auditInformation_starts_with_nocase: String
+  auditInformation_not_starts_with: String
+  auditInformation_not_starts_with_nocase: String
+  auditInformation_ends_with: String
+  auditInformation_ends_with_nocase: String
+  auditInformation_not_ends_with: String
+  auditInformation_not_ends_with_nocase: String
+  auditInformation_: AuditInformation_filter
   """Filter for the block changed event."""
   _change_block: BlockChangedFilter
   and: [Attestation_filter]
@@ -188,10 +211,23 @@ input Attestation_filter {
 
 enum Attestation_orderBy {
   id
-  schemaId
+  schema
+  schema__id
+  schema__name
+  schema__description
+  schema__context
+  schema__schema
+  schema__attestationCounter
   replacedBy
   attester
   portal
+  portal__id
+  portal__ownerAddress
+  portal__isRevocable
+  portal__name
+  portal__description
+  portal__ownerName
+  portal__attestationCounter
   attestedDate
   expirationDate
   revocationDate
@@ -200,8 +236,202 @@ enum Attestation_orderBy {
   subject
   encodedSubject
   attestationData
-  schemaString
   decodedData
+  auditInformation
+  auditInformation__id
+}
+
+type Audit {
+  id: ID!
+  blockNumber: BigInt!
+  transactionHash: Bytes!
+  transactionTimestamp: BigInt!
+  fromAddress: Bytes!
+  toAddress: Bytes
+  valueTransferred: BigInt
+  gasPrice: BigInt
+}
+
+type AuditInformation {
+  id: ID!
+  creation: Audit!
+  lastModification: Audit!
+  modifications(skip: Int = 0, first: Int = 100, orderBy: Audit_orderBy, orderDirection: OrderDirection, where: Audit_filter): [Audit!]!
+}
+
+input AuditInformation_filter {
+  id: ID
+  id_not: ID
+  id_gt: ID
+  id_lt: ID
+  id_gte: ID
+  id_lte: ID
+  id_in: [ID!]
+  id_not_in: [ID!]
+  creation: String
+  creation_not: String
+  creation_gt: String
+  creation_lt: String
+  creation_gte: String
+  creation_lte: String
+  creation_in: [String!]
+  creation_not_in: [String!]
+  creation_contains: String
+  creation_contains_nocase: String
+  creation_not_contains: String
+  creation_not_contains_nocase: String
+  creation_starts_with: String
+  creation_starts_with_nocase: String
+  creation_not_starts_with: String
+  creation_not_starts_with_nocase: String
+  creation_ends_with: String
+  creation_ends_with_nocase: String
+  creation_not_ends_with: String
+  creation_not_ends_with_nocase: String
+  creation_: Audit_filter
+  lastModification: String
+  lastModification_not: String
+  lastModification_gt: String
+  lastModification_lt: String
+  lastModification_gte: String
+  lastModification_lte: String
+  lastModification_in: [String!]
+  lastModification_not_in: [String!]
+  lastModification_contains: String
+  lastModification_contains_nocase: String
+  lastModification_not_contains: String
+  lastModification_not_contains_nocase: String
+  lastModification_starts_with: String
+  lastModification_starts_with_nocase: String
+  lastModification_not_starts_with: String
+  lastModification_not_starts_with_nocase: String
+  lastModification_ends_with: String
+  lastModification_ends_with_nocase: String
+  lastModification_not_ends_with: String
+  lastModification_not_ends_with_nocase: String
+  lastModification_: Audit_filter
+  modifications: [String!]
+  modifications_not: [String!]
+  modifications_contains: [String!]
+  modifications_contains_nocase: [String!]
+  modifications_not_contains: [String!]
+  modifications_not_contains_nocase: [String!]
+  modifications_: Audit_filter
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [AuditInformation_filter]
+  or: [AuditInformation_filter]
+}
+
+enum AuditInformation_orderBy {
+  id
+  creation
+  creation__id
+  creation__blockNumber
+  creation__transactionHash
+  creation__transactionTimestamp
+  creation__fromAddress
+  creation__toAddress
+  creation__valueTransferred
+  creation__gasPrice
+  lastModification
+  lastModification__id
+  lastModification__blockNumber
+  lastModification__transactionHash
+  lastModification__transactionTimestamp
+  lastModification__fromAddress
+  lastModification__toAddress
+  lastModification__valueTransferred
+  lastModification__gasPrice
+  modifications
+}
+
+input Audit_filter {
+  id: ID
+  id_not: ID
+  id_gt: ID
+  id_lt: ID
+  id_gte: ID
+  id_lte: ID
+  id_in: [ID!]
+  id_not_in: [ID!]
+  blockNumber: BigInt
+  blockNumber_not: BigInt
+  blockNumber_gt: BigInt
+  blockNumber_lt: BigInt
+  blockNumber_gte: BigInt
+  blockNumber_lte: BigInt
+  blockNumber_in: [BigInt!]
+  blockNumber_not_in: [BigInt!]
+  transactionHash: Bytes
+  transactionHash_not: Bytes
+  transactionHash_gt: Bytes
+  transactionHash_lt: Bytes
+  transactionHash_gte: Bytes
+  transactionHash_lte: Bytes
+  transactionHash_in: [Bytes!]
+  transactionHash_not_in: [Bytes!]
+  transactionHash_contains: Bytes
+  transactionHash_not_contains: Bytes
+  transactionTimestamp: BigInt
+  transactionTimestamp_not: BigInt
+  transactionTimestamp_gt: BigInt
+  transactionTimestamp_lt: BigInt
+  transactionTimestamp_gte: BigInt
+  transactionTimestamp_lte: BigInt
+  transactionTimestamp_in: [BigInt!]
+  transactionTimestamp_not_in: [BigInt!]
+  fromAddress: Bytes
+  fromAddress_not: Bytes
+  fromAddress_gt: Bytes
+  fromAddress_lt: Bytes
+  fromAddress_gte: Bytes
+  fromAddress_lte: Bytes
+  fromAddress_in: [Bytes!]
+  fromAddress_not_in: [Bytes!]
+  fromAddress_contains: Bytes
+  fromAddress_not_contains: Bytes
+  toAddress: Bytes
+  toAddress_not: Bytes
+  toAddress_gt: Bytes
+  toAddress_lt: Bytes
+  toAddress_gte: Bytes
+  toAddress_lte: Bytes
+  toAddress_in: [Bytes!]
+  toAddress_not_in: [Bytes!]
+  toAddress_contains: Bytes
+  toAddress_not_contains: Bytes
+  valueTransferred: BigInt
+  valueTransferred_not: BigInt
+  valueTransferred_gt: BigInt
+  valueTransferred_lt: BigInt
+  valueTransferred_gte: BigInt
+  valueTransferred_lte: BigInt
+  valueTransferred_in: [BigInt!]
+  valueTransferred_not_in: [BigInt!]
+  gasPrice: BigInt
+  gasPrice_not: BigInt
+  gasPrice_gt: BigInt
+  gasPrice_lt: BigInt
+  gasPrice_gte: BigInt
+  gasPrice_lte: BigInt
+  gasPrice_in: [BigInt!]
+  gasPrice_not_in: [BigInt!]
+  """Filter for the block changed event."""
+  _change_block: BlockChangedFilter
+  and: [Audit_filter]
+  or: [Audit_filter]
+}
+
+enum Audit_orderBy {
+  id
+  blockNumber
+  transactionHash
+  transactionTimestamp
+  fromAddress
+  toAddress
+  valueTransferred
+  gasPrice
 }
 
 scalar BigDecimal
@@ -291,6 +521,7 @@ scalar Int8
 
 type Issuer {
   id: ID!
+  auditInformation: AuditInformation!
 }
 
 input Issuer_filter {
@@ -302,6 +533,27 @@ input Issuer_filter {
   id_lte: ID
   id_in: [ID!]
   id_not_in: [ID!]
+  auditInformation: String
+  auditInformation_not: String
+  auditInformation_gt: String
+  auditInformation_lt: String
+  auditInformation_gte: String
+  auditInformation_lte: String
+  auditInformation_in: [String!]
+  auditInformation_not_in: [String!]
+  auditInformation_contains: String
+  auditInformation_contains_nocase: String
+  auditInformation_not_contains: String
+  auditInformation_not_contains_nocase: String
+  auditInformation_starts_with: String
+  auditInformation_starts_with_nocase: String
+  auditInformation_not_starts_with: String
+  auditInformation_not_starts_with_nocase: String
+  auditInformation_ends_with: String
+  auditInformation_ends_with_nocase: String
+  auditInformation_not_ends_with: String
+  auditInformation_not_ends_with_nocase: String
+  auditInformation_: AuditInformation_filter
   """Filter for the block changed event."""
   _change_block: BlockChangedFilter
   and: [Issuer_filter]
@@ -310,6 +562,8 @@ input Issuer_filter {
 
 enum Issuer_orderBy {
   id
+  auditInformation
+  auditInformation__id
 }
 
 type Module {
@@ -317,6 +571,7 @@ type Module {
   moduleAddress: Bytes!
   name: String!
   description: String!
+  auditInformation: AuditInformation!
 }
 
 input Module_filter {
@@ -378,6 +633,27 @@ input Module_filter {
   description_ends_with_nocase: String
   description_not_ends_with: String
   description_not_ends_with_nocase: String
+  auditInformation: String
+  auditInformation_not: String
+  auditInformation_gt: String
+  auditInformation_lt: String
+  auditInformation_gte: String
+  auditInformation_lte: String
+  auditInformation_in: [String!]
+  auditInformation_not_in: [String!]
+  auditInformation_contains: String
+  auditInformation_contains_nocase: String
+  auditInformation_not_contains: String
+  auditInformation_not_contains_nocase: String
+  auditInformation_starts_with: String
+  auditInformation_starts_with_nocase: String
+  auditInformation_not_starts_with: String
+  auditInformation_not_starts_with_nocase: String
+  auditInformation_ends_with: String
+  auditInformation_ends_with_nocase: String
+  auditInformation_not_ends_with: String
+  auditInformation_not_ends_with_nocase: String
+  auditInformation_: AuditInformation_filter
   """Filter for the block changed event."""
   _change_block: BlockChangedFilter
   and: [Module_filter]
@@ -389,6 +665,8 @@ enum Module_orderBy {
   moduleAddress
   name
   description
+  auditInformation
+  auditInformation__id
 }
 
 """Defines the order direction, either ascending or descending"""
@@ -406,6 +684,7 @@ type Portal {
   description: String!
   ownerName: String!
   attestationCounter: Int
+  auditInformation: AuditInformation!
 }
 
 input Portal_filter {
@@ -505,6 +784,27 @@ input Portal_filter {
   attestationCounter_lte: Int
   attestationCounter_in: [Int!]
   attestationCounter_not_in: [Int!]
+  auditInformation: String
+  auditInformation_not: String
+  auditInformation_gt: String
+  auditInformation_lt: String
+  auditInformation_gte: String
+  auditInformation_lte: String
+  auditInformation_in: [String!]
+  auditInformation_not_in: [String!]
+  auditInformation_contains: String
+  auditInformation_contains_nocase: String
+  auditInformation_not_contains: String
+  auditInformation_not_contains_nocase: String
+  auditInformation_starts_with: String
+  auditInformation_starts_with_nocase: String
+  auditInformation_not_starts_with: String
+  auditInformation_not_starts_with_nocase: String
+  auditInformation_ends_with: String
+  auditInformation_ends_with_nocase: String
+  auditInformation_not_ends_with: String
+  auditInformation_not_ends_with_nocase: String
+  auditInformation_: AuditInformation_filter
   """Filter for the block changed event."""
   _change_block: BlockChangedFilter
   and: [Portal_filter]
@@ -520,6 +820,8 @@ enum Portal_orderBy {
   description
   ownerName
   attestationCounter
+  auditInformation
+  auditInformation__id
 }
 
 type Query {
@@ -705,6 +1007,58 @@ type Query {
     """
     subgraphError: _SubgraphErrorPolicy_! = deny
   ): [RegistryVersion!]!
+  auditInformation(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): AuditInformation
+  auditInformations(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: AuditInformation_orderBy
+    orderDirection: OrderDirection
+    where: AuditInformation_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [AuditInformation!]!
+  audit(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): Audit
+  audits(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: Audit_orderBy
+    orderDirection: OrderDirection
+    where: Audit_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [Audit!]!
   """Access to subgraph metadata"""
   _meta(block: Block_height): _Meta_
 }
@@ -713,6 +1067,7 @@ type RegistryVersion {
   id: ID!
   versionNumber: Int
   timestamp: BigInt
+  auditInformation: AuditInformation!
 }
 
 input RegistryVersion_filter {
@@ -740,6 +1095,27 @@ input RegistryVersion_filter {
   timestamp_lte: BigInt
   timestamp_in: [BigInt!]
   timestamp_not_in: [BigInt!]
+  auditInformation: String
+  auditInformation_not: String
+  auditInformation_gt: String
+  auditInformation_lt: String
+  auditInformation_gte: String
+  auditInformation_lte: String
+  auditInformation_in: [String!]
+  auditInformation_not_in: [String!]
+  auditInformation_contains: String
+  auditInformation_contains_nocase: String
+  auditInformation_not_contains: String
+  auditInformation_not_contains_nocase: String
+  auditInformation_starts_with: String
+  auditInformation_starts_with_nocase: String
+  auditInformation_not_starts_with: String
+  auditInformation_not_starts_with_nocase: String
+  auditInformation_ends_with: String
+  auditInformation_ends_with_nocase: String
+  auditInformation_not_ends_with: String
+  auditInformation_not_ends_with_nocase: String
+  auditInformation_: AuditInformation_filter
   """Filter for the block changed event."""
   _change_block: BlockChangedFilter
   and: [RegistryVersion_filter]
@@ -750,6 +1126,8 @@ enum RegistryVersion_orderBy {
   id
   versionNumber
   timestamp
+  auditInformation
+  auditInformation__id
 }
 
 type Schema {
@@ -759,6 +1137,7 @@ type Schema {
   context: String!
   schema: String!
   attestationCounter: Int
+  auditInformation: AuditInformation!
 }
 
 input Schema_filter {
@@ -858,6 +1237,27 @@ input Schema_filter {
   attestationCounter_lte: Int
   attestationCounter_in: [Int!]
   attestationCounter_not_in: [Int!]
+  auditInformation: String
+  auditInformation_not: String
+  auditInformation_gt: String
+  auditInformation_lt: String
+  auditInformation_gte: String
+  auditInformation_lte: String
+  auditInformation_in: [String!]
+  auditInformation_not_in: [String!]
+  auditInformation_contains: String
+  auditInformation_contains_nocase: String
+  auditInformation_not_contains: String
+  auditInformation_not_contains_nocase: String
+  auditInformation_starts_with: String
+  auditInformation_starts_with_nocase: String
+  auditInformation_not_starts_with: String
+  auditInformation_not_starts_with_nocase: String
+  auditInformation_ends_with: String
+  auditInformation_ends_with_nocase: String
+  auditInformation_not_ends_with: String
+  auditInformation_not_ends_with_nocase: String
+  auditInformation_: AuditInformation_filter
   """Filter for the block changed event."""
   _change_block: BlockChangedFilter
   and: [Schema_filter]
@@ -871,6 +1271,8 @@ enum Schema_orderBy {
   context
   schema
   attestationCounter
+  auditInformation
+  auditInformation__id
 }
 
 type Subscription {
@@ -1056,6 +1458,58 @@ type Subscription {
     """
     subgraphError: _SubgraphErrorPolicy_! = deny
   ): [RegistryVersion!]!
+  auditInformation(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): AuditInformation
+  auditInformations(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: AuditInformation_orderBy
+    orderDirection: OrderDirection
+    where: AuditInformation_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [AuditInformation!]!
+  audit(
+    id: ID!
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): Audit
+  audits(
+    skip: Int = 0
+    first: Int = 100
+    orderBy: Audit_orderBy
+    orderDirection: OrderDirection
+    where: Audit_filter
+    """
+    The block at which the query should be executed. Can either be a `{ hash: Bytes }` value containing a block hash, a `{ number: Int }` containing the block number, or a `{ number_gte: Int }` containing the minimum block number. In the case of `number_gte`, the query will be executed on the latest block only if the subgraph has progressed to or past the minimum block number. Defaults to the latest block when omitted.
+    """
+    block: Block_height
+    """
+    Set to `allow` to receive data even if the subgraph has skipped over errors while syncing.
+    """
+    subgraphError: _SubgraphErrorPolicy_! = deny
+  ): [Audit!]!
   """Access to subgraph metadata"""
   _meta(block: Block_height): _Meta_
 }

--- a/sdk/.graphclient/sources/linea-attestation-registry/types.ts
+++ b/sdk/.graphclient/sources/linea-attestation-registry/types.ts
@@ -31,10 +31,10 @@ export type Aggregation_interval =
 
 export type Attestation = {
   id: Scalars['ID']['output'];
-  schemaId: Scalars['Bytes']['output'];
+  schema: Schema;
   replacedBy: Scalars['Bytes']['output'];
   attester: Scalars['Bytes']['output'];
-  portal: Scalars['Bytes']['output'];
+  portal: Portal;
   attestedDate: Scalars['BigInt']['output'];
   expirationDate: Scalars['BigInt']['output'];
   revocationDate: Scalars['BigInt']['output'];
@@ -43,8 +43,8 @@ export type Attestation = {
   subject: Scalars['Bytes']['output'];
   encodedSubject: Scalars['Bytes']['output'];
   attestationData: Scalars['Bytes']['output'];
-  schemaString?: Maybe<Scalars['String']['output']>;
   decodedData?: Maybe<Array<Scalars['String']['output']>>;
+  auditInformation: AuditInformation;
 };
 
 export type Attestation_filter = {
@@ -56,16 +56,27 @@ export type Attestation_filter = {
   id_lte?: InputMaybe<Scalars['ID']['input']>;
   id_in?: InputMaybe<Array<Scalars['ID']['input']>>;
   id_not_in?: InputMaybe<Array<Scalars['ID']['input']>>;
-  schemaId?: InputMaybe<Scalars['Bytes']['input']>;
-  schemaId_not?: InputMaybe<Scalars['Bytes']['input']>;
-  schemaId_gt?: InputMaybe<Scalars['Bytes']['input']>;
-  schemaId_lt?: InputMaybe<Scalars['Bytes']['input']>;
-  schemaId_gte?: InputMaybe<Scalars['Bytes']['input']>;
-  schemaId_lte?: InputMaybe<Scalars['Bytes']['input']>;
-  schemaId_in?: InputMaybe<Array<Scalars['Bytes']['input']>>;
-  schemaId_not_in?: InputMaybe<Array<Scalars['Bytes']['input']>>;
-  schemaId_contains?: InputMaybe<Scalars['Bytes']['input']>;
-  schemaId_not_contains?: InputMaybe<Scalars['Bytes']['input']>;
+  schema?: InputMaybe<Scalars['String']['input']>;
+  schema_not?: InputMaybe<Scalars['String']['input']>;
+  schema_gt?: InputMaybe<Scalars['String']['input']>;
+  schema_lt?: InputMaybe<Scalars['String']['input']>;
+  schema_gte?: InputMaybe<Scalars['String']['input']>;
+  schema_lte?: InputMaybe<Scalars['String']['input']>;
+  schema_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  schema_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  schema_contains?: InputMaybe<Scalars['String']['input']>;
+  schema_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  schema_not_contains?: InputMaybe<Scalars['String']['input']>;
+  schema_not_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  schema_starts_with?: InputMaybe<Scalars['String']['input']>;
+  schema_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  schema_not_starts_with?: InputMaybe<Scalars['String']['input']>;
+  schema_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  schema_ends_with?: InputMaybe<Scalars['String']['input']>;
+  schema_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  schema_not_ends_with?: InputMaybe<Scalars['String']['input']>;
+  schema_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  schema_?: InputMaybe<Schema_filter>;
   replacedBy?: InputMaybe<Scalars['Bytes']['input']>;
   replacedBy_not?: InputMaybe<Scalars['Bytes']['input']>;
   replacedBy_gt?: InputMaybe<Scalars['Bytes']['input']>;
@@ -86,16 +97,27 @@ export type Attestation_filter = {
   attester_not_in?: InputMaybe<Array<Scalars['Bytes']['input']>>;
   attester_contains?: InputMaybe<Scalars['Bytes']['input']>;
   attester_not_contains?: InputMaybe<Scalars['Bytes']['input']>;
-  portal?: InputMaybe<Scalars['Bytes']['input']>;
-  portal_not?: InputMaybe<Scalars['Bytes']['input']>;
-  portal_gt?: InputMaybe<Scalars['Bytes']['input']>;
-  portal_lt?: InputMaybe<Scalars['Bytes']['input']>;
-  portal_gte?: InputMaybe<Scalars['Bytes']['input']>;
-  portal_lte?: InputMaybe<Scalars['Bytes']['input']>;
-  portal_in?: InputMaybe<Array<Scalars['Bytes']['input']>>;
-  portal_not_in?: InputMaybe<Array<Scalars['Bytes']['input']>>;
-  portal_contains?: InputMaybe<Scalars['Bytes']['input']>;
-  portal_not_contains?: InputMaybe<Scalars['Bytes']['input']>;
+  portal?: InputMaybe<Scalars['String']['input']>;
+  portal_not?: InputMaybe<Scalars['String']['input']>;
+  portal_gt?: InputMaybe<Scalars['String']['input']>;
+  portal_lt?: InputMaybe<Scalars['String']['input']>;
+  portal_gte?: InputMaybe<Scalars['String']['input']>;
+  portal_lte?: InputMaybe<Scalars['String']['input']>;
+  portal_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  portal_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  portal_contains?: InputMaybe<Scalars['String']['input']>;
+  portal_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  portal_not_contains?: InputMaybe<Scalars['String']['input']>;
+  portal_not_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  portal_starts_with?: InputMaybe<Scalars['String']['input']>;
+  portal_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  portal_not_starts_with?: InputMaybe<Scalars['String']['input']>;
+  portal_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  portal_ends_with?: InputMaybe<Scalars['String']['input']>;
+  portal_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  portal_not_ends_with?: InputMaybe<Scalars['String']['input']>;
+  portal_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  portal_?: InputMaybe<Portal_filter>;
   attestedDate?: InputMaybe<Scalars['BigInt']['input']>;
   attestedDate_not?: InputMaybe<Scalars['BigInt']['input']>;
   attestedDate_gt?: InputMaybe<Scalars['BigInt']['input']>;
@@ -162,32 +184,33 @@ export type Attestation_filter = {
   attestationData_not_in?: InputMaybe<Array<Scalars['Bytes']['input']>>;
   attestationData_contains?: InputMaybe<Scalars['Bytes']['input']>;
   attestationData_not_contains?: InputMaybe<Scalars['Bytes']['input']>;
-  schemaString?: InputMaybe<Scalars['String']['input']>;
-  schemaString_not?: InputMaybe<Scalars['String']['input']>;
-  schemaString_gt?: InputMaybe<Scalars['String']['input']>;
-  schemaString_lt?: InputMaybe<Scalars['String']['input']>;
-  schemaString_gte?: InputMaybe<Scalars['String']['input']>;
-  schemaString_lte?: InputMaybe<Scalars['String']['input']>;
-  schemaString_in?: InputMaybe<Array<Scalars['String']['input']>>;
-  schemaString_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
-  schemaString_contains?: InputMaybe<Scalars['String']['input']>;
-  schemaString_contains_nocase?: InputMaybe<Scalars['String']['input']>;
-  schemaString_not_contains?: InputMaybe<Scalars['String']['input']>;
-  schemaString_not_contains_nocase?: InputMaybe<Scalars['String']['input']>;
-  schemaString_starts_with?: InputMaybe<Scalars['String']['input']>;
-  schemaString_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
-  schemaString_not_starts_with?: InputMaybe<Scalars['String']['input']>;
-  schemaString_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
-  schemaString_ends_with?: InputMaybe<Scalars['String']['input']>;
-  schemaString_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
-  schemaString_not_ends_with?: InputMaybe<Scalars['String']['input']>;
-  schemaString_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
   decodedData?: InputMaybe<Array<Scalars['String']['input']>>;
   decodedData_not?: InputMaybe<Array<Scalars['String']['input']>>;
   decodedData_contains?: InputMaybe<Array<Scalars['String']['input']>>;
   decodedData_contains_nocase?: InputMaybe<Array<Scalars['String']['input']>>;
   decodedData_not_contains?: InputMaybe<Array<Scalars['String']['input']>>;
   decodedData_not_contains_nocase?: InputMaybe<Array<Scalars['String']['input']>>;
+  auditInformation?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_not?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_gt?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_lt?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_gte?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_lte?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  auditInformation_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  auditInformation_contains?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_not_contains?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_not_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_starts_with?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_not_starts_with?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_ends_with?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_not_ends_with?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_?: InputMaybe<AuditInformation_filter>;
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
   and?: InputMaybe<Array<InputMaybe<Attestation_filter>>>;
@@ -196,10 +219,23 @@ export type Attestation_filter = {
 
 export type Attestation_orderBy =
   | 'id'
-  | 'schemaId'
+  | 'schema'
+  | 'schema__id'
+  | 'schema__name'
+  | 'schema__description'
+  | 'schema__context'
+  | 'schema__schema'
+  | 'schema__attestationCounter'
   | 'replacedBy'
   | 'attester'
   | 'portal'
+  | 'portal__id'
+  | 'portal__ownerAddress'
+  | 'portal__isRevocable'
+  | 'portal__name'
+  | 'portal__description'
+  | 'portal__ownerName'
+  | 'portal__attestationCounter'
   | 'attestedDate'
   | 'expirationDate'
   | 'revocationDate'
@@ -208,8 +244,209 @@ export type Attestation_orderBy =
   | 'subject'
   | 'encodedSubject'
   | 'attestationData'
-  | 'schemaString'
-  | 'decodedData';
+  | 'decodedData'
+  | 'auditInformation'
+  | 'auditInformation__id';
+
+export type Audit = {
+  id: Scalars['ID']['output'];
+  blockNumber: Scalars['BigInt']['output'];
+  transactionHash: Scalars['Bytes']['output'];
+  transactionTimestamp: Scalars['BigInt']['output'];
+  fromAddress: Scalars['Bytes']['output'];
+  toAddress?: Maybe<Scalars['Bytes']['output']>;
+  valueTransferred?: Maybe<Scalars['BigInt']['output']>;
+  gasPrice?: Maybe<Scalars['BigInt']['output']>;
+};
+
+export type AuditInformation = {
+  id: Scalars['ID']['output'];
+  creation: Audit;
+  lastModification: Audit;
+  modifications: Array<Audit>;
+};
+
+
+export type AuditInformationmodificationsArgs = {
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<Audit_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<Audit_filter>;
+};
+
+export type AuditInformation_filter = {
+  id?: InputMaybe<Scalars['ID']['input']>;
+  id_not?: InputMaybe<Scalars['ID']['input']>;
+  id_gt?: InputMaybe<Scalars['ID']['input']>;
+  id_lt?: InputMaybe<Scalars['ID']['input']>;
+  id_gte?: InputMaybe<Scalars['ID']['input']>;
+  id_lte?: InputMaybe<Scalars['ID']['input']>;
+  id_in?: InputMaybe<Array<Scalars['ID']['input']>>;
+  id_not_in?: InputMaybe<Array<Scalars['ID']['input']>>;
+  creation?: InputMaybe<Scalars['String']['input']>;
+  creation_not?: InputMaybe<Scalars['String']['input']>;
+  creation_gt?: InputMaybe<Scalars['String']['input']>;
+  creation_lt?: InputMaybe<Scalars['String']['input']>;
+  creation_gte?: InputMaybe<Scalars['String']['input']>;
+  creation_lte?: InputMaybe<Scalars['String']['input']>;
+  creation_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  creation_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  creation_contains?: InputMaybe<Scalars['String']['input']>;
+  creation_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  creation_not_contains?: InputMaybe<Scalars['String']['input']>;
+  creation_not_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  creation_starts_with?: InputMaybe<Scalars['String']['input']>;
+  creation_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  creation_not_starts_with?: InputMaybe<Scalars['String']['input']>;
+  creation_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  creation_ends_with?: InputMaybe<Scalars['String']['input']>;
+  creation_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  creation_not_ends_with?: InputMaybe<Scalars['String']['input']>;
+  creation_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  creation_?: InputMaybe<Audit_filter>;
+  lastModification?: InputMaybe<Scalars['String']['input']>;
+  lastModification_not?: InputMaybe<Scalars['String']['input']>;
+  lastModification_gt?: InputMaybe<Scalars['String']['input']>;
+  lastModification_lt?: InputMaybe<Scalars['String']['input']>;
+  lastModification_gte?: InputMaybe<Scalars['String']['input']>;
+  lastModification_lte?: InputMaybe<Scalars['String']['input']>;
+  lastModification_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  lastModification_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  lastModification_contains?: InputMaybe<Scalars['String']['input']>;
+  lastModification_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  lastModification_not_contains?: InputMaybe<Scalars['String']['input']>;
+  lastModification_not_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  lastModification_starts_with?: InputMaybe<Scalars['String']['input']>;
+  lastModification_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  lastModification_not_starts_with?: InputMaybe<Scalars['String']['input']>;
+  lastModification_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  lastModification_ends_with?: InputMaybe<Scalars['String']['input']>;
+  lastModification_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  lastModification_not_ends_with?: InputMaybe<Scalars['String']['input']>;
+  lastModification_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  lastModification_?: InputMaybe<Audit_filter>;
+  modifications?: InputMaybe<Array<Scalars['String']['input']>>;
+  modifications_not?: InputMaybe<Array<Scalars['String']['input']>>;
+  modifications_contains?: InputMaybe<Array<Scalars['String']['input']>>;
+  modifications_contains_nocase?: InputMaybe<Array<Scalars['String']['input']>>;
+  modifications_not_contains?: InputMaybe<Array<Scalars['String']['input']>>;
+  modifications_not_contains_nocase?: InputMaybe<Array<Scalars['String']['input']>>;
+  modifications_?: InputMaybe<Audit_filter>;
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<AuditInformation_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<AuditInformation_filter>>>;
+};
+
+export type AuditInformation_orderBy =
+  | 'id'
+  | 'creation'
+  | 'creation__id'
+  | 'creation__blockNumber'
+  | 'creation__transactionHash'
+  | 'creation__transactionTimestamp'
+  | 'creation__fromAddress'
+  | 'creation__toAddress'
+  | 'creation__valueTransferred'
+  | 'creation__gasPrice'
+  | 'lastModification'
+  | 'lastModification__id'
+  | 'lastModification__blockNumber'
+  | 'lastModification__transactionHash'
+  | 'lastModification__transactionTimestamp'
+  | 'lastModification__fromAddress'
+  | 'lastModification__toAddress'
+  | 'lastModification__valueTransferred'
+  | 'lastModification__gasPrice'
+  | 'modifications';
+
+export type Audit_filter = {
+  id?: InputMaybe<Scalars['ID']['input']>;
+  id_not?: InputMaybe<Scalars['ID']['input']>;
+  id_gt?: InputMaybe<Scalars['ID']['input']>;
+  id_lt?: InputMaybe<Scalars['ID']['input']>;
+  id_gte?: InputMaybe<Scalars['ID']['input']>;
+  id_lte?: InputMaybe<Scalars['ID']['input']>;
+  id_in?: InputMaybe<Array<Scalars['ID']['input']>>;
+  id_not_in?: InputMaybe<Array<Scalars['ID']['input']>>;
+  blockNumber?: InputMaybe<Scalars['BigInt']['input']>;
+  blockNumber_not?: InputMaybe<Scalars['BigInt']['input']>;
+  blockNumber_gt?: InputMaybe<Scalars['BigInt']['input']>;
+  blockNumber_lt?: InputMaybe<Scalars['BigInt']['input']>;
+  blockNumber_gte?: InputMaybe<Scalars['BigInt']['input']>;
+  blockNumber_lte?: InputMaybe<Scalars['BigInt']['input']>;
+  blockNumber_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  blockNumber_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  transactionHash?: InputMaybe<Scalars['Bytes']['input']>;
+  transactionHash_not?: InputMaybe<Scalars['Bytes']['input']>;
+  transactionHash_gt?: InputMaybe<Scalars['Bytes']['input']>;
+  transactionHash_lt?: InputMaybe<Scalars['Bytes']['input']>;
+  transactionHash_gte?: InputMaybe<Scalars['Bytes']['input']>;
+  transactionHash_lte?: InputMaybe<Scalars['Bytes']['input']>;
+  transactionHash_in?: InputMaybe<Array<Scalars['Bytes']['input']>>;
+  transactionHash_not_in?: InputMaybe<Array<Scalars['Bytes']['input']>>;
+  transactionHash_contains?: InputMaybe<Scalars['Bytes']['input']>;
+  transactionHash_not_contains?: InputMaybe<Scalars['Bytes']['input']>;
+  transactionTimestamp?: InputMaybe<Scalars['BigInt']['input']>;
+  transactionTimestamp_not?: InputMaybe<Scalars['BigInt']['input']>;
+  transactionTimestamp_gt?: InputMaybe<Scalars['BigInt']['input']>;
+  transactionTimestamp_lt?: InputMaybe<Scalars['BigInt']['input']>;
+  transactionTimestamp_gte?: InputMaybe<Scalars['BigInt']['input']>;
+  transactionTimestamp_lte?: InputMaybe<Scalars['BigInt']['input']>;
+  transactionTimestamp_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  transactionTimestamp_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  fromAddress?: InputMaybe<Scalars['Bytes']['input']>;
+  fromAddress_not?: InputMaybe<Scalars['Bytes']['input']>;
+  fromAddress_gt?: InputMaybe<Scalars['Bytes']['input']>;
+  fromAddress_lt?: InputMaybe<Scalars['Bytes']['input']>;
+  fromAddress_gte?: InputMaybe<Scalars['Bytes']['input']>;
+  fromAddress_lte?: InputMaybe<Scalars['Bytes']['input']>;
+  fromAddress_in?: InputMaybe<Array<Scalars['Bytes']['input']>>;
+  fromAddress_not_in?: InputMaybe<Array<Scalars['Bytes']['input']>>;
+  fromAddress_contains?: InputMaybe<Scalars['Bytes']['input']>;
+  fromAddress_not_contains?: InputMaybe<Scalars['Bytes']['input']>;
+  toAddress?: InputMaybe<Scalars['Bytes']['input']>;
+  toAddress_not?: InputMaybe<Scalars['Bytes']['input']>;
+  toAddress_gt?: InputMaybe<Scalars['Bytes']['input']>;
+  toAddress_lt?: InputMaybe<Scalars['Bytes']['input']>;
+  toAddress_gte?: InputMaybe<Scalars['Bytes']['input']>;
+  toAddress_lte?: InputMaybe<Scalars['Bytes']['input']>;
+  toAddress_in?: InputMaybe<Array<Scalars['Bytes']['input']>>;
+  toAddress_not_in?: InputMaybe<Array<Scalars['Bytes']['input']>>;
+  toAddress_contains?: InputMaybe<Scalars['Bytes']['input']>;
+  toAddress_not_contains?: InputMaybe<Scalars['Bytes']['input']>;
+  valueTransferred?: InputMaybe<Scalars['BigInt']['input']>;
+  valueTransferred_not?: InputMaybe<Scalars['BigInt']['input']>;
+  valueTransferred_gt?: InputMaybe<Scalars['BigInt']['input']>;
+  valueTransferred_lt?: InputMaybe<Scalars['BigInt']['input']>;
+  valueTransferred_gte?: InputMaybe<Scalars['BigInt']['input']>;
+  valueTransferred_lte?: InputMaybe<Scalars['BigInt']['input']>;
+  valueTransferred_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  valueTransferred_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  gasPrice?: InputMaybe<Scalars['BigInt']['input']>;
+  gasPrice_not?: InputMaybe<Scalars['BigInt']['input']>;
+  gasPrice_gt?: InputMaybe<Scalars['BigInt']['input']>;
+  gasPrice_lt?: InputMaybe<Scalars['BigInt']['input']>;
+  gasPrice_gte?: InputMaybe<Scalars['BigInt']['input']>;
+  gasPrice_lte?: InputMaybe<Scalars['BigInt']['input']>;
+  gasPrice_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  gasPrice_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  /** Filter for the block changed event. */
+  _change_block?: InputMaybe<BlockChangedFilter>;
+  and?: InputMaybe<Array<InputMaybe<Audit_filter>>>;
+  or?: InputMaybe<Array<InputMaybe<Audit_filter>>>;
+};
+
+export type Audit_orderBy =
+  | 'id'
+  | 'blockNumber'
+  | 'transactionHash'
+  | 'transactionTimestamp'
+  | 'fromAddress'
+  | 'toAddress'
+  | 'valueTransferred'
+  | 'gasPrice';
 
 export type BlockChangedFilter = {
   number_gte: Scalars['Int']['input'];
@@ -285,6 +522,7 @@ export type Counter_orderBy =
 
 export type Issuer = {
   id: Scalars['ID']['output'];
+  auditInformation: AuditInformation;
 };
 
 export type Issuer_filter = {
@@ -296,6 +534,27 @@ export type Issuer_filter = {
   id_lte?: InputMaybe<Scalars['ID']['input']>;
   id_in?: InputMaybe<Array<Scalars['ID']['input']>>;
   id_not_in?: InputMaybe<Array<Scalars['ID']['input']>>;
+  auditInformation?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_not?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_gt?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_lt?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_gte?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_lte?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  auditInformation_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  auditInformation_contains?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_not_contains?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_not_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_starts_with?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_not_starts_with?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_ends_with?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_not_ends_with?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_?: InputMaybe<AuditInformation_filter>;
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
   and?: InputMaybe<Array<InputMaybe<Issuer_filter>>>;
@@ -303,13 +562,16 @@ export type Issuer_filter = {
 };
 
 export type Issuer_orderBy =
-  | 'id';
+  | 'id'
+  | 'auditInformation'
+  | 'auditInformation__id';
 
 export type Module = {
   id: Scalars['ID']['output'];
   moduleAddress: Scalars['Bytes']['output'];
   name: Scalars['String']['output'];
   description: Scalars['String']['output'];
+  auditInformation: AuditInformation;
 };
 
 export type Module_filter = {
@@ -371,6 +633,27 @@ export type Module_filter = {
   description_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
   description_not_ends_with?: InputMaybe<Scalars['String']['input']>;
   description_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  auditInformation?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_not?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_gt?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_lt?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_gte?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_lte?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  auditInformation_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  auditInformation_contains?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_not_contains?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_not_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_starts_with?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_not_starts_with?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_ends_with?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_not_ends_with?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_?: InputMaybe<AuditInformation_filter>;
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
   and?: InputMaybe<Array<InputMaybe<Module_filter>>>;
@@ -381,7 +664,9 @@ export type Module_orderBy =
   | 'id'
   | 'moduleAddress'
   | 'name'
-  | 'description';
+  | 'description'
+  | 'auditInformation'
+  | 'auditInformation__id';
 
 /** Defines the order direction, either ascending or descending */
 export type OrderDirection =
@@ -397,6 +682,7 @@ export type Portal = {
   description: Scalars['String']['output'];
   ownerName: Scalars['String']['output'];
   attestationCounter?: Maybe<Scalars['Int']['output']>;
+  auditInformation: AuditInformation;
 };
 
 export type Portal_filter = {
@@ -496,6 +782,27 @@ export type Portal_filter = {
   attestationCounter_lte?: InputMaybe<Scalars['Int']['input']>;
   attestationCounter_in?: InputMaybe<Array<Scalars['Int']['input']>>;
   attestationCounter_not_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  auditInformation?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_not?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_gt?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_lt?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_gte?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_lte?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  auditInformation_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  auditInformation_contains?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_not_contains?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_not_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_starts_with?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_not_starts_with?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_ends_with?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_not_ends_with?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_?: InputMaybe<AuditInformation_filter>;
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
   and?: InputMaybe<Array<InputMaybe<Portal_filter>>>;
@@ -510,7 +817,9 @@ export type Portal_orderBy =
   | 'name'
   | 'description'
   | 'ownerName'
-  | 'attestationCounter';
+  | 'attestationCounter'
+  | 'auditInformation'
+  | 'auditInformation__id';
 
 export type Query = {
   attestation?: Maybe<Attestation>;
@@ -527,6 +836,10 @@ export type Query = {
   issuers: Array<Issuer>;
   registryVersion?: Maybe<RegistryVersion>;
   registryVersions: Array<RegistryVersion>;
+  auditInformation?: Maybe<AuditInformation>;
+  auditInformations: Array<AuditInformation>;
+  audit?: Maybe<Audit>;
+  audits: Array<Audit>;
   /** Access to subgraph metadata */
   _meta?: Maybe<_Meta_>;
 };
@@ -658,6 +971,42 @@ export type QueryregistryVersionsArgs = {
 };
 
 
+export type QueryauditInformationArgs = {
+  id: Scalars['ID']['input'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryauditInformationsArgs = {
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<AuditInformation_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<AuditInformation_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryauditArgs = {
+  id: Scalars['ID']['input'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type QueryauditsArgs = {
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<Audit_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<Audit_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
 export type Query_metaArgs = {
   block?: InputMaybe<Block_height>;
 };
@@ -666,6 +1015,7 @@ export type RegistryVersion = {
   id: Scalars['ID']['output'];
   versionNumber?: Maybe<Scalars['Int']['output']>;
   timestamp?: Maybe<Scalars['BigInt']['output']>;
+  auditInformation: AuditInformation;
 };
 
 export type RegistryVersion_filter = {
@@ -693,6 +1043,27 @@ export type RegistryVersion_filter = {
   timestamp_lte?: InputMaybe<Scalars['BigInt']['input']>;
   timestamp_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
   timestamp_not_in?: InputMaybe<Array<Scalars['BigInt']['input']>>;
+  auditInformation?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_not?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_gt?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_lt?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_gte?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_lte?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  auditInformation_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  auditInformation_contains?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_not_contains?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_not_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_starts_with?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_not_starts_with?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_ends_with?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_not_ends_with?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_?: InputMaybe<AuditInformation_filter>;
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
   and?: InputMaybe<Array<InputMaybe<RegistryVersion_filter>>>;
@@ -702,7 +1073,9 @@ export type RegistryVersion_filter = {
 export type RegistryVersion_orderBy =
   | 'id'
   | 'versionNumber'
-  | 'timestamp';
+  | 'timestamp'
+  | 'auditInformation'
+  | 'auditInformation__id';
 
 export type Schema = {
   id: Scalars['ID']['output'];
@@ -711,6 +1084,7 @@ export type Schema = {
   context: Scalars['String']['output'];
   schema: Scalars['String']['output'];
   attestationCounter?: Maybe<Scalars['Int']['output']>;
+  auditInformation: AuditInformation;
 };
 
 export type Schema_filter = {
@@ -810,6 +1184,27 @@ export type Schema_filter = {
   attestationCounter_lte?: InputMaybe<Scalars['Int']['input']>;
   attestationCounter_in?: InputMaybe<Array<Scalars['Int']['input']>>;
   attestationCounter_not_in?: InputMaybe<Array<Scalars['Int']['input']>>;
+  auditInformation?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_not?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_gt?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_lt?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_gte?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_lte?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  auditInformation_not_in?: InputMaybe<Array<Scalars['String']['input']>>;
+  auditInformation_contains?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_not_contains?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_not_contains_nocase?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_starts_with?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_not_starts_with?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_not_starts_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_ends_with?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_not_ends_with?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_not_ends_with_nocase?: InputMaybe<Scalars['String']['input']>;
+  auditInformation_?: InputMaybe<AuditInformation_filter>;
   /** Filter for the block changed event. */
   _change_block?: InputMaybe<BlockChangedFilter>;
   and?: InputMaybe<Array<InputMaybe<Schema_filter>>>;
@@ -822,7 +1217,9 @@ export type Schema_orderBy =
   | 'description'
   | 'context'
   | 'schema'
-  | 'attestationCounter';
+  | 'attestationCounter'
+  | 'auditInformation'
+  | 'auditInformation__id';
 
 export type Subscription = {
   attestation?: Maybe<Attestation>;
@@ -839,6 +1236,10 @@ export type Subscription = {
   issuers: Array<Issuer>;
   registryVersion?: Maybe<RegistryVersion>;
   registryVersions: Array<RegistryVersion>;
+  auditInformation?: Maybe<AuditInformation>;
+  auditInformations: Array<AuditInformation>;
+  audit?: Maybe<Audit>;
+  audits: Array<Audit>;
   /** Access to subgraph metadata */
   _meta?: Maybe<_Meta_>;
 };
@@ -970,6 +1371,42 @@ export type SubscriptionregistryVersionsArgs = {
 };
 
 
+export type SubscriptionauditInformationArgs = {
+  id: Scalars['ID']['input'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionauditInformationsArgs = {
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<AuditInformation_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<AuditInformation_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionauditArgs = {
+  id: Scalars['ID']['input'];
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
+export type SubscriptionauditsArgs = {
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  orderBy?: InputMaybe<Audit_orderBy>;
+  orderDirection?: InputMaybe<OrderDirection>;
+  where?: InputMaybe<Audit_filter>;
+  block?: InputMaybe<Block_height>;
+  subgraphError?: _SubgraphErrorPolicy_;
+};
+
+
 export type Subscription_metaArgs = {
   block?: InputMaybe<Block_height>;
 };
@@ -1036,6 +1473,14 @@ export type _SubgraphErrorPolicy_ =
   registryVersion: InContextSdkMethod<Query['registryVersion'], QueryregistryVersionArgs, MeshContext>,
   /** null **/
   registryVersions: InContextSdkMethod<Query['registryVersions'], QueryregistryVersionsArgs, MeshContext>,
+  /** null **/
+  auditInformation: InContextSdkMethod<Query['auditInformation'], QueryauditInformationArgs, MeshContext>,
+  /** null **/
+  auditInformations: InContextSdkMethod<Query['auditInformations'], QueryauditInformationsArgs, MeshContext>,
+  /** null **/
+  audit: InContextSdkMethod<Query['audit'], QueryauditArgs, MeshContext>,
+  /** null **/
+  audits: InContextSdkMethod<Query['audits'], QueryauditsArgs, MeshContext>,
   /** Access to subgraph metadata **/
   _meta: InContextSdkMethod<Query['_meta'], Query_metaArgs, MeshContext>
   };
@@ -1073,6 +1518,14 @@ export type _SubgraphErrorPolicy_ =
   registryVersion: InContextSdkMethod<Subscription['registryVersion'], SubscriptionregistryVersionArgs, MeshContext>,
   /** null **/
   registryVersions: InContextSdkMethod<Subscription['registryVersions'], SubscriptionregistryVersionsArgs, MeshContext>,
+  /** null **/
+  auditInformation: InContextSdkMethod<Subscription['auditInformation'], SubscriptionauditInformationArgs, MeshContext>,
+  /** null **/
+  auditInformations: InContextSdkMethod<Subscription['auditInformations'], SubscriptionauditInformationsArgs, MeshContext>,
+  /** null **/
+  audit: InContextSdkMethod<Subscription['audit'], SubscriptionauditArgs, MeshContext>,
+  /** null **/
+  audits: InContextSdkMethod<Subscription['audits'], SubscriptionauditsArgs, MeshContext>,
   /** Access to subgraph metadata **/
   _meta: InContextSdkMethod<Subscription['_meta'], Subscription_metaArgs, MeshContext>
   };

--- a/sdk/.graphclientrc.yml
+++ b/sdk/.graphclientrc.yml
@@ -3,4 +3,4 @@ sources:
   - name: linea-attestation-registry
     handler:
       graphql:
-        endpoint: https://api.studio.thegraph.com/query/67521/verax-v1-linea/v0.0.1
+        endpoint: https://api.studio.thegraph.com/query/67521/verax-v2-linea/v0.0.1

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verax-attestation-registry/verax-sdk",
-  "version": "1.11.1",
+  "version": "2.0.0-beta.4",
   "description": "Verax Attestation Registry SDK to interact with the subgraph and the contracts",
   "keywords": [
     "linea-attestation-registry",

--- a/sdk/src/VeraxSdk.ts
+++ b/sdk/src/VeraxSdk.ts
@@ -26,8 +26,8 @@ export class VeraxSdk {
   static DEFAULT_LINEA_MAINNET: Conf = {
     chain: linea,
     mode: SDKMode.BACKEND,
-    subgraphUrl: "https://api.studio.thegraph.com/query/67521/verax-v1-linea/v0.0.1",
-    // Backup URL: subgraphUrl: "https://graph-query.linea.build/subgraphs/name/Consensys/linea-attestation-registry",
+    subgraphUrl: "https://api.studio.thegraph.com/query/67521/verax-v2-linea/v0.0.1",
+    // Backup URL: subgraphUrl: "https://api.goldsky.com/api/public/project_clxx488osyuf501vygg71f86w/subgraphs/verax-v2-linea/0.0.1/gn",
     portalRegistryAddress: "0xd5d61e4ECDf6d46A63BfdC262af92544DFc19083",
     moduleRegistryAddress: "0xf851513A732996F22542226341748f3C9978438f",
     schemaRegistryAddress: "0x0f95dCec4c7a93F2637eb13b655F2223ea036B59",
@@ -43,7 +43,7 @@ export class VeraxSdk {
     chain: arbitrumNova,
     mode: SDKMode.BACKEND,
     subgraphUrl:
-      "https://api.goldsky.com/api/public/project_clwsa54350ydv01wjbq5r17v1/subgraphs/verax-v1-arbitrum-nova/0.0.4/gn",
+      "https://api.goldsky.com/api/public/project_cm06hsedxpgls01xm39r67el8/subgraphs/verax-v2-arbitrum-nova/0.0.1/gn",
     portalRegistryAddress: "0xADc8da3d3388dEe74C7134fC4AEe1cF866Da5d38",
     moduleRegistryAddress: "0x46F7471cd2C1d69Cb5e62c1a34F3fCAf81304Fc3",
     schemaRegistryAddress: "0x9b5BABcEbf0E8550da1eCDe5674783179B6557FB",
@@ -58,7 +58,7 @@ export class VeraxSdk {
   static DEFAULT_LINEA_SEPOLIA: Conf = {
     chain: lineaSepolia,
     mode: SDKMode.BACKEND,
-    subgraphUrl: "https://api.studio.thegraph.com/query/67521/verax-v1-linea-sepolia/v0.0.12",
+    subgraphUrl: "https://api.studio.thegraph.com/query/67521/verax-v2-linea-sepolia/v0.0.2",
     portalRegistryAddress: "0xF35fe79104e157703dbCC3Baa72a81A99591744D",
     moduleRegistryAddress: "0x3C443B9f0c8ed3A3270De7A4815487BA3223C2Fa",
     schemaRegistryAddress: "0x90b8542d7288a83EC887229A7C727989C3b56209",
@@ -73,7 +73,7 @@ export class VeraxSdk {
   static DEFAULT_ARBITRUM_SEPOLIA: Conf = {
     chain: arbitrumSepolia,
     mode: SDKMode.BACKEND,
-    subgraphUrl: "https://api.studio.thegraph.com/query/67521/verax-v1-arbitrum-sepolia/v0.0.2",
+    subgraphUrl: "https://api.studio.thegraph.com/query/67521/verax-v2-arbitrum-sepolia/v0.0.2",
     portalRegistryAddress: "0x1ceb52584B6C45C7049dc7fDC476bC138E4beaDE",
     moduleRegistryAddress: "0xEC572277d4E87a64DcfA774ED219Dd4E69E4BDc6",
     schemaRegistryAddress: "0x025531b655D9EE335B8E6cc4C118b313f26ACc8F",
@@ -88,7 +88,7 @@ export class VeraxSdk {
   static DEFAULT_ARBITRUM: Conf = {
     chain: arbitrum,
     mode: SDKMode.BACKEND,
-    subgraphUrl: "https://api.studio.thegraph.com/query/67521/verax-v1-arbitrum/v0.0.1",
+    subgraphUrl: "https://api.studio.thegraph.com/query/67521/verax-v2-arbitrum/v0.0.2",
     portalRegistryAddress: "0x4042D0A54f997EE3a1b0F51e4813654199BFd8bD",
     moduleRegistryAddress: "0x3acF4daAB6cbc01546Dd4a96c9665B398d48A4ba",
     schemaRegistryAddress: "0xE96072F46EA0e42e538762dDc0aFa4ED8AE6Ec27",
@@ -103,7 +103,7 @@ export class VeraxSdk {
   static DEFAULT_BASE_SEPOLIA: Conf = {
     chain: baseSepolia,
     mode: SDKMode.BACKEND,
-    subgraphUrl: "https://api.studio.thegraph.com/query/67521/verax-v1-base-sepolia/v0.0.2",
+    subgraphUrl: "https://api.studio.thegraph.com/query/67521/verax-v2-base-sepolia/v0.0.2",
     portalRegistryAddress: "0x025531b655D9EE335B8E6cc4C118b313f26ACc8F",
     moduleRegistryAddress: "0xEC572277d4E87a64DcfA774ED219Dd4E69E4BDc6",
     schemaRegistryAddress: "0x66D2F3DCc970343b83a6263E20832184fa71CFe7",
@@ -118,7 +118,7 @@ export class VeraxSdk {
   static DEFAULT_BASE: Conf = {
     chain: base,
     mode: SDKMode.BACKEND,
-    subgraphUrl: "https://api.studio.thegraph.com/query/67521/verax-v1-base/v0.0.2",
+    subgraphUrl: "https://api.studio.thegraph.com/query/67521/verax-v2-base/v0.0.1",
     portalRegistryAddress: "0xcbf28432C25B400E645F0EaC05F8954e8EE7c0d6",
     moduleRegistryAddress: "0xAd0C12db58098A6665CBEf48f60eB67d81d1F1ff",
     schemaRegistryAddress: "0x8081dCd745f160c148Eb5be510F78628A0951c31",
@@ -133,7 +133,7 @@ export class VeraxSdk {
   static DEFAULT_BSC_TESTNET: Conf = {
     chain: bscTestnet,
     mode: SDKMode.BACKEND,
-    subgraphUrl: "https://api.studio.thegraph.com/query/67521/verax-v1-bsc-testnet/v0.0.1",
+    subgraphUrl: "https://api.studio.thegraph.com/query/67521/verax-v2-bsc-testnet/v0.0.1",
     portalRegistryAddress: "0xA4a7517F62216BD42e42a67dF09C25adc72A5897",
     moduleRegistryAddress: "0x6c46c245918d4fcfC13F0a9e2e49d4E2739A353a",
     schemaRegistryAddress: "0x51929da151eC2C5a5881C750E5b9941eACC46c1d",
@@ -148,7 +148,7 @@ export class VeraxSdk {
   static DEFAULT_BSC: Conf = {
     chain: bsc,
     mode: SDKMode.BACKEND,
-    subgraphUrl: "https://api.studio.thegraph.com/query/67521/verax-v1-bsc/v0.0.1",
+    subgraphUrl: "https://api.studio.thegraph.com/query/67521/verax-v2-bsc/v0.0.1",
     portalRegistryAddress: "0xb2553A7E443DFA7C9dEc01D327FdDff1A5eF59b0",
     moduleRegistryAddress: "0xD70a06f7A0f197D55Fa841fcF668782b2B8266eB",
     schemaRegistryAddress: "0x29205492435E1b06B20CeAeEC4AC41bcF595DFFd",

--- a/sdk/src/dataMapper/AttestationDataMapper.ts
+++ b/sdk/src/dataMapper/AttestationDataMapper.ts
@@ -17,19 +17,35 @@ export default class AttestationDataMapper extends BaseDataMapper<
   typeName = "attestation";
   gqlInterface = `{
             id
-            schemaId
             replacedBy
             attester
-            portal
             attestedDate
             expirationDate
             revocationDate
             version
             revoked
             subject
+            encodedSubject
             attestationData
-            schemaString
             decodedData
+            schema {
+                id
+                name
+                description
+                context
+                schema
+                attestationCounter
+            }
+            portal {
+                id
+                ownerAddress
+                modules
+                isRevocable
+                name
+                description
+                ownerName
+                attestationCounter
+            }
   }`;
 
   override async findOneById(id: string) {
@@ -58,8 +74,7 @@ export default class AttestationDataMapper extends BaseDataMapper<
   }
 
   private async enrichAttestation(attestation: Attestation) {
-    const schema = (await this.veraxSdk.schema.findOneById(attestation.schemaId)) as Schema;
-    attestation.decodedPayload = decodeWithRetry(schema.schema, attestation.attestationData as Hex);
+    attestation.decodedPayload = decodeWithRetry(attestation.schema.schema, attestation.attestationData as Hex);
 
     attestation.attestedDate = Number(attestation.attestedDate);
     attestation.expirationDate = Number(attestation.expirationDate);
@@ -67,8 +82,8 @@ export default class AttestationDataMapper extends BaseDataMapper<
 
     attestation.version = Number(attestation.version);
 
-    // Check if data is stored offchain
-    if (attestation.schemaId === Constants.OFFCHAIN_DATA_SCHEMA_ID) {
+    // Check if data is stored off-chain
+    if (attestation.schema.id === Constants.OFFCHAIN_DATA_SCHEMA_ID) {
       attestation.offchainData = {
         schemaId: (attestation.decodedPayload as OffchainData[])[0].schemaId,
         uri: (attestation.decodedPayload as OffchainData[])[0].uri,
@@ -79,10 +94,10 @@ export default class AttestationDataMapper extends BaseDataMapper<
           const ipfsHash = attestation.offchainData.uri.split("//")[1];
           const response = await getIPFSContent(ipfsHash);
           if (response.toString().startsWith("0x")) {
-            const offchainDataSchema = (await this.veraxSdk.schema.findOneById(
+            const offChainDataSchema = (await this.veraxSdk.schema.findOneById(
               attestation.offchainData.schemaId,
             )) as Schema;
-            attestation.decodedPayload = decodeWithRetry(offchainDataSchema.schema, attestation.attestationData as Hex);
+            attestation.decodedPayload = decodeWithRetry(offChainDataSchema.schema, attestation.attestationData as Hex);
           } else {
             attestation.decodedPayload = response as unknown as object;
           }
@@ -99,7 +114,7 @@ export default class AttestationDataMapper extends BaseDataMapper<
       undefined,
       {
         attestationData_contains: id,
-        schemaId_in: [Constants.RELATIONSHIP_SCHEMA_ID, Constants.NAMED_GRAPH_RELATIONSHIP_SCHEMA_ID],
+        schema_in: [Constants.RELATIONSHIP_SCHEMA_ID, Constants.NAMED_GRAPH_RELATIONSHIP_SCHEMA_ID],
       },
       undefined,
       undefined,

--- a/sdk/src/types/index.ts
+++ b/sdk/src/types/index.ts
@@ -20,7 +20,6 @@ export type AttestationPayload = {
 
 export type Attestation = OnChainAttestation & {
   id: string;
-  schemaString: string;
   decodedData: string[];
   decodedPayload: object;
   offchainData?: OffchainData;
@@ -30,10 +29,10 @@ export type OffchainData = { schemaId: string; uri: string; error?: string };
 
 export type OnChainAttestation = {
   attestationId: string; // The unique identifier of the attestation.
-  schemaId: string; // The identifier of the schema this attestation adheres to.
+  schema: Schema; // The Schema this attestation adheres to.
   replacedBy: string | null; // Whether the attestation was replaced by a new one.
   attester: Address; // The address issuing the attestation to the subject.
-  portal: Address; // The id of the portal that created the attestation.
+  portal: Portal; // The Portal that created the attestation.
   attestedDate: number; // The date the attestation is issued.
   expirationDate: number; // The expiration date of the attestation.
   revocationDate: number | null; // The date when the attestation was revoked.

--- a/sdk/test/integration/Attestation.integration.test.ts
+++ b/sdk/test/integration/Attestation.integration.test.ts
@@ -15,10 +15,24 @@ describe("AttestationDataMapper", () => {
 
       expect(result).not.toBeUndefined();
       expect(result?.id).toEqual(attestationId);
-      expect(result?.schemaId).toEqual("0x5dc8bc9158dd69ee8a234bb8f9ab1f4f17bb52c84b6fd4720d58ec82bb43d2f5");
+      expect(result?.schema.id).toEqual("0x5dc8bc9158dd69ee8a234bb8f9ab1f4f17bb52c84b6fd4720d58ec82bb43d2f5");
+      expect(result?.schema.name).toEqual("Token Balance");
+      expect(result?.schema.description).toEqual("Describes a balance owned on a contract");
+      expect(result?.schema.context).toEqual(
+        "Describes a token balance owned on a contract (ERC-20, ERC-721, ERC-1155, etc.)",
+      );
+      expect(result?.schema.schema).toEqual("(address contract, uint256 balance)");
+      expect(result?.schema.attestationCounter).toBeGreaterThanOrEqual(26);
       expect(result?.replacedBy).toEqual("0x0000000000000000000000000000000000000000000000000000000000000000");
       expect(result?.attester).toEqual("0x6ecfd8252c19ac2bf4bd1cbdc026c001c93e179d");
-      expect(result?.portal).toEqual("0x0cb56f201e7afe02e542e2d2d42c34d4ce7203f7");
+      expect(result?.portal.id).toEqual("0x0cb56f201e7afe02e542e2d2d42c34d4ce7203f7");
+      expect(result?.portal.name).toEqual("eFrogs Portal");
+      expect(result?.portal.description).toEqual("eFrogs attestations");
+      expect(result?.portal.modules).toEqual([]);
+      expect(result?.portal.isRevocable).toBeTruthy();
+      expect(result?.portal.attestationCounter).toBeGreaterThanOrEqual(26);
+      expect(result?.portal.ownerAddress).toEqual("0x6ecfd8252c19ac2bf4bd1cbdc026c001c93e179d");
+      expect(result?.portal.ownerName).toEqual("alainnicolas.eth");
       expect(result?.attestedDate).toEqual(1718025507);
       expect(result?.expirationDate).toEqual(1720617499);
       expect(result?.revocationDate).toEqual(0);
@@ -28,7 +42,6 @@ describe("AttestationDataMapper", () => {
       expect(result?.attestationData).toEqual(
         "0x00000000000000000000000035c134262605bc69b3383ea132a077d09d8df0610000000000000000000000000000000000000000000000000000000000000006",
       );
-      expect(result?.schemaString).toEqual("address,uint256");
       expect(result?.decodedData).toEqual(["0x35c134262605bc69b3383ea132a077d09d8df061", "0x6"]);
       expect(result?.decodedPayload).toEqual([
         {


### PR DESCRIPTION
## What does this PR do?

1. Migrates the SDK from subgraph v1 to subgraph v2
2. Upgrades the SDK for the explorer

Consequences:

- Breaking changes with a new `Attestation` type
- Way less calls to the subgraph to get Attestations (from up to 301 calls to display 100 Attestations to only 1 call)

Remaining work:

- [x] Deploy SDK v2 on npm with the 'beta' tag
- [x] Replace all the subgraph v1 URLs to subgraph v2 URLs in the SDK configs
- [x] Improve the integration tests at the SDK level
- [ ] Warn the builders of the breaking changes

### Related ticket

Fixes #585 

### Type of change

- [ ] Chore
- [ ] Bug fix
- [X] New feature
- [ ] Documentation update

## Check list

- [ ] Unit tests for any smart contract change
- [ ] Contracts and functions are documented
