### PR TITLE
chore(sdk): Add unit tests for the subgraph calls on the SDK

### DIFF
--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -55,19 +55,10 @@ jobs:
       - name: Run the unit tests
         run: pnpm run test:unit:coverage
 
-      - name: Move the report at the root of the project
-        run: |
-          if [ -f coverage/lcov.info ]; then
-            mv coverage/lcov.info .
-          else
-            echo "lcov.info file not found!"
-            exit 1
-          fi
-
       - name: Upload coverage report to Codecov
         uses: codecov/codecov-action@v3
         with:
-          files: ./lcov.info
+          files: ./coverage/lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
           verbose: true

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -55,11 +55,37 @@ jobs:
       - name: Run the unit tests
         run: pnpm run test:unit:coverage
 
-      - name: Upload coverage report
-        uses: actions/upload-artifact@v3
+      - name: Move the report at the root of the project
+        if: steps.check-changes.outputs.changed == 'true'
+        run: mv sdk/coverage/lcov.info .
+
+      - name: Upload coverage report to Codecov
+        if: steps.check-changes.outputs.changed == 'true'
+        uses: codecov/codecov-action@v3
         with:
-          name: coverage-report
-          path: sdk/coverage
+          files: ./lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true
+          verbose: true
+
+      - name: Check test coverage
+        if: steps.check-changes.outputs.changed == 'true'
+        uses: terencetcf/github-actions-lcov-minimum-coverage-checker@v1
+        with:
+          coverage-file: lcov.info
+          minimum-coverage: 50
+
+      - name: Add coverage summary
+        if: steps.check-changes.outputs.changed == 'true'
+        run: |
+          echo "## Coverage result" >> $GITHUB_STEP_SUMMARY
+          echo "✅ Uploaded to Codecov" >> $GITHUB_STEP_SUMMARY
+
+      - name: Add coverage summary
+        if: steps.check-changes.outputs.changed == 'false'
+        run: |
+          echo "## Coverage result" >> $GITHUB_STEP_SUMMARY
+          echo "✅ No coverage report to upload" >> $GITHUB_STEP_SUMMARY
 
       - name: Run the integration tests
         run: pnpm run test:integration:ci

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Upload coverage report to Codecov
         uses: codecov/codecov-action@v3
         with:
-          files: ./lcov.info
+          files: sdk/coverage/lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
           verbose: true

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -24,14 +24,6 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v3
 
-      - id: check-changes
-        run: |
-          if [ -n "$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} | grep '^sdk/')" ]; then
-            echo "::set-output name=changed::true"
-          else
-            echo "::set-output name=changed::false"
-          fi
-
       - name: Install Pnpm
         uses: pnpm/action-setup@v2
         with:
@@ -64,11 +56,9 @@ jobs:
         run: pnpm run test:unit:coverage
 
       - name: Move the report at the root of the project
-        if: steps.check-changes.outputs.changed == 'true'
         run: mv sdk/coverage/lcov.info .
 
       - name: Upload coverage report to Codecov
-        if: steps.check-changes.outputs.changed == 'true'
         uses: codecov/codecov-action@v3
         with:
           files: ./lcov.info
@@ -77,28 +67,15 @@ jobs:
           verbose: true
 
       - name: Check test coverage
-        if: steps.check-changes.outputs.changed == 'true'
         uses: terencetcf/github-actions-lcov-minimum-coverage-checker@v1
         with:
           coverage-file: lcov.info
           minimum-coverage: 50
 
       - name: Add coverage summary
-        if: steps.check-changes.outputs.changed == 'true'
         run: |
           echo "## Coverage result" >> $GITHUB_STEP_SUMMARY
           echo "✅ Uploaded to Codecov" >> $GITHUB_STEP_SUMMARY
 
-      - name: Add coverage summary
-        if: steps.check-changes.outputs.changed == 'false'
-        run: |
-          echo "## Coverage result" >> $GITHUB_STEP_SUMMARY
-          echo "✅ No coverage report to upload" >> $GITHUB_STEP_SUMMARY
-
       - name: Run the integration tests
         run: pnpm run test:integration:ci
