### PR TITLE
feat(contracts): As a developer, I want to have a PausablePortal example

### DIFF
--- a/contracts/src/examples/portals/PausablePortal.sol
+++ b/contracts/src/examples/portals/PausablePortal.sol
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.21;
+
+import { Pausable } from "@openzeppelin/contracts/security/Pausable.sol";
+import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
+import { IERC165 } from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
+import { AbstractPortal } from "../../abstracts/AbstractPortal.sol";
+import { Attestation, AttestationPayload } from "../../types/Structs.sol";
+import { IPortal } from "../../interfaces/IPortal.sol";
+
+/**
+ * @title Pausable Portal
+ * @author Consensys
+ * @notice This Portal aims to be pausable to prevent any attestation to be added in case of emergency
+ */
+contract PausablePortal is AbstractPortal, Pausable, Ownable {
+  /**
+   * @notice Contract constructor
+   * @param modules list of modules to use for the portal (can be empty)
+   * @param router Router's address
+   * @dev This sets the addresses for the AttestationRegistry, ModuleRegistry and PortalRegistry
+   */
+  constructor(address[] memory modules, address router) AbstractPortal(modules, router) Ownable() {}
+
+  /**
+   * @dev Pauses the contract.
+   * See {Pausable-_pause}.
+   * Can only be called by the owner.
+   */
+  function pause() external onlyOwner {
+    _pause();
+  }
+
+  /**
+   * @dev Unpauses the contract.
+   * See {Pausable-_unpause}.
+   * Can only be called by the owner.
+   */
+  function unpause() external onlyOwner {
+    _unpause();
+  }
+
+  /**
+   * @inheritdoc AbstractPortal
+   * @dev By default, this Portal does not have any withdrawal logic
+   */
+  function withdraw(address payable to, uint256 amount) external virtual override {}
+
+  /**
+   * @inheritdoc AbstractPortal
+   */
+  function _onAttest(
+    AttestationPayload memory attestationPayload,
+    address attester,
+    uint256 value
+  ) internal virtual override whenNotPaused {}
+
+  /**
+   * @inheritdoc AbstractPortal
+   */
+  function _onAttestV2(
+    AttestationPayload memory attestationPayload,
+    bytes[] memory validationPayloads,
+    uint256 value
+  ) internal virtual override whenNotPaused {}
+
+  /**
+   * @inheritdoc AbstractPortal
+   */
+  function _onBulkAttest(
+    AttestationPayload[] memory attestationsPayloads,
+    bytes[][] memory validationPayloads
+  ) internal virtual override whenNotPaused {}
+
+  /**
+   * @inheritdoc AbstractPortal
+   * @dev Only the owner of the portal can replace an attestation
+   */
+  function _onReplace(
+    bytes32 /*attestationId*/,
+    AttestationPayload memory /*attestationPayload*/,
+    address /*attester*/,
+    uint256 /*value*/
+  ) internal virtual override whenNotPaused {
+    if (msg.sender != portalRegistry.getPortalByAddress(address(this)).ownerAddress) revert OnlyPortalOwner();
+  }
+
+  /**
+   * @inheritdoc AbstractPortal
+   * @dev Only the owner of the portal can bulk replace attestations
+   */
+  function _onBulkReplace(
+    bytes32[] memory /*attestationIds*/,
+    AttestationPayload[] memory /*attestationsPayloads*/,
+    bytes[][] memory /*validationPayloads*/
+  ) internal virtual override whenNotPaused {
+    if (msg.sender != portalRegistry.getPortalByAddress(address(this)).ownerAddress) revert OnlyPortalOwner();
+  }
+
+  /**
+   * @inheritdoc AbstractPortal
+   * @dev Only the owner of the portal can revoke an attestation
+   */
+  function _onRevoke(bytes32 /*attestationId*/) internal virtual override whenNotPaused {
+    if (msg.sender != portalRegistry.getPortalByAddress(address(this)).ownerAddress) revert OnlyPortalOwner();
+  }
+
+  /**
+   * @inheritdoc AbstractPortal
+   * @dev Only the owner of the portal can bulk revoke attestations
+   */
+  function _onBulkRevoke(bytes32[] memory /*attestationIds*/) internal virtual override whenNotPaused {
+    if (msg.sender != portalRegistry.getPortalByAddress(address(this)).ownerAddress) revert OnlyPortalOwner();
+  }
+}

