### PR TITLE
fix(contracts): As an an Admin, I want to ensure that Issuer addresses cannot be set as the zero address

### DIFF
--- a/contracts/src/PortalRegistry.sol
+++ b/contracts/src/PortalRegistry.sol
@@ -45,6 +45,8 @@ contract PortalRegistry is OwnableUpgradeable {
   error PortalInvalid();
   /// @notice Error thrown when attempting to get a Portal that is not registered
   error PortalNotRegistered();
+  /// @notice Error thrown when an invalid address is given
+  error AddressInvalid();
 
   /// @notice Event emitted when a Portal is registered
   event PortalRegistered(string name, string description, address portalAddress);
@@ -87,6 +89,8 @@ contract PortalRegistry is OwnableUpgradeable {
    * @param issuer the address to register as an issuer
    */
   function setIssuer(address issuer) public onlyOwner {
+    if (issuer == address(0)) revert AddressInvalid();
+
     issuers[issuer] = true;
     emit IssuerAdded(issuer);
   }

--- a/contracts/src/stdlib/IssuersModule.sol
+++ b/contracts/src/stdlib/IssuersModule.sol
@@ -32,6 +32,9 @@ contract IssuersModule is AbstractModule {
   ) public view override {
     address subject = address(0);
 
+    if (_attestationPayload.subject.length != 32 && _attestationPayload.subject.length != 20)
+      revert UnauthorizedSubject();
+
     if (_attestationPayload.subject.length == 32) subject = abi.decode(_attestationPayload.subject, (address));
     if (_attestationPayload.subject.length == 20) subject = address(uint160(bytes20(_attestationPayload.subject)));
 

--- a/contracts/src/stdlib/IssuersModuleV2.sol
+++ b/contracts/src/stdlib/IssuersModuleV2.sol
@@ -36,6 +36,9 @@ contract IssuersModuleV2 is AbstractModuleV2 {
   ) public view override {
     address subject = address(0);
 
+    if (attestationPayload.subject.length != 32 && attestationPayload.subject.length != 20)
+      revert UnauthorizedSubject();
+
     if (attestationPayload.subject.length == 32) subject = abi.decode(attestationPayload.subject, (address));
     if (attestationPayload.subject.length == 20) subject = address(uint160(bytes20(attestationPayload.subject)));
 

--- a/contracts/test/PortalRegistry.t.sol
+++ b/contracts/test/PortalRegistry.t.sol
@@ -94,6 +94,27 @@ contract PortalRegistryTest is Test {
     assertEq(isIssuer, true);
   }
 
+  function test_setIssuer_OnlyOwner() public {
+    address issuerAddress = makeAddr("Issuer");
+
+    vm.prank(makeAddr("random"));
+    vm.expectRevert("Ownable: caller is not the owner");
+    portalRegistry.setIssuer(issuerAddress);
+
+    bool isIssuer = portalRegistry.isIssuer(issuerAddress);
+    assertEq(isIssuer, false);
+  }
+
+  function test_setIssuer_AddressInvalid() public {
+    vm.prank(address(0));
+
+    vm.expectRevert(PortalRegistry.AddressInvalid.selector);
+    portalRegistry.setIssuer(address(0));
+
+    bool isIssuer = portalRegistry.isIssuer(address(0));
+    assertEq(isIssuer, false);
+  }
+
   function test_setIsTestnet_true() public {
     bool isTestnet = portalRegistry.getIsTestnet();
     assertEq(isTestnet, false);

--- a/contracts/test/integration/IssuersPortal.t.sol
+++ b/contracts/test/integration/IssuersPortal.t.sol
@@ -45,9 +45,10 @@ contract IssuersPortalTest is Test {
     issuersModule = new IssuersModule(address(portalRegistry));
     senderModule = new SenderModule(address(portalRegistry));
 
-    portalRegistry.setIssuer(address(0));
     portalRegistry.setIssuer(issuerAddress);
+    vm.stopPrank();
 
+    vm.startPrank(issuerAddress);
     moduleRegistry.register("IssuersModule", "IssuersModule description", address(issuersModule));
     moduleRegistry.register("SenderModule", "SenderModule description", address(senderModule));
 

--- a/contracts/test/integration/IssuersPortalV2.t.sol
+++ b/contracts/test/integration/IssuersPortalV2.t.sol
@@ -45,9 +45,10 @@ contract IssuersPortalTest is Test {
     issuersModule = new IssuersModuleV2(address(portalRegistry));
     senderModule = new SenderModuleV2(address(portalRegistry));
 
-    portalRegistry.setIssuer(address(0));
     portalRegistry.setIssuer(issuerAddress);
+    vm.stopPrank();
 
+    vm.startPrank(issuerAddress);
     moduleRegistry.register("IssuersModuleV2", "IssuersModule description", address(issuersModule));
     moduleRegistry.register("SenderModuleV2", "SenderModule description", address(senderModule));
 

--- a/contracts/test/stdlib/IssuersModule.t.sol
+++ b/contracts/test/stdlib/IssuersModule.t.sol
@@ -68,4 +68,16 @@ contract IssuersModuleTest is Test {
     vm.expectRevert(IssuersModule.UnauthorizedSubject.selector);
     issuersModule.run(attestationPayload, "", makeAddr("sender"), 0);
   }
+
+  function test_run_unauthorized_InvalidSubject() public {
+    AttestationPayload memory attestationPayload = AttestationPayload(
+      bytes32("schema1"),
+      0,
+      abi.encode("randomString"),
+      new bytes(0)
+    );
+    vm.expectRevert(IssuersModule.UnauthorizedSubject.selector);
+    issuersModule.run(attestationPayload, "", makeAddr("sender"), 0);
+    vm.stopPrank();
+  }
 }

--- a/contracts/test/stdlib/IssuersModuleV2.t.sol
+++ b/contracts/test/stdlib/IssuersModuleV2.t.sol
@@ -102,4 +102,25 @@ contract IssuersModuleV2Test is Test {
       OperationType.Attest
     );
   }
+
+  function test_run_unauthorized_InvalidSubject() public {
+    AttestationPayload memory attestationPayload = AttestationPayload(
+      bytes32("schema1"),
+      0,
+      abi.encode("randomString"),
+      new bytes(0)
+    );
+    vm.startPrank(portal);
+    vm.expectRevert(IssuersModuleV2.UnauthorizedSubject.selector);
+    issuersModule.run(
+      attestationPayload,
+      "",
+      makeAddr("sender"),
+      0,
+      address(makeAddr("attester")),
+      portal,
+      OperationType.Attest
+    );
+    vm.stopPrank();
+  }
 }


### PR DESCRIPTION
## What does this PR do?

1. Forbids the Zero Address from being registered as an Issuer
2. Reinforces the checks when decoding an address

### Related ticket

Fixes #717 

### Type of change

- [ ] Chore
- [X] Bug fix
- [ ] New feature
- [ ] Documentation update

## Check list

- [ ] Unit tests for any smart contract change
- [ ] Contracts and functions are documented