-
-      - name: Add test summary
-        run: |
-          echo "## Tests result" >> $GITHUB_STEP_SUMMARY
-          echo "✅ Passed" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -13,7 +13,7 @@ on:
       - release/*
 
 jobs:
-  test-sdk:
+  unit-test-sdk:
     runs-on: ubuntu-latest
 
     defaults:
@@ -55,24 +55,21 @@ jobs:
       - name: Run the unit tests
         run: pnpm run test:unit:coverage
 
-      - name: List coverage directory
-        run: ls -R coverage
+      - name: Move the report at the root of the 'sdk' folder
+        run: mv coverage/lcov.info .
 
       - name: Upload coverage report to Codecov
         uses: codecov/codecov-action@v3
         with:
-          files: coverage/lcov.info
+          files: ./sdk/lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
           verbose: true
 
-      - name: Move the report at the root of the project
-        run: mv coverage/lcov.info .
-
       - name: Check test coverage
         uses: terencetcf/github-actions-lcov-minimum-coverage-checker@v1
         with:
-          coverage-file: coverage/lcov.info
+          coverage-file: sdk/lcov.info
           minimum-coverage: 50
 
       - name: Add coverage summary
@@ -80,5 +77,49 @@ jobs:
           echo "## Coverage result" >> $GITHUB_STEP_SUMMARY
           echo "✅ Uploaded to Codecov" >> $GITHUB_STEP_SUMMARY
 
+  integration-test-sdk:
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: sdk
+
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v3
+
+      - name: Install Pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 9
+          run_install: false
+
+      - name: Install Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: pnpm
+
+      - name: Get pnpm store directory
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+      - uses: actions/cache@v3
+        name: Setup pnpm cache
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
       - name: Run the integration tests
         run: pnpm run test:integration:ci
+
+      - name: Integration tests summary
+        run: |
+          echo "## Integration tests result" >> $GITHUB_STEP_SUMMARY
+          echo "✅ All passed" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Check test coverage
         uses: terencetcf/github-actions-lcov-minimum-coverage-checker@v1
         with:
-          coverage-file: lcov.info
+          coverage-file: coverage/lcov.info
           minimum-coverage: 50
 
       - name: Add coverage summary

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -55,6 +55,12 @@ jobs:
       - name: Run the unit tests
         run: pnpm run test:unit:ci
 
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage-report
+          path: sdk/coverage
+
       - name: Run the integration tests
         run: pnpm run test:integration:ci
 

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -55,6 +55,15 @@ jobs:
       - name: Run the unit tests
         run: pnpm run test:unit:coverage
 
+      - name: Run the integration tests
+        run: pnpm run test:integration:ci
+
+  coverage-contracts:
+    runs-on: ubuntu-latest
+
+    needs: test-sdk
+
+    steps:
       - name: Move the report at the root of the project
         run: mv sdk/coverage/lcov.info .
 
@@ -76,6 +85,3 @@ jobs:
         run: |
           echo "## Coverage result" >> $GITHUB_STEP_SUMMARY
           echo "✅ Uploaded to Codecov" >> $GITHUB_STEP_SUMMARY
-
-      - name: Run the integration tests
-        run: pnpm run test:integration:ci

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Check test coverage
         uses: terencetcf/github-actions-lcov-minimum-coverage-checker@v1
         with:
-          coverage-file: lcov.info
+          coverage-file: coverage/lcov.info
           minimum-coverage: 50
 
       - name: Add coverage summary

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -66,10 +66,13 @@ jobs:
           fail_ci_if_error: true
           verbose: true
 
+      - name: Move the report at the root of the project
+        run: mv coverage/lcov.info .
+
       - name: Check test coverage
         uses: terencetcf/github-actions-lcov-minimum-coverage-checker@v1
         with:
-          coverage-file: coverage/lcov.info
+          coverage-file: lcov.info
           minimum-coverage: 50
 
       - name: Add coverage summary

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -53,7 +53,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Run the unit tests
-        run: pnpm run test:unit:ci
+        run: pnpm run test:unit:coverage
 
       - name: Upload coverage report
         uses: actions/upload-artifact@v3

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -58,19 +58,10 @@ jobs:
       - name: List coverage directory
         run: ls -R coverage
 
-      - name: Move the coverage report to root (if needed)
-        run: |
-          if [ -f coverage/lcov.info ]; then
-            mv coverage/lcov.info .
-          else
-            echo "lcov.info file not found!"
-            exit 1
-          fi
-
       - name: Upload coverage report to Codecov
         uses: codecov/codecov-action@v3
         with:
-          files: sdk/coverage/lcov.info
+          files: coverage/lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
           verbose: true

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -56,7 +56,13 @@ jobs:
         run: pnpm run test:unit:coverage
 
       - name: Move the report at the root of the project
-        run: mv coverage/lcov.info .
+        run: |
+          if [ -f coverage/lcov.info ]; then
+            mv coverage/lcov.info .
+          else
+            echo "lcov.info file not found!"
+            exit 1
+          fi
 
       - name: Upload coverage report to Codecov
         uses: codecov/codecov-action@v3

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -24,6 +24,14 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v3
 
+      - id: check-changes
+        run: |
+          if [ -n "$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} | grep '^sdk/')" ]; then
+            echo "::set-output name=changed::true"
+          else
+            echo "::set-output name=changed::false"
+          fi
+
       - name: Install Pnpm
         uses: pnpm/action-setup@v2
         with:

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -55,17 +55,8 @@ jobs:
       - name: Run the unit tests
         run: pnpm run test:unit:coverage
 
-      - name: Run the integration tests
-        run: pnpm run test:integration:ci
-
-  coverage-contracts:
-    runs-on: ubuntu-latest
-
-    needs: test-sdk
-
-    steps:
       - name: Move the report at the root of the project
-        run: mv sdk/coverage/lcov.info .
+        run: mv coverage/lcov.info .
 
       - name: Upload coverage report to Codecov
         uses: codecov/codecov-action@v3
@@ -85,3 +76,6 @@ jobs:
         run: |
           echo "## Coverage result" >> $GITHUB_STEP_SUMMARY
           echo "✅ Uploaded to Codecov" >> $GITHUB_STEP_SUMMARY
+
+      - name: Run the integration tests
+        run: pnpm run test:integration:ci

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -55,10 +55,22 @@ jobs:
       - name: Run the unit tests
         run: pnpm run test:unit:coverage
 
+      - name: List coverage directory
+        run: ls -R coverage
+
+      - name: Move the coverage report to root (if needed)
+        run: |
+          if [ -f coverage/lcov.info ]; then
+            mv coverage/lcov.info .
+          else
+            echo "lcov.info file not found!"
+            exit 1
+          fi
+
       - name: Upload coverage report to Codecov
         uses: codecov/codecov-action@v3
         with:
-          files: ./coverage/lcov.info
+          files: ./lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
           verbose: true

--- a/sdk/.npmignore
+++ b/sdk/.npmignore
@@ -5,6 +5,7 @@ node_modules
 src
 !dist/src
 test
+*.test.*
 .env
 .env.example
 .graphclientrc.yml

--- a/sdk/jest.config.js
+++ b/sdk/jest.config.js
@@ -5,7 +5,8 @@ const config = {
   transform: {
     ".graphclient/index.ts": ["babel-jest", { configFile: "./babel-jest.config.cjs" }],
   },
-  coverageReporters: ["lcov", "text", "clover"],
+  coverageDirectory: "coverage",
+  coverageReporters: ["lcov", "text"],
 };
 
 module.exports = config;

--- a/sdk/jest.config.js
+++ b/sdk/jest.config.js
@@ -5,6 +5,7 @@ const config = {
   transform: {
     ".graphclient/index.ts": ["babel-jest", { configFile: "./babel-jest.config.cjs" }],
   },
+  coverageReporters: ["lcov", "text", "clover"],
 };
 
 module.exports = config;

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -35,7 +35,7 @@
     "test:integration": "jest integration",
     "test:integration:ci": "cp .env.example .env && pnpm run test:integration",
     "test:unit": "jest --testPathIgnorePatterns='integration'",
-    "test:unit:ci": "pnpm run test:unit --coverage"
+    "test:unit:coverage": "pnpm run test:unit --coverage"
   },
   "dependencies": {
     "@graphql-mesh/cache-localforage": "^0.95.8",

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -34,8 +34,8 @@
     "test:ci": "cp .env.example .env && pnpm run test",
     "test:integration": "jest integration",
     "test:integration:ci": "cp .env.example .env && pnpm run test:integration",
-    "test:unit": "echo \"TODO\"",
-    "test:unit:ci": "cp .env.example .env && pnpm run test:unit"
+    "test:unit": "jest --testPathIgnorePatterns='integration'",
+    "test:unit:ci": "pnpm run test:unit"
   },
   "dependencies": {
     "@graphql-mesh/cache-localforage": "^0.95.8",

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -35,7 +35,7 @@
     "test:integration": "jest integration",
     "test:integration:ci": "cp .env.example .env && pnpm run test:integration",
     "test:unit": "jest --testPathIgnorePatterns='integration'",
-    "test:unit:ci": "pnpm run test:unit"
+    "test:unit:ci": "pnpm run test:unit --coverage"
   },
   "dependencies": {
     "@graphql-mesh/cache-localforage": "^0.95.8",

--- a/sdk/src/dataMapper/AttestationDataMapper.test.ts
+++ b/sdk/src/dataMapper/AttestationDataMapper.test.ts
@@ -1,0 +1,158 @@
+import AttestationDataMapper from "./AttestationDataMapper";
+import { Constants, SDKMode } from "../utils/constants";
+import { decodeWithRetry } from "../utils/abiCoder";
+import { getIPFSContent } from "../utils/ipfsClient";
+import { Attestation, Conf } from "../types";
+import BaseDataMapper from "./BaseDataMapper";
+import { lineaSepolia } from "viem/chains";
+import { PublicClient, WalletClient } from "viem";
+import { VeraxSdk } from "../VeraxSdk";
+import { off } from "process";
+
+jest.mock("./BaseDataMapper");
+jest.mock("../utils/abiCoder");
+jest.mock("../utils/ipfsClient");
+
+describe("AttestationDataMapper", () => {
+  let attestationDataMapper: AttestationDataMapper;
+  const mockConf: Conf = {
+    subgraphUrl: "http://mock-subgraph.com",
+    chain: lineaSepolia,
+    mode: SDKMode.BACKEND,
+    portalRegistryAddress: "0x1",
+    moduleRegistryAddress: "0x2",
+    schemaRegistryAddress: "0x3",
+    attestationRegistryAddress: "0x4",
+  };
+
+  const mockAttestation: Attestation = {
+    id: "1",
+    attestationId: "1",
+    replacedBy: null,
+    attester: "0xAttester",
+    attestedDate: 1634515200,
+    expirationDate: 1734515200,
+    revocationDate: 1634615200,
+    version: 1,
+    revoked: false,
+    subject: "0xSubject",
+    encodedSubject: "0xEncodedSubject",
+    attestationData: "0xAttestationData",
+    decodedData: [],
+    decodedPayload: {},
+    schema: {
+      id: Constants.OFFCHAIN_DATA_SCHEMA_ID,
+      name: "Test Schema",
+      description: "A test schema",
+      context: "http://schema.org",
+      schema: "schema",
+      attestationCounter: 1,
+    },
+    portal: {
+      id: "0xPortal",
+      ownerAddress: "0xOwner",
+      modules: ["0xModule"],
+      isRevocable: false,
+      name: "Test Portal",
+      description: "A test portal",
+      ownerName: "Owner",
+      attestationCounter: 1,
+    },
+    offchainData: undefined,
+  };
+
+  const mockWeb3Client = {} as PublicClient;
+  const mockWalletClient = {} as WalletClient;
+  const mockVeraxSdk = {} as VeraxSdk;
+
+  beforeEach(() => {
+    attestationDataMapper = new AttestationDataMapper(mockConf, mockWeb3Client, mockVeraxSdk, mockWalletClient);
+    jest.clearAllMocks();
+  });
+
+  describe("findOneById", () => {
+    it("should find attestation by id and enrich it", async () => {
+      (BaseDataMapper.prototype.findOneById as jest.Mock).mockResolvedValue(mockAttestation);
+      (decodeWithRetry as jest.Mock).mockReturnValue([
+        { schemaId: Constants.OFFCHAIN_DATA_SCHEMA_ID, uri: "ipfs://QmHash" },
+      ]);
+
+      const result = await attestationDataMapper.findOneById("1");
+
+      expect(BaseDataMapper.prototype.findOneById).toHaveBeenCalledWith("1");
+      expect(decodeWithRetry).toHaveBeenCalledWith(mockAttestation.schema.schema, mockAttestation.attestationData);
+      expect(result).toEqual(mockAttestation);
+    });
+
+    it("should return undefined if no attestation is found", async () => {
+      (BaseDataMapper.prototype.findOneById as jest.Mock).mockResolvedValue(undefined);
+
+      const result = await attestationDataMapper.findOneById("1");
+
+      expect(BaseDataMapper.prototype.findOneById).toHaveBeenCalledWith("1");
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe("findBy", () => {
+    it("should find attestations and enrich each of them", async () => {
+      const attestations = [mockAttestation];
+      (BaseDataMapper.prototype.findBy as jest.Mock).mockResolvedValue(attestations);
+      (decodeWithRetry as jest.Mock).mockReturnValue([
+        { schemaId: Constants.OFFCHAIN_DATA_SCHEMA_ID, uri: "ipfs://QmHash" },
+      ]);
+
+      const result = await attestationDataMapper.findBy(10, 0, {}, "attestedDate", "desc");
+
+      expect(BaseDataMapper.prototype.findBy).toHaveBeenCalledWith(10, 0, {}, "attestedDate", "desc");
+      expect(decodeWithRetry).toHaveBeenCalledTimes(1);
+      expect(result).toEqual(attestations);
+    });
+  });
+
+  describe("enrichAttestation", () => {
+    it("should enrich attestation with decoded payload for off-chain data schema", async () => {
+      (BaseDataMapper.prototype.findOneById as jest.Mock).mockResolvedValue(mockAttestation);
+      (decodeWithRetry as jest.Mock).mockReturnValue([
+        { schemaId: Constants.OFFCHAIN_DATA_SCHEMA_ID, uri: "ipfs://QmHash" },
+      ]);
+      (getIPFSContent as jest.Mock).mockResolvedValue("data");
+
+      const result = await attestationDataMapper.findOneById("1");
+
+      expect(result?.decodedPayload).toEqual("data");
+      expect(result?.offchainData).toEqual({
+        schemaId: Constants.OFFCHAIN_DATA_SCHEMA_ID,
+        uri: "ipfs://QmHash",
+      });
+    });
+
+    it("should set offchainData.error if IPFS request fails", async () => {
+      (decodeWithRetry as jest.Mock).mockReturnValue([
+        { schemaId: Constants.OFFCHAIN_DATA_SCHEMA_ID, uri: "ipfs://QmHash" },
+      ]);
+      (getIPFSContent as jest.Mock).mockRejectedValue(new Error("IPFS Error"));
+
+      // Call findOneById, which will trigger enrichAttestation
+      const result = await attestationDataMapper.findOneById("1");
+
+      expect(result?.offchainData?.error).toBe("IPFS Error");
+    });
+
+    it("should not enrich if schema ID is not offchain data", async () => {
+      const nonOffchainAttestation = {
+        ...mockAttestation,
+        schema: { ...mockAttestation.schema, id: "0x123" },
+        offchainData: undefined,
+      };
+      (decodeWithRetry as jest.Mock).mockReturnValue([{}]);
+      (BaseDataMapper.prototype.findOneById as jest.Mock).mockResolvedValue(nonOffchainAttestation);
+
+      // Call findOneById, which will trigger enrichAttestation
+      const result = await attestationDataMapper.findOneById("1");
+
+      expect(result?.decodedPayload).toStrictEqual([{}]);
+      expect(result?.offchainData).toBeUndefined();
+    });
+  });
+});

--- a/sdk/src/dataMapper/BaseDataMapper.test.ts
+++ b/sdk/src/dataMapper/BaseDataMapper.test.ts
@@ -116,8 +116,17 @@ describe("BaseDataMapper", () => {
       ]);
     });
 
-    it("should return an empty array if no data is found", async () => {
+    it("should return an empty array if data test type is empty", async () => {
       const mockResponse = { data: { data: { TestTypes: [] } }, status: 200 };
+      (subgraphCall as jest.Mock).mockResolvedValueOnce(mockResponse);
+
+      const result = await mockDataMapper.findBy();
+
+      expect(result).toEqual([]);
+    });
+
+    it("should return an empty array if no data is found", async () => {
+      const mockResponse = { data: {}, status: 200 };
       (subgraphCall as jest.Mock).mockResolvedValueOnce(mockResponse);
 
       const result = await mockDataMapper.findBy();

--- a/sdk/src/dataMapper/BaseDataMapper.test.ts
+++ b/sdk/src/dataMapper/BaseDataMapper.test.ts
@@ -1,0 +1,135 @@
+import BaseDataMapper from "./BaseDataMapper";
+import { PublicClient, WalletClient } from "viem";
+import { lineaSepolia } from "viem/chains";
+
+import { Conf } from "../types";
+import { SDKMode, VeraxSdk } from "../VeraxSdk";
+import { subgraphCall, stringifyWhereClause } from "../utils/graphClientHelper";
+
+jest.mock("../utils/graphClientHelper");
+
+type TestType = {
+  id: string;
+  name: string;
+};
+
+type TestFilter = {
+  name: string;
+};
+
+class MockDataMapper extends BaseDataMapper<TestType, TestFilter, unknown> {
+  protected typeName = "TestType";
+  protected gqlInterface = "{ id, name }";
+}
+
+describe("BaseDataMapper", () => {
+  const mockConf: Conf = {
+    subgraphUrl: "http://mock-subgraph.com",
+    chain: lineaSepolia,
+    mode: SDKMode.BACKEND,
+    portalRegistryAddress: "0x1",
+    moduleRegistryAddress: "0x2",
+    schemaRegistryAddress: "0x3",
+    attestationRegistryAddress: "0x4",
+  };
+
+  const mockWeb3Client = {} as PublicClient;
+  const mockWalletClient = {} as WalletClient;
+  const mockVeraxSdk = {} as VeraxSdk;
+
+  let mockDataMapper: MockDataMapper;
+
+  beforeEach(() => {
+    mockDataMapper = new MockDataMapper(mockConf, mockWeb3Client, mockVeraxSdk, mockWalletClient);
+    jest.clearAllMocks();
+  });
+
+  describe("findOneById", () => {
+    it("should call subgraphCall with the correct query and return the result", async () => {
+      const mockResponse = { data: { data: { TestType: { id: "1", name: "Test" } } }, status: 200 };
+      (subgraphCall as jest.Mock).mockResolvedValueOnce(mockResponse);
+
+      const result = await mockDataMapper.findOneById("1");
+
+      expect(subgraphCall).toHaveBeenCalledWith(
+        `query get_TestType { TestType(id: "1") { id, name } }`,
+        mockConf.subgraphUrl,
+      );
+      expect(result).toEqual({ id: "1", name: "Test" });
+    });
+
+    it("should throw an error if the status is not 200", async () => {
+      const mockResponse = { status: 500 };
+      (subgraphCall as jest.Mock).mockResolvedValueOnce(mockResponse);
+
+      await expect(mockDataMapper.findOneById("1")).rejects.toThrow("Error(s) while fetching TestType");
+    });
+
+    it("should return undefined if no data is found", async () => {
+      const mockResponse = { data: null, status: 200 };
+      (subgraphCall as jest.Mock).mockResolvedValueOnce(mockResponse);
+
+      const result = await mockDataMapper.findOneById("1");
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe("findBy", () => {
+    it("should call subgraphCall with the correct query and return the results", async () => {
+      const mockResponse = {
+        data: {
+          data: {
+            TestTypes: [
+              { id: "1", name: "Test1" },
+              { id: "2", name: "Test2" },
+            ],
+          },
+        },
+        status: 200,
+      };
+      (subgraphCall as jest.Mock).mockResolvedValueOnce(mockResponse);
+
+      const filter: TestFilter | undefined = { name: "Test" };
+      (stringifyWhereClause as jest.Mock).mockReturnValueOnce('{name:"Test"}');
+
+      const result = await mockDataMapper.findBy(10, 0, filter, "name", "asc");
+
+      expect(subgraphCall).toHaveBeenCalledWith(
+        `
+        query get_TestTypes{
+          TestTypes(
+            first: 10
+            skip: 0
+            where: {name:"Test"}
+            orderBy: name
+            orderDirection: asc
+          )
+          { id, name }
+        }
+    `,
+        mockConf.subgraphUrl,
+      );
+      expect(result).toEqual([
+        { id: "1", name: "Test1" },
+        { id: "2", name: "Test2" },
+      ]);
+    });
+
+    it("should return an empty array if no data is found", async () => {
+      const mockResponse = { data: { data: { TestTypes: [] } }, status: 200 };
+      (subgraphCall as jest.Mock).mockResolvedValueOnce(mockResponse);
+
+      const result = await mockDataMapper.findBy();
+
+      expect(result).toEqual([]);
+    });
+
+    it("should throw an error if the status is not 200", async () => {
+      const mockResponse = { status: 500 };
+      (subgraphCall as jest.Mock).mockResolvedValueOnce(mockResponse);
+
+      await expect(mockDataMapper.findBy()).rejects.toThrow("Error(s) while fetching TestTypes");
+    });
+  });
+});

--- a/sdk/src/dataMapper/ModuleDataMapper.test.ts
+++ b/sdk/src/dataMapper/ModuleDataMapper.test.ts
@@ -1,0 +1,120 @@
+import { PublicClient, WalletClient } from "viem";
+import { Conf, SDKMode, VeraxSdk } from "../VeraxSdk";
+import { subgraphCall } from "../utils/graphClientHelper";
+import ModuleDataMapper from "./ModuleDataMapper";
+import { lineaSepolia } from "viem/chains";
+
+jest.mock("../utils/graphClientHelper", () => ({
+  subgraphCall: jest.fn(),
+}));
+
+describe("ModuleDataMapper", () => {
+  let moduleDataMapper: ModuleDataMapper;
+  const mockConf: Conf = {
+    subgraphUrl: "http://mock-subgraph.com",
+    chain: lineaSepolia,
+    mode: SDKMode.BACKEND,
+    portalRegistryAddress: "0x1",
+    moduleRegistryAddress: "0x2",
+    schemaRegistryAddress: "0x3",
+    attestationRegistryAddress: "0x4",
+  };
+  const mockWeb3Client = {} as PublicClient;
+  const mockVeraxSdk = {} as VeraxSdk;
+  const mockWalletClient = {} as WalletClient;
+
+  beforeEach(() => {
+    moduleDataMapper = new ModuleDataMapper(mockConf, mockWeb3Client, mockVeraxSdk, mockWalletClient);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("findOneById should return a module if found", async () => {
+    const mockData = {
+      data: {
+        module: {
+          id: "1",
+          moduleAddress: "0x123",
+          name: "Module 1",
+          description: "Test module",
+        },
+      },
+    };
+
+    // Mocking subgraphCall to return mocked data
+    (subgraphCall as jest.Mock).mockResolvedValue({ data: mockData, status: 200 });
+
+    const result = await moduleDataMapper.findOneById("1");
+
+    expect(subgraphCall).toHaveBeenCalledWith(
+      `query get_module { module(id: "1") {
+        id
+        moduleAddress
+        name
+        description
+  } }`,
+      "http://mock-subgraph.com",
+    );
+    expect(result).toEqual(mockData.data.module);
+  });
+
+  test("findOneById should throw an error if the response status is not 200", async () => {
+    (subgraphCall as jest.Mock).mockResolvedValue({ status: 500 });
+
+    await expect(moduleDataMapper.findOneById("1")).rejects.toThrowError("Error(s) while fetching module");
+  });
+
+  test("findBy should return modules if found", async () => {
+    const mockData = {
+      data: {
+        modules: [
+          { id: "1", moduleAddress: "0x123", name: "Module 1", description: "Test module 1" },
+          { id: "2", moduleAddress: "0x456", name: "Module 2", description: "Test module 2" },
+        ],
+      },
+    };
+
+    (subgraphCall as jest.Mock).mockResolvedValue({ data: mockData, status: 200 });
+
+    const result = await moduleDataMapper.findBy();
+
+    expect(subgraphCall).toHaveBeenCalledWith(
+      `
+        query get_modules{
+          modules(
+            first: 100
+            skip: 0
+            where: null
+            orderBy: null
+            orderDirection: null
+          )
+          {
+        id
+        moduleAddress
+        name
+        description
+  }
+        }
+    `,
+      mockConf.subgraphUrl,
+    );
+    expect(result).toEqual(mockData.data.modules);
+  });
+
+  test("findBy should return an empty array if no modules found", async () => {
+    const mockData = { data: { modules: [] } };
+    (subgraphCall as jest.Mock).mockResolvedValue({ data: mockData, status: 200 });
+
+    const result = await moduleDataMapper.findBy();
+
+    expect(result).toEqual([]);
+  });
+
+  test("findBy should throw an error if the response status is not 200", async () => {
+    (subgraphCall as jest.Mock).mockResolvedValue({ status: 500 });
+
+    await expect(moduleDataMapper.findBy()).rejects.toThrowError("Error(s) while fetching modules");
+  });
+});

--- a/sdk/src/dataMapper/PortalDataMapper.test.ts
+++ b/sdk/src/dataMapper/PortalDataMapper.test.ts
@@ -1,0 +1,128 @@
+import { PublicClient, WalletClient } from "viem";
+import { Conf, SDKMode, VeraxSdk } from "../VeraxSdk";
+import { subgraphCall } from "../utils/graphClientHelper";
+import PortalDataMapper from "./PortalDataMapper";
+import { lineaSepolia } from "viem/chains";
+
+jest.mock("../utils/graphClientHelper", () => ({
+  subgraphCall: jest.fn(),
+}));
+
+describe("PortalDataMapper", () => {
+  let portalDataMapper: PortalDataMapper;
+  const mockConf: Conf = {
+    subgraphUrl: "http://mock-subgraph.com",
+    chain: lineaSepolia,
+    mode: SDKMode.BACKEND,
+    portalRegistryAddress: "0x1",
+    moduleRegistryAddress: "0x2",
+    schemaRegistryAddress: "0x3",
+    attestationRegistryAddress: "0x4",
+  };
+  const mockWeb3Client = {} as PublicClient;
+  const mockVeraxSdk = {} as VeraxSdk;
+  const mockWalletClient = {} as WalletClient;
+
+  beforeEach(() => {
+    portalDataMapper = new PortalDataMapper(mockConf, mockWeb3Client, mockVeraxSdk, mockWalletClient);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("findOneById should return a portal if found", async () => {
+    const mockData = {
+      data: {
+        portal: {
+          id: "1",
+          portalAddress: "0x123",
+          name: "Portal 1",
+          description: "Test portal",
+        },
+      },
+    };
+
+    // Mocking subgraphCall to return mocked data
+    (subgraphCall as jest.Mock).mockResolvedValue({ data: mockData, status: 200 });
+
+    const result = await portalDataMapper.findOneById("1");
+
+    expect(subgraphCall).toHaveBeenCalledWith(
+      `query get_portal { portal(id: "1") {
+        id
+        ownerAddress
+        modules
+        isRevocable
+        name
+        description
+        ownerName
+        attestationCounter
+  } }`,
+      "http://mock-subgraph.com",
+    );
+    expect(result).toEqual(mockData.data.portal);
+  });
+
+  test("findOneById should throw an error if the response status is not 200", async () => {
+    (subgraphCall as jest.Mock).mockResolvedValue({ status: 500 });
+
+    await expect(portalDataMapper.findOneById("1")).rejects.toThrowError("Error(s) while fetching portal");
+  });
+
+  test("findBy should return portals if found", async () => {
+    const mockData = {
+      data: {
+        portals: [
+          { id: "1", portalAddress: "0x123", name: "Portal 1", description: "Test portal 1" },
+          { id: "2", portalAddress: "0x456", name: "Portal 2", description: "Test portal 2" },
+        ],
+      },
+    };
+
+    (subgraphCall as jest.Mock).mockResolvedValue({ data: mockData, status: 200 });
+
+    const result = await portalDataMapper.findBy();
+
+    expect(subgraphCall).toHaveBeenCalledWith(
+      `
+        query get_portals{
+          portals(
+            first: 100
+            skip: 0
+            where: null
+            orderBy: null
+            orderDirection: null
+          )
+          {
+        id
+        ownerAddress
+        modules
+        isRevocable
+        name
+        description
+        ownerName
+        attestationCounter
+  }
+        }
+    `,
+      mockConf.subgraphUrl,
+    );
+    expect(result).toEqual(mockData.data.portals);
+  });
+
+  test("findBy should return an empty array if no portals found", async () => {
+    const mockData = { data: { portals: [] } };
+    (subgraphCall as jest.Mock).mockResolvedValue({ data: mockData, status: 200 });
+
+    const result = await portalDataMapper.findBy();
+
+    expect(result).toEqual([]);
+  });
+
+  test("findBy should throw an error if the response status is not 200", async () => {
+    (subgraphCall as jest.Mock).mockResolvedValue({ status: 500 });
+
+    await expect(portalDataMapper.findBy()).rejects.toThrowError("Error(s) while fetching portals");
+  });
+});

--- a/sdk/src/dataMapper/SchemaDataMapper.test.ts
+++ b/sdk/src/dataMapper/SchemaDataMapper.test.ts
@@ -1,0 +1,124 @@
+import { PublicClient, WalletClient } from "viem";
+import { Conf, SDKMode, VeraxSdk } from "../VeraxSdk";
+import { subgraphCall } from "../utils/graphClientHelper";
+import SchemaDataMapper from "./SchemaDataMapper";
+import { lineaSepolia } from "viem/chains";
+
+jest.mock("../utils/graphClientHelper", () => ({
+  subgraphCall: jest.fn(),
+}));
+
+describe("SchemaDataMapper", () => {
+  let schemaDataMapper: SchemaDataMapper;
+  const mockConf: Conf = {
+    subgraphUrl: "http://mock-subgraph.com",
+    chain: lineaSepolia,
+    mode: SDKMode.BACKEND,
+    schemaRegistryAddress: "0x1",
+    moduleRegistryAddress: "0x2",
+    portalRegistryAddress: "0x3",
+    attestationRegistryAddress: "0x4",
+  };
+  const mockWeb3Client = {} as PublicClient;
+  const mockVeraxSdk = {} as VeraxSdk;
+  const mockWalletClient = {} as WalletClient;
+
+  beforeEach(() => {
+    schemaDataMapper = new SchemaDataMapper(mockConf, mockWeb3Client, mockVeraxSdk, mockWalletClient);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("findOneById should return a schema if found", async () => {
+    const mockData = {
+      data: {
+        schema: {
+          id: "1",
+          schemaAddress: "0x123",
+          name: "Schema 1",
+          description: "Test schema",
+        },
+      },
+    };
+
+    // Mocking subgraphCall to return mocked data
+    (subgraphCall as jest.Mock).mockResolvedValue({ data: mockData, status: 200 });
+
+    const result = await schemaDataMapper.findOneById("1");
+
+    expect(subgraphCall).toHaveBeenCalledWith(
+      `query get_schema { schema(id: "1") {
+        id
+        name
+        description
+        context
+        schema
+        attestationCounter
+  } }`,
+      "http://mock-subgraph.com",
+    );
+    expect(result).toEqual(mockData.data.schema);
+  });
+
+  test("findOneById should throw an error if the response status is not 200", async () => {
+    (subgraphCall as jest.Mock).mockResolvedValue({ status: 500 });
+
+    await expect(schemaDataMapper.findOneById("1")).rejects.toThrowError("Error(s) while fetching schema");
+  });
+
+  test("findBy should return schemas if found", async () => {
+    const mockData = {
+      data: {
+        schemas: [
+          { id: "1", schemaAddress: "0x123", name: "Schema 1", description: "Test schema 1" },
+          { id: "2", schemaAddress: "0x456", name: "Schema 2", description: "Test schema 2" },
+        ],
+      },
+    };
+
+    (subgraphCall as jest.Mock).mockResolvedValue({ data: mockData, status: 200 });
+
+    const result = await schemaDataMapper.findBy();
+
+    expect(subgraphCall).toHaveBeenCalledWith(
+      `
+        query get_schemas{
+          schemas(
+            first: 100
+            skip: 0
+            where: null
+            orderBy: null
+            orderDirection: null
+          )
+          {
+        id
+        name
+        description
+        context
+        schema
+        attestationCounter
+  }
+        }
+    `,
+      mockConf.subgraphUrl,
+    );
+    expect(result).toEqual(mockData.data.schemas);
+  });
+
+  test("findBy should return an empty array if no schemas found", async () => {
+    const mockData = { data: { schemas: [] } };
+    (subgraphCall as jest.Mock).mockResolvedValue({ data: mockData, status: 200 });
+
+    const result = await schemaDataMapper.findBy();
+
+    expect(result).toEqual([]);
+  });
+
+  test("findBy should throw an error if the response status is not 200", async () => {
+    (subgraphCall as jest.Mock).mockResolvedValue({ status: 500 });
+
+    await expect(schemaDataMapper.findBy()).rejects.toThrowError("Error(s) while fetching schemas");
+  });
+});

--- a/sdk/src/utils/abiCoder.test.ts
+++ b/sdk/src/utils/abiCoder.test.ts
@@ -1,0 +1,101 @@
+import { encode, decode, decodeWithRetry } from "./abiCoder";
+import { encodeAbiParameters, decodeAbiParameters, parseAbiParameters } from "viem";
+
+jest.mock("viem", () => ({
+  encodeAbiParameters: jest.fn(),
+  decodeAbiParameters: jest.fn(),
+  parseAbiParameters: jest.fn(),
+}));
+
+describe("abiCoder", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("encode", () => {
+    it("should encode the values with the given schema", () => {
+      const schema = "uint256";
+      const values = [123];
+      const mockEncodedData = "0xabc123";
+
+      (parseAbiParameters as jest.Mock).mockReturnValue([schema]);
+      (encodeAbiParameters as jest.Mock).mockReturnValue(mockEncodedData);
+
+      const result = encode(schema, values);
+
+      expect(parseAbiParameters).toHaveBeenCalledWith(schema);
+      expect(encodeAbiParameters).toHaveBeenCalledWith([schema], values);
+      expect(result).toBe(mockEncodedData);
+    });
+  });
+
+  describe("decode", () => {
+    it("should decode attestation data with the given schema", () => {
+      const schema = "uint256";
+      const attestationData = "0xabc123";
+      const mockDecodedData = [123];
+
+      (parseAbiParameters as jest.Mock).mockReturnValue([schema]);
+      (decodeAbiParameters as jest.Mock).mockReturnValue(mockDecodedData);
+
+      const result = decode(schema, attestationData);
+
+      expect(parseAbiParameters).toHaveBeenCalledWith(schema);
+      expect(decodeAbiParameters).toHaveBeenCalledWith([schema], attestationData);
+      expect(result).toBe(mockDecodedData);
+    });
+  });
+
+  describe("decodeWithRetry", () => {
+    it("should decode successfully without retry", () => {
+      const schema = "(uint256)";
+      const attestationData = "0xabc123";
+      const mockDecodedData = [123];
+
+      (parseAbiParameters as jest.Mock).mockReturnValue([schema]);
+      (decodeAbiParameters as jest.Mock).mockReturnValue(mockDecodedData);
+
+      const result = decodeWithRetry(schema, attestationData);
+
+      expect(parseAbiParameters).toHaveBeenCalledWith(schema);
+      expect(decodeAbiParameters).toHaveBeenCalledWith([schema], attestationData);
+      expect(result).toBe(mockDecodedData);
+    });
+
+    it("should retry with prefixed encoded parenthesis if no result initially", () => {
+      const schema = "uint256";
+      const attestationData = "0xdef456";
+      const mockEmptyDecodedData: readonly unknown[] = [];
+      const mockDecodedDataAfterRetry = [456];
+
+      (parseAbiParameters as jest.Mock).mockReturnValue([schema]);
+      (decodeAbiParameters as jest.Mock)
+        .mockReturnValueOnce(mockEmptyDecodedData) // First try returns empty array
+        .mockReturnValueOnce(mockDecodedDataAfterRetry); // Retry returns valid data
+
+      const result = decodeWithRetry(schema, attestationData);
+
+      expect(parseAbiParameters).toHaveBeenCalledWith(`(${schema})`);
+      expect(decodeAbiParameters).toHaveBeenNthCalledWith(1, [schema], attestationData);
+      expect(decodeAbiParameters).toHaveBeenNthCalledWith(
+        2,
+        [schema],
+        `0x0000000000000000000000000000000000000000000000000000000000000020${attestationData.substring(2)}`,
+      );
+      expect(result).toBe(mockDecodedDataAfterRetry);
+    });
+
+    it("should return empty array if both attempts fail", () => {
+      const schema = "uint256";
+      const attestationData = "0xdef456";
+      const mockEmptyDecodedData: readonly unknown[] = [];
+
+      (parseAbiParameters as jest.Mock).mockReturnValue([schema]);
+      (decodeAbiParameters as jest.Mock).mockReturnValue(mockEmptyDecodedData);
+
+      const result = decodeWithRetry(schema, attestationData);
+
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/sdk/src/utils/abiCoder.test.ts
+++ b/sdk/src/utils/abiCoder.test.ts
@@ -1,11 +1,21 @@
 import { encode, decode, decodeWithRetry } from "./abiCoder";
 import { encodeAbiParameters, decodeAbiParameters, parseAbiParameters } from "viem";
 
+// Mock viem functions
 jest.mock("viem", () => ({
   encodeAbiParameters: jest.fn(),
   decodeAbiParameters: jest.fn(),
   parseAbiParameters: jest.fn(),
 }));
+
+// Mocking the BaseError as it's not a constructible error
+const BaseErrorMock = class extends Error {
+  shortMessage: string;
+  constructor(message: string) {
+    super(message);
+    this.shortMessage = message;
+  }
+};
 
 describe("abiCoder", () => {
   beforeEach(() => {
@@ -96,6 +106,115 @@ describe("abiCoder", () => {
       const result = decodeWithRetry(schema, attestationData);
 
       expect(result).toEqual([]);
+    });
+  });
+
+  describe("tryParse", () => {
+    it("should reverse the schema when it starts with parentheses", () => {
+      const schema = "(uint256 address)";
+      const reversedSchema = "(address uint256)";
+      const attestationData = "0xabc123";
+      const mockDecodedData = ["0xaddress", 123];
+
+      const error = new BaseErrorMock("Invalid ABI parameter.");
+
+      // Mock `parseAbiParameters` to throw an error first, then succeed after schema reversal
+      (parseAbiParameters as jest.Mock)
+        .mockImplementationOnce(() => {
+          throw error; // First attempt with the original schema throws an error
+        })
+        .mockReturnValueOnce([reversedSchema]); // Second attempt with reversed schema
+
+      (decodeAbiParameters as jest.Mock).mockReturnValue(mockDecodedData);
+
+      const result = decodeWithRetry(schema, attestationData);
+
+      // Check if the schema was parsed correctly and reversed after failure
+      expect(parseAbiParameters).toHaveBeenNthCalledWith(1, "(uint256 address)");
+      expect(parseAbiParameters).toHaveBeenNthCalledWith(2, "(address uint256)");
+      expect(decodeAbiParameters).toHaveBeenCalledWith([reversedSchema], attestationData);
+      expect(result).toBe(mockDecodedData);
+    });
+
+    it("should reverse the schema when it does not start with parentheses", () => {
+      const schema = "uint256 address";
+      const reversedSchema = "address uint256";
+      const attestationData = "0xabc123";
+      const mockDecodedData = ["0xaddress", 123];
+
+      const error = new BaseErrorMock("Invalid ABI parameter.");
+
+      // Since the schema is automatically wrapped with parentheses, we need to adjust the expectation
+      (parseAbiParameters as jest.Mock)
+        .mockImplementationOnce(() => {
+          throw error; // First attempt with the wrapped schema
+        })
+        .mockReturnValueOnce([reversedSchema]); // Second attempt after reversing
+
+      (decodeAbiParameters as jest.Mock).mockReturnValue(mockDecodedData);
+
+      const result = decodeWithRetry(schema, attestationData);
+
+      // Expect the wrapped schema on the first call
+      expect(parseAbiParameters).toHaveBeenNthCalledWith(1, "(uint256 address)");
+      // Expect the reversed schema on the second call
+      expect(parseAbiParameters).toHaveBeenNthCalledWith(2, "(address uint256)");
+      expect(decodeAbiParameters).toHaveBeenCalledWith([reversedSchema], attestationData);
+      expect(result).toBe(mockDecodedData);
+    });
+
+    it("should return empty array if reverse schema also fails", () => {
+      const schema = "uint256 address";
+      const attestationData = "0xabc123";
+
+      const error = new BaseErrorMock("Invalid ABI parameter.");
+
+      (parseAbiParameters as jest.Mock).mockImplementation(() => {
+        throw error; // throws an error
+      });
+      (decodeAbiParameters as jest.Mock).mockReturnValue([]);
+
+      const result = decodeWithRetry(schema, attestationData);
+
+      expect(parseAbiParameters).toHaveBeenCalledTimes(4);
+      expect(result).toEqual([]);
+    });
+
+    it("should return empty array if decodeAbiParameters fails", () => {
+      const schema = "(uint256)";
+      const attestationData = "0xabc123";
+
+      (parseAbiParameters as jest.Mock).mockReturnValue([schema]);
+
+      const error = new BaseErrorMock("Some error");
+      (decodeAbiParameters as jest.Mock).mockImplementation(() => {
+        throw error; // throws an error
+      });
+
+      const result = decodeWithRetry(schema, attestationData);
+
+      expect(parseAbiParameters).toHaveBeenCalledWith(schema);
+      expect(decodeAbiParameters).toHaveBeenCalledWith([schema], attestationData);
+      expect(parseAbiParameters).toHaveBeenCalledTimes(2);
+      expect(result).toEqual([]);
+    });
+
+    it("should return empty array on BaseError without 'Invalid ABI parameter.' message", () => {
+      const schema = "uint256 address";
+      const attestationData = "0xabc123";
+
+      const error = new BaseErrorMock("Some other message");
+
+      (parseAbiParameters as jest.Mock).mockImplementationOnce(() => {
+        throw error; // throws an error
+      });
+      (decodeAbiParameters as jest.Mock).mockReturnValue([]);
+
+      const result = decodeWithRetry(schema, attestationData);
+
+      expect(parseAbiParameters).toHaveBeenNthCalledWith(1, `(${schema})`);
+      expect(decodeAbiParameters).toHaveBeenCalledWith([], attestationData);
+      expect(result).toStrictEqual([]);
     });
   });
 });

--- a/sdk/src/utils/errorHandler.test.ts
+++ b/sdk/src/utils/errorHandler.test.ts
@@ -1,0 +1,65 @@
+import { BaseError, ContractFunctionRevertedError, Abi } from "viem";
+import { handleError } from "./errorHandler";
+import { ActionType } from "./constants";
+
+describe("errorHandler", () => {
+  const mockAbi: Abi = [
+    {
+      name: "myFunction",
+      type: "function",
+      inputs: [{ name: "param1", type: "uint256" }],
+      outputs: [{ name: "", type: "bool" }],
+      stateMutability: "nonpayable",
+    },
+  ];
+
+  const mockBaseError = new BaseError("Base error");
+  const mockRevertedError = new ContractFunctionRevertedError({
+    abi: mockAbi,
+    functionName: "myFunction",
+    data: "0x1234",
+  });
+
+  mockRevertedError.data = {
+    errorName: "MockErrorName",
+    abiItem: mockAbi[0],
+    args: [42],
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+  describe("handleError", () => {
+    const actionType: ActionType = ActionType.Transaction;
+
+    it("should throw with the revert error name if error is a ContractFunctionRevertedError", () => {
+      jest.spyOn(mockBaseError, "walk").mockImplementation((fn: (arg0: unknown) => unknown) => {
+        return fn(mockRevertedError) ? mockRevertedError : null;
+      });
+
+      expect(() => handleError(actionType, mockBaseError)).toThrow(`${actionType} failed with MockErrorName`);
+    });
+
+    it("should throw a generic error message if it's an instance of BaseError but not ContractFunctionRevertedError", () => {
+      const mockBaseError = new BaseError("Base error");
+
+      jest.spyOn(mockBaseError, "walk").mockImplementation(() => null);
+
+      expect(() => handleError(actionType, mockBaseError)).toThrow("${type} failed");
+    });
+
+    it("should throw a generic error message if error is not an instance of BaseError", () => {
+      const genericError = "Something went wrong";
+
+      expect(() => handleError(actionType, genericError)).toThrow(`${actionType} failed with ${genericError}`);
+    });
+
+    it("should throw a generic error message even when there is no errorName in ContractFunctionRevertedError", () => {
+      jest.spyOn(mockBaseError, "walk").mockImplementation((fn: (arg0: unknown) => unknown) => {
+        return fn(mockRevertedError) ? mockRevertedError : null;
+      });
+
+      expect(() => handleError(actionType, mockBaseError)).toThrow(`${actionType} failed with `);
+    });
+  });
+});

--- a/sdk/src/utils/errorHandler.test.ts
+++ b/sdk/src/utils/errorHandler.test.ts
@@ -40,6 +40,19 @@ describe("errorHandler", () => {
       expect(() => handleError(actionType, mockBaseError)).toThrow(`${actionType} failed with MockErrorName`);
     });
 
+    it("should throw a generic error message if errorName is undefined", () => {
+      // Temporarily cast mockRevertedError.data to bypass TypeScript checks for testing
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (mockRevertedError.data as any).errorName = undefined; // Simulate errorName being `undefined`
+
+      jest.spyOn(mockBaseError, "walk").mockImplementation((fn: (arg0: unknown) => unknown) => {
+        return fn(mockRevertedError) ? mockRevertedError : null;
+      });
+
+      // This should test the code path where `errorName` is `undefined` and fallback to an empty string
+      expect(() => handleError(actionType, mockBaseError)).toThrow(`${actionType} failed with `);
+    });
+
     it("should throw a generic error message if it's an instance of BaseError but not ContractFunctionRevertedError", () => {
       const mockBaseError = new BaseError("Base error");
 

--- a/sdk/src/utils/graphClientHelper.test.ts
+++ b/sdk/src/utils/graphClientHelper.test.ts
@@ -1,0 +1,64 @@
+import axios from "axios";
+import { stringifyWhereClause, subgraphCall } from "./graphClientHelper";
+
+jest.mock("axios");
+
+describe("graphClientHelper", () => {
+  const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+  describe("stringifyWhereClause", () => {
+    it("should stringify an object and remove double quotes from keys", () => {
+      const input = { key1: "value1", key2: 123, key3: true };
+      const result = stringifyWhereClause(input);
+      expect(result).toBe('{key1:"value1",key2:123,key3:true}');
+    });
+
+    it("should handle an empty object", () => {
+      const input = {};
+      const result = stringifyWhereClause(input);
+      expect(result).toBe("{}");
+    });
+
+    it("should handle special characters in keys", () => {
+      const input = { "key-name": "value" };
+      const result = stringifyWhereClause(input);
+      expect(result).toBe('{key-name:"value"}');
+    });
+  });
+
+  describe("subgraphCall", () => {
+    const mockUrl = "http://mocked-url.com";
+    const mockQuery = "{ mockQuery }";
+
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it("should make a POST request with the correct headers", async () => {
+      const mockResponse = { data: { someData: "testData" } };
+      mockedAxios.post.mockResolvedValue(mockResponse);
+
+      const result = await subgraphCall(mockQuery, mockUrl);
+
+      expect(mockedAxios.post).toHaveBeenCalledWith(
+        mockUrl,
+        { query: mockQuery },
+        {
+          headers: {
+            "Content-Type": "application/json",
+            Accept: "application/json",
+          },
+        },
+      );
+
+      expect(result).toBe(mockResponse);
+    });
+
+    it("should handle errors from the axios request", async () => {
+      const mockError = new Error("Network Error");
+      mockedAxios.post.mockRejectedValue(mockError);
+
+      await expect(subgraphCall(mockQuery, mockUrl)).rejects.toThrow("Network Error");
+    });
+  });
+});

--- a/sdk/src/utils/ipfsClient.test.ts
+++ b/sdk/src/utils/ipfsClient.test.ts
@@ -1,0 +1,34 @@
+import axios from "axios";
+import { getIPFSContent } from "./ipfsClient";
+
+jest.mock("axios");
+
+describe("ipfsClient", () => {
+  describe("getIPFSContent", () => {
+    const ipfsHash = "QmXoypizjW3WknFiJnKLwHCnL72vedxjQkddHjMGJkGivK";
+    const mockIPFSData = "Mock IPFS content";
+
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it("should fetch and return content from IPFS", async () => {
+      (axios.get as jest.Mock).mockResolvedValueOnce({
+        data: mockIPFSData,
+      });
+
+      const content = await getIPFSContent(ipfsHash);
+      expect(axios.get).toHaveBeenCalledWith(`https://cloudflare-ipfs.com/ipfs/${ipfsHash}`);
+      expect(content).toBe(mockIPFSData);
+    });
+
+    it("should throw an error when the request fails", async () => {
+      const mockError = new Error("Network error");
+
+      (axios.get as jest.Mock).mockRejectedValueOnce(mockError);
+
+      await expect(getIPFSContent(ipfsHash)).rejects.toThrow("Network error");
+      expect(axios.get).toHaveBeenCalledWith(`https://cloudflare-ipfs.com/ipfs/${ipfsHash}`);
+    });
+  });
+});

--- a/sdk/tsconfig.build.json
+++ b/sdk/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["test", "examples"]
+  "exclude": ["test", "examples", "**/*.test.ts"]
 }


### PR DESCRIPTION
## What does this PR do?
Unit tests are added in SDK for utils and base data mapper

### Related ticket

Fixes #727 

### Type of change

- [x] Chore
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update

## Check list

- [x] Unit tests for any smart contract change
- [ ] Contracts and functions are documented