--- a/contracts/test/examples/portals/PausablePortal.t.sol
+++ b/contracts/test/examples/portals/PausablePortal.t.sol
@@ -1,0 +1,507 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.21;
+
+import { Test } from "forge-std/Test.sol";
+import { PausablePortal } from "../../../src/examples/portals/PausablePortal.sol";
+import { Router } from "../../../src/Router.sol";
+import { AbstractPortal } from "../../../src/abstracts/AbstractPortal.sol";
+import { AttestationPayload } from "../../../src/types/Structs.sol";
+import { AttestationRegistryMock } from "../../mocks/AttestationRegistryMock.sol";
+import { PortalRegistryMock } from "../../mocks/PortalRegistryMock.sol";
+import { ModuleRegistryMock } from "../../mocks/ModuleRegistryMock.sol";
+import { Pausable } from "@openzeppelin/contracts/security/Pausable.sol";
+import { IERC165 } from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
+
+contract PausablePortalTest is Test {
+  address portalOwner = makeAddr("portalOwner");
+  PausablePortal public pausablePortal;
+  address[] public modules = new address[](0);
+  ModuleRegistryMock public moduleRegistryMock = new ModuleRegistryMock();
+  AttestationRegistryMock public attestationRegistryMock = new AttestationRegistryMock();
+  PortalRegistryMock public portalRegistryMock = new PortalRegistryMock();
+  Router public router = new Router();
+
+  event Initialized(uint8 version);
+  event AttestationRegistered();
+  event AttestationReplaced();
+  event BulkAttestationsReplaced();
+  event BulkAttestationsRegistered();
+  event AttestationRevoked(bytes32 attestationId);
+  event BulkAttestationsRevoked(bytes32[] attestationId);
+
+  function setUp() public {
+    router.initialize();
+    router.updateModuleRegistry(address(moduleRegistryMock));
+    router.updateAttestationRegistry(address(attestationRegistryMock));
+    router.updatePortalRegistry(address(portalRegistryMock));
+
+    pausablePortal = new PausablePortal(modules, address(router));
+
+    vm.prank(portalOwner);
+    portalRegistryMock.register(address(pausablePortal), "PausablePortal", "PausablePortal", true, "owner");
+  }
+
+  function test_setUp() public view {
+    bool paused = pausablePortal.paused();
+    assertFalse(paused);
+  }
+
+  function test_pause() public {
+    bool paused = pausablePortal.paused();
+    assertFalse(paused);
+
+    vm.prank(address(this));
+    pausablePortal.pause();
+
+    paused = pausablePortal.paused();
+    assertTrue(paused);
+  }
+
+  function test_unpause() public {
+    bool paused = pausablePortal.paused();
+    assertFalse(paused);
+
+    vm.prank(address(this));
+    pausablePortal.pause();
+
+    paused = pausablePortal.paused();
+    assertTrue(paused);
+
+    vm.prank(address(this));
+    pausablePortal.unpause();
+
+    paused = pausablePortal.paused();
+    assertFalse(paused);
+  }
+
+  function test_attest_unpaused() public {
+    AttestationPayload memory attestationPayload = AttestationPayload(
+      bytes32(uint256(1)),
+      uint64(block.timestamp + 30 days),
+      abi.encode(makeAddr("user")),
+      new bytes(1)
+    );
+    bytes[] memory validationPayload = new bytes[](0);
+
+    vm.expectEmit(true, true, true, true);
+    emit AttestationRegistered();
+    pausablePortal.attest(attestationPayload, validationPayload);
+  }
+
+  function test_attest_paused() public {
+    AttestationPayload memory attestationPayload = AttestationPayload(
+      bytes32(uint256(1)),
+      uint64(block.timestamp + 30 days),
+      abi.encode(makeAddr("user")),
+      new bytes(1)
+    );
+    bytes[] memory validationPayload = new bytes[](0);
+
+    vm.prank(address(this));
+    pausablePortal.pause();
+
+    vm.expectRevert("Pausable: paused");
+    pausablePortal.attest(attestationPayload, validationPayload);
+  }
+
+  function test_attestV2_unpaused() public {
+    AttestationPayload memory attestationPayload = AttestationPayload(
+      bytes32(uint256(1)),
+      uint64(block.timestamp + 30 days),
+      abi.encode(makeAddr("user")),
+      new bytes(1)
+    );
+    bytes[] memory validationPayload = new bytes[](0);
+
+    vm.expectEmit(true, true, true, true);
+    emit AttestationRegistered();
+    pausablePortal.attestV2(attestationPayload, validationPayload);
+  }
+
+  function test_attestV2_paused() public {
+    AttestationPayload memory attestationPayload = AttestationPayload(
+      bytes32(uint256(1)),
+      uint64(block.timestamp + 30 days),
+      abi.encode(makeAddr("user")),
+      new bytes(1)
+    );
+    bytes[] memory validationPayload = new bytes[](0);
+
+    vm.prank(address(this));
+    pausablePortal.pause();
+
+    vm.expectRevert("Pausable: paused");
+    pausablePortal.attestV2(attestationPayload, validationPayload);
+  }
+
+  function test_bulkAttest_unpaused() public {
+    AttestationPayload memory attestationPayload = AttestationPayload(
+      bytes32(uint256(1)),
+      uint64(block.timestamp + 30 days),
+      abi.encode(makeAddr("user")),
+      new bytes(1)
+    );
+    AttestationPayload[] memory attestationPayloads = new AttestationPayload[](2);
+    attestationPayloads[0] = attestationPayload;
+    attestationPayloads[1] = attestationPayload;
+
+    bytes[] memory validationPayload = new bytes[](2);
+    bytes[][] memory validationPayloads = new bytes[][](2);
+    validationPayloads[0] = validationPayload;
+    validationPayloads[1] = validationPayload;
+
+    vm.prank(address(0));
+    vm.expectEmit(true, true, true, true);
+    emit BulkAttestationsRegistered();
+    pausablePortal.bulkAttest(attestationPayloads, validationPayloads);
+  }
+
+  function test_bulkAttest_paused() public {
+    AttestationPayload memory attestationPayload = AttestationPayload(
+      bytes32(uint256(1)),
+      uint64(block.timestamp + 30 days),
+      abi.encode(makeAddr("user")),
+      new bytes(1)
+    );
+    AttestationPayload[] memory attestationPayloads = new AttestationPayload[](2);
+    attestationPayloads[0] = attestationPayload;
+    attestationPayloads[1] = attestationPayload;
+
+    bytes[] memory validationPayload = new bytes[](2);
+    bytes[][] memory validationPayloads = new bytes[][](2);
+    validationPayloads[0] = validationPayload;
+    validationPayloads[1] = validationPayload;
+
+    vm.prank(address(this));
+    pausablePortal.pause();
+
+    vm.expectRevert("Pausable: paused");
+    pausablePortal.bulkAttest(attestationPayloads, validationPayloads);
+  }
+
+  function test_bulkAttestV2_unpaused() public {
+    AttestationPayload memory attestationPayload = AttestationPayload(
+      bytes32(uint256(1)),
+      uint64(block.timestamp + 30 days),
+      abi.encode(makeAddr("user")),
+      new bytes(1)
+    );
+    AttestationPayload[] memory attestationPayloads = new AttestationPayload[](2);
+    attestationPayloads[0] = attestationPayload;
+    attestationPayloads[1] = attestationPayload;
+
+    bytes[] memory validationPayload = new bytes[](2);
+    bytes[][] memory validationPayloads = new bytes[][](2);
+    validationPayloads[0] = validationPayload;
+    validationPayloads[1] = validationPayload;
+
+    vm.prank(address(0));
+    vm.expectEmit(true, true, true, true);
+    emit BulkAttestationsRegistered();
+    pausablePortal.bulkAttestV2(attestationPayloads, validationPayloads);
+  }
+
+  function test_bulkAttestV2_paused() public {
+    AttestationPayload memory attestationPayload = AttestationPayload(
+      bytes32(uint256(1)),
+      uint64(block.timestamp + 30 days),
+      abi.encode(makeAddr("user")),
+      new bytes(1)
+    );
+    AttestationPayload[] memory attestationPayloads = new AttestationPayload[](2);
+    attestationPayloads[0] = attestationPayload;
+    attestationPayloads[1] = attestationPayload;
+
+    bytes[] memory validationPayload = new bytes[](2);
+    bytes[][] memory validationPayloads = new bytes[][](2);
+    validationPayloads[0] = validationPayload;
+    validationPayloads[1] = validationPayload;
+
+    vm.prank(address(this));
+    pausablePortal.pause();
+
+    vm.expectRevert("Pausable: paused");
+    pausablePortal.bulkAttestV2(attestationPayloads, validationPayloads);
+  }
+
+  function test_replace_unpaused() public {
+    AttestationPayload memory attestationPayload = AttestationPayload(
+      bytes32(uint256(1)),
+      uint64(block.timestamp + 30 days),
+      abi.encode(makeAddr("user")),
+      new bytes(1)
+    );
+    bytes[] memory validationPayload = new bytes[](0);
+
+    vm.expectEmit(true, true, true, true);
+    emit AttestationRegistered();
+    pausablePortal.attestV2(attestationPayload, validationPayload);
+
+    vm.prank(portalOwner);
+    vm.expectEmit(true, true, true, true);
+    emit AttestationReplaced();
+    pausablePortal.replace(bytes32(uint256(1)), attestationPayload, validationPayload);
+  }
+
+  function test_replace_paused() public {
+    AttestationPayload memory attestationPayload = AttestationPayload(
+      bytes32(uint256(1)),
+      uint64(block.timestamp + 30 days),
+      abi.encode(makeAddr("user")),
+      new bytes(1)
+    );
+    bytes[] memory validationPayload = new bytes[](0);
+
+    vm.expectEmit(true, true, true, true);
+    emit AttestationRegistered();
+    pausablePortal.attestV2(attestationPayload, validationPayload);
+
+    vm.prank(address(this));
+    pausablePortal.pause();
+
+    vm.prank(portalOwner);
+    vm.expectRevert("Pausable: paused");
+    pausablePortal.replace(bytes32(uint256(1)), attestationPayload, validationPayload);
+  }
+
+  function test_replace_onlyPortalOwner() public {
+    AttestationPayload memory attestationPayload = AttestationPayload(
+      bytes32(uint256(1)),
+      uint64(block.timestamp + 30 days),
+      abi.encode(makeAddr("user")),
+      new bytes(1)
+    );
+    bytes[] memory validationPayload = new bytes[](0);
+
+    vm.expectEmit(true, true, true, true);
+    emit AttestationRegistered();
+    pausablePortal.attestV2(attestationPayload, validationPayload);
+
+    vm.prank(makeAddr("wrongOwner"));
+    vm.expectRevert(AbstractPortal.OnlyPortalOwner.selector);
+    pausablePortal.replace(bytes32(uint256(1)), attestationPayload, validationPayload);
+  }
+
+  function test_bulkReplace_unpaused() public {
+    AttestationPayload memory attestationPayload = AttestationPayload(
+      bytes32(uint256(1)),
+      uint64(block.timestamp + 30 days),
+      abi.encode(makeAddr("user")),
+      new bytes(1)
+    );
+    AttestationPayload[] memory attestationPayloads = new AttestationPayload[](2);
+    attestationPayloads[0] = attestationPayload;
+    attestationPayloads[1] = attestationPayload;
+
+    bytes[] memory validationPayload = new bytes[](2);
+    bytes[][] memory validationPayloads = new bytes[][](2);
+    validationPayloads[0] = validationPayload;
+    validationPayloads[1] = validationPayload;
+
+    bytes32[] memory attestationIds = new bytes32[](2);
+    attestationIds[0] = bytes32(uint256(1));
+    attestationIds[1] = bytes32(uint256(2));
+
+    vm.prank(portalOwner);
+    vm.expectEmit(true, true, true, true);
+    emit BulkAttestationsReplaced();
+    pausablePortal.bulkReplace(attestationIds, attestationPayloads, validationPayloads);
+  }
+
+  function test_bulkReplace_paused() public {
+    AttestationPayload memory attestationPayload = AttestationPayload(
+      bytes32(uint256(1)),
+      uint64(block.timestamp + 30 days),
+      abi.encode(makeAddr("user")),
+      new bytes(1)
+    );
+    AttestationPayload[] memory attestationPayloads = new AttestationPayload[](2);
+    attestationPayloads[0] = attestationPayload;
+    attestationPayloads[1] = attestationPayload;
+
+    bytes[] memory validationPayload = new bytes[](2);
+    bytes[][] memory validationPayloads = new bytes[][](2);
+    validationPayloads[0] = validationPayload;
+    validationPayloads[1] = validationPayload;
+
+    bytes32[] memory attestationIds = new bytes32[](2);
+    attestationIds[0] = bytes32(uint256(1));
+    attestationIds[1] = bytes32(uint256(2));
+
+    vm.prank(address(this));
+    pausablePortal.pause();
+
+    vm.prank(portalOwner);
+    vm.expectRevert("Pausable: paused");
+    pausablePortal.bulkReplace(attestationIds, attestationPayloads, validationPayloads);
+  }
+
+  function test_bulkReplace_onlyPortalOwner() public {
+    AttestationPayload memory attestationPayload = AttestationPayload(
+      bytes32(uint256(1)),
+      uint64(block.timestamp + 30 days),
+      abi.encode(makeAddr("user")),
+      new bytes(1)
+    );
+    AttestationPayload[] memory attestationPayloads = new AttestationPayload[](2);
+    attestationPayloads[0] = attestationPayload;
+    attestationPayloads[1] = attestationPayload;
+
+    bytes[] memory validationPayload = new bytes[](2);
+    bytes[][] memory validationPayloads = new bytes[][](2);
+    validationPayloads[0] = validationPayload;
+    validationPayloads[1] = validationPayload;
+
+    bytes32[] memory attestationIds = new bytes32[](2);
+    attestationIds[0] = bytes32(uint256(1));
+    attestationIds[1] = bytes32(uint256(2));
+
+    vm.prank(makeAddr("wrongOwner"));
+    vm.expectRevert(AbstractPortal.OnlyPortalOwner.selector);
+    pausablePortal.bulkReplace(attestationIds, attestationPayloads, validationPayloads);
+  }
+
+  function test_revoke_unpaused() public {
+    AttestationPayload memory attestationPayload = AttestationPayload(
+      bytes32(uint256(1)),
+      uint64(block.timestamp + 30 days),
+      abi.encode(makeAddr("user")),
+      new bytes(1)
+    );
+    bytes[] memory validationPayload = new bytes[](0);
+
+    vm.expectEmit(true, true, true, true);
+    emit AttestationRegistered();
+    pausablePortal.attestV2(attestationPayload, validationPayload);
+
+    vm.prank(portalOwner);
+    vm.expectEmit(true, true, true, true);
+    emit AttestationRevoked(bytes32(uint256(1)));
+    pausablePortal.revoke(bytes32(uint256(1)));
+  }
+
+  function test_revoke_paused() public {
+    AttestationPayload memory attestationPayload = AttestationPayload(
+      bytes32(uint256(1)),
+      uint64(block.timestamp + 30 days),
+      abi.encode(makeAddr("user")),
+      new bytes(1)
+    );
+    bytes[] memory validationPayload = new bytes[](0);
+
+    vm.expectEmit(true, true, true, true);
+    emit AttestationRegistered();
+    pausablePortal.attestV2(attestationPayload, validationPayload);
+
+    vm.prank(address(this));
+    pausablePortal.pause();
+
+    vm.prank(portalOwner);
+    vm.expectRevert("Pausable: paused");
+    pausablePortal.replace(bytes32(uint256(1)), attestationPayload, validationPayload);
+  }
+
+  function test_revoke_onlyPortalOwner() public {
+    AttestationPayload memory attestationPayload = AttestationPayload(
+      bytes32(uint256(1)),
+      uint64(block.timestamp + 30 days),
+      abi.encode(makeAddr("user")),
+      new bytes(1)
+    );
+    bytes[] memory validationPayload = new bytes[](0);
+
+    vm.expectEmit(true, true, true, true);
+    emit AttestationRegistered();
+    pausablePortal.attestV2(attestationPayload, validationPayload);
+
+    vm.prank(makeAddr("wrongOwner"));
+    vm.expectRevert(AbstractPortal.OnlyPortalOwner.selector);
+    pausablePortal.revoke(bytes32(uint256(1)));
+  }
+
+  function test_bulkRevoke_unpaused() public {
+    AttestationPayload memory attestationPayload = AttestationPayload(
+      bytes32(uint256(1)),
+      uint64(block.timestamp + 30 days),
+      abi.encode(makeAddr("user")),
+      new bytes(1)
+    );
+    bytes[] memory validationPayload = new bytes[](0);
+
+    vm.expectEmit(true, true, true, true);
+    emit AttestationRegistered();
+    pausablePortal.attestV2(attestationPayload, validationPayload);
+    vm.expectEmit(true, true, true, true);
+    emit AttestationRegistered();
+    pausablePortal.attestV2(attestationPayload, validationPayload);
+
+    bytes32[] memory attestationIds = new bytes32[](2);
+    attestationIds[0] = bytes32(uint256(1));
+    attestationIds[1] = bytes32(uint256(2));
+
+    vm.prank(portalOwner);
+    vm.expectEmit(true, true, true, true);
+    emit BulkAttestationsRevoked(attestationIds);
+    pausablePortal.bulkRevoke(attestationIds);
+  }
+
+  function test_bulkRevoke_paused() public {
+    AttestationPayload memory attestationPayload = AttestationPayload(
+      bytes32(uint256(1)),
+      uint64(block.timestamp + 30 days),
+      abi.encode(makeAddr("user")),
+      new bytes(1)
+    );
+    bytes[] memory validationPayload = new bytes[](0);
+
+    vm.expectEmit(true, true, true, true);
+    emit AttestationRegistered();
+    pausablePortal.attestV2(attestationPayload, validationPayload);
+    vm.expectEmit(true, true, true, true);
+    emit AttestationRegistered();
+    pausablePortal.attestV2(attestationPayload, validationPayload);
+
+    bytes32[] memory attestationIds = new bytes32[](2);
+    attestationIds[0] = bytes32(uint256(1));
+    attestationIds[1] = bytes32(uint256(2));
+
+    vm.prank(address(this));
+    pausablePortal.pause();
+
+    vm.prank(portalOwner);
+    vm.expectRevert("Pausable: paused");
+    pausablePortal.bulkRevoke(attestationIds);
+  }
+
+  function test_bulkRevoke_onlyPortalOwner() public {
+    AttestationPayload memory attestationPayload = AttestationPayload(
+      bytes32(uint256(1)),
+      uint64(block.timestamp + 30 days),
+      abi.encode(makeAddr("user")),
+      new bytes(1)
+    );
+    bytes[] memory validationPayload = new bytes[](0);
+
+    vm.expectEmit(true, true, true, true);
+    emit AttestationRegistered();
+    pausablePortal.attestV2(attestationPayload, validationPayload);
+    vm.expectEmit(true, true, true, true);
+    emit AttestationRegistered();
+    pausablePortal.attestV2(attestationPayload, validationPayload);
+
+    bytes32[] memory attestationIds = new bytes32[](2);
+    attestationIds[0] = bytes32(uint256(1));
+    attestationIds[1] = bytes32(uint256(2));
+
+    vm.prank(makeAddr("wrongOwner"));
+    vm.expectRevert(AbstractPortal.OnlyPortalOwner.selector);
+    pausablePortal.bulkRevoke(attestationIds);
+  }
+
+  function testSupportsInterface() public view {
+    bool isIERC165Supported = pausablePortal.supportsInterface(type(IERC165).interfaceId);
+    assertTrue(isIERC165Supported);
+    bool isEASAbstractPortalSupported = pausablePortal.supportsInterface(type(AbstractPortal).interfaceId);
+    assertTrue(isEASAbstractPortalSupported);
+  }
+}

