### PR TITLE
fix(explorer): The Explorer doesn't correctly display the list of Attestations on all networks

### DIFF
--- a/explorer/src/config/index.tsx
+++ b/explorer/src/config/index.tsx
@@ -58,6 +58,7 @@ const chains: INetwork[] = [
     img: <LineaMainnetIcon />,
     imgDark: <LineaMainnetIconDark />,
     network: "linea",
+    prefix: "0x0000",
   },
   {
     name: "Linea Sepolia",
@@ -65,6 +66,7 @@ const chains: INetwork[] = [
     veraxEnv: VeraxSdk.DEFAULT_LINEA_SEPOLIA_FRONTEND,
     img: <LineaSepoliaIcon />,
     network: "linea-sepolia",
+    prefix: "0x0000",
   },
   {
     name: "Arbitrum",
@@ -73,6 +75,7 @@ const chains: INetwork[] = [
     img: <ArbitrumIcon />,
     imgDark: <ArbitrumIconDark />,
     network: "arbitrum",
+    prefix: "0x0001",
   },
   {
     name: "Arbitrum Sepolia",
@@ -80,6 +83,7 @@ const chains: INetwork[] = [
     veraxEnv: VeraxSdk.DEFAULT_ARBITRUM_SEPOLIA_FRONTEND,
     img: <ArbitrumSepoliaIcon />,
     network: "arbitrum-sepolia",
+    prefix: "0x0001",
   },
   {
     name: "Arbitrum Nova",
@@ -88,6 +92,7 @@ const chains: INetwork[] = [
     img: <ArbitrumNovaIcon />,
     imgDark: <ArbitrumNovaIconDark />,
     network: "arbitrum-nova",
+    prefix: "0x0002",
   },
   {
     name: "Base Mainnet",
@@ -96,6 +101,7 @@ const chains: INetwork[] = [
     img: <BaseMainnetIcon />,
     imgDark: <BaseIconDark />,
     network: "base-mainnet",
+    prefix: "0x0005",
   },
   {
     name: "Base Sepolia",
@@ -103,6 +109,7 @@ const chains: INetwork[] = [
     veraxEnv: VeraxSdk.DEFAULT_BASE_SEPOLIA_FRONTEND,
     img: <BaseSepoliaIcon />,
     network: "base-sepolia",
+    prefix: "0x0005",
   },
   {
     name: "BSC Mainnet",
@@ -111,6 +118,7 @@ const chains: INetwork[] = [
     img: <BscMainnetIcon />,
     imgDark: <BscMainnetIconDark />,
     network: "bsc-mainnet",
+    prefix: "0x0006",
   },
   {
     name: "BSC Testnet",
@@ -118,6 +126,7 @@ const chains: INetwork[] = [
     veraxEnv: VeraxSdk.DEFAULT_BSC_TESTNET_FRONTEND,
     img: <BscTestnetIcon />,
     network: "bsc-testnet",
+    prefix: "0x0006",
   },
 ];
 

--- a/explorer/src/interfaces/config/index.ts
+++ b/explorer/src/interfaces/config/index.ts
@@ -1,4 +1,5 @@
 import { Conf } from "@verax-attestation-registry/verax-sdk";
+import { Hex } from "viem";
 import { Chain } from "wagmi";
 
 export interface INetwork {
@@ -8,4 +9,5 @@ export interface INetwork {
   img: JSX.Element;
   imgDark?: JSX.Element;
   network: string;
+  prefix: Hex;
 }

--- a/explorer/src/utils/attestationIdUtils.ts
+++ b/explorer/src/utils/attestationIdUtils.ts
@@ -1,0 +1,8 @@
+import { Hex } from "viem";
+import { numberToHex } from "viem/utils";
+
+export const buildAttestationId = (rawNumberId: number, chainPrefix: Hex): Hex => {
+  const rawId = numberToHex(rawNumberId, { size: 32 });
+  const idWithoutPrefix = rawId.slice(6);
+  return `${chainPrefix}${idWithoutPrefix}`;
+};


### PR DESCRIPTION
## What does this PR do?

- Displays the latest Attestation which was hidden
- Displays Attestations on networks other than Linea

### Related ticket

Fixes #697 

### Type of change

- [ ] Chore
- [X] Bug fix
- [ ] New feature
- [ ] Documentation update

## Check list

- [ ] Unit tests for any smart contract change
- [ ] Contracts and functions are documented
