### PR TITLE
fix(explorer): The search is case sensitive

### DIFF
--- a/explorer/src/utils/searchUtils.ts
+++ b/explorer/src/utils/searchUtils.ts
@@ -50,7 +50,9 @@ export const parseSearch = (search: string | null, chainPrefix: Hex): Partial<Re
   const defaultAddresses = filterByRegex(startsWith0x, regexEthAddress.byNumberOfChar[42]).map((address) =>
     address.toLowerCase(),
   );
-  const longAddresses = filterByRegex(startsWith0x, regexEthAddress.byNumberOfChar[64]);
+  const longAddresses = filterByRegex(startsWith0x, regexEthAddress.byNumberOfChar[64]).map((longAddress) =>
+    longAddress.toLowerCase(),
+  );
 
   const urls = filterByRegex(splitSearchBySpace, urlRegex);
   const allStrings = [...urls, ...defaultAddresses, ...longAddresses, ...attestationIds];

--- a/explorer/src/utils/searchUtils.ts
+++ b/explorer/src/utils/searchUtils.ts
@@ -47,7 +47,9 @@ export const parseSearch = (search: string | null, chainPrefix: Hex): Partial<Re
   const hexNumbers = rawNumbers.map((num) => buildAttestationId(Number(num), chainPrefix));
   const attestationIds = [...potentialAttestationIds, ...hexNumbers];
 
-  const defaultAddresses = filterByRegex(startsWith0x, regexEthAddress.byNumberOfChar[42]);
+  const defaultAddresses = filterByRegex(startsWith0x, regexEthAddress.byNumberOfChar[42]).map((address) =>
+    address.toLowerCase(),
+  );
   const longAddresses = filterByRegex(startsWith0x, regexEthAddress.byNumberOfChar[64]);
 
   const urls = filterByRegex(splitSearchBySpace, urlRegex);


### PR DESCRIPTION
## What does this PR do?

This PR fixes the case sensitivity issue with omni search

Address and Long Address searches are made case insensitive

### Related ticket

Fixes #721 

### Type of change

- [ ] Chore
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update

## Check list

- [ ] Unit tests for any smart contract change
- [ ] Contracts and functions are documented