--- a/contracts/test/mocks/AttestationRegistryMock.sol
+++ b/contracts/test/mocks/AttestationRegistryMock.sol
@@ -9,8 +9,9 @@ contract AttestationRegistryMock {
   mapping(bytes32 attestationId => Attestation attestation) private attestations;
 
   event AttestationRegistered();
-  event AttestationReplaced();
   event BulkAttestationsRegistered();
+  event AttestationReplaced();
+  event BulkAttestationsReplaced();
   event AttestationRevoked(bytes32 attestationId);
   event BulkAttestationsRevoked(bytes32[] attestationId);
 
@@ -55,7 +56,9 @@ contract AttestationRegistryMock {
     bytes32[] calldata /*attestationId*/,
     AttestationPayload[] calldata /*attestationPayload*/,
     address /*attester*/
-  ) public {}
+  ) public {
+    emit BulkAttestationsReplaced();
+  }
 
   function revoke(bytes32 attestationId) public {
     emit AttestationRevoked(attestationId);


### PR DESCRIPTION
## What does this PR do?

Introduces a `PausablePortal` leveraging the `Pausable` contract from OpenZeppeline.
This gives an example of how to create a Portal that can be paused in case of emergency, preventing it from issuing, replacing or revoking any Attestation if needed.

### Related ticket

Fixes #712 

### Type of change

- [ ] Chore
- [ ] Bug fix
- [X] New feature
- [ ] Documentation update

## Check list

- [ ] Unit tests for any smart contract change
- [ ] Contracts and functions are documented
