### PR TITLE
fix(explorer): The Explorer doesn't correctly display the list of Attestations on all networks

### DIFF
--- a/explorer/src/constants/regex/index.ts
+++ b/explorer/src/constants/regex/index.ts
@@ -6,6 +6,8 @@ export const regexEthAddress = {
   by0x: /^0x/,
 };
 
+export const isNumber = /^\d+$/;
+
 export const urlRegex = /^(https?:\/\/)?(www\.)?([a-zA-Z0-9-]+(\.[a-zA-Z]{2,})+)(\/[^\s]*)?$/;
 
 export const schemaRegex =

--- a/explorer/src/pages/Search/index.tsx
+++ b/explorer/src/pages/Search/index.tsx
@@ -9,6 +9,7 @@ import { EMPTY_STRING } from "@/constants";
 import { DEFAULT_SEARCH_ELEMENTS } from "@/constants/components";
 import { EQueryParams } from "@/enums/queryParams";
 import { Page, SearchElementProps } from "@/interfaces/components";
+import { useNetworkContext } from "@/providers/network-provider/context.ts";
 import { parseSearch } from "@/utils/searchUtils";
 
 import { SearchAttestationsReceived } from "./components/SearchAttestationsReceived";
@@ -20,7 +21,10 @@ import { SearchSchemas } from "./components/SearchSchemas";
 export const Search = () => {
   const [searchParams] = useSearchParams();
   const search = searchParams.get(EQueryParams.SEARCH_QUERY);
-  const parsedString = useMemo(() => parseSearch(search), [search]);
+  const {
+    network: { prefix },
+  } = useNetworkContext();
+  const parsedString = useMemo(() => parseSearch(search, prefix), [search, prefix]);
 
   const [searchElements, setSearchElements] = useState<SearchElementProps>(DEFAULT_SEARCH_ELEMENTS);
   const [notFound, setNotFound] = useState(false);


### PR DESCRIPTION
## What does this PR do?

Search by Attestation ID, written in decimal instead of only hexadecimal

Note: Needs #698 to be merged first

### Related ticket

Fixes #514 

### Type of change

- [ ] Chore
- [X] Bug fix
- [ ] New feature
- [ ] Documentation update

## Check list

- [ ] Unit tests for any smart contract change
- [ ] Contracts and functions are documented
