### PR TITLE
chore(sdk): Add a call to attestV2 at the SDK level

### DIFF
--- a/sdk/examples/portal/portalExamples.ts
+++ b/sdk/examples/portal/portalExamples.ts
@@ -52,6 +52,40 @@ export default class PortalExamples {
       );
     }
 
+    if (methodName.toLowerCase() == "simulateAttestV2".toLowerCase() || methodName == "") {
+      let params;
+      if (argv !== "") params = JSON.parse(argv);
+      const portalAddress = params?.portalAddress
+        ? (params.portalAddress as Address)
+        : "0xA93162E5de5c1dcb4762cda08A26aeE4C5b9F264";
+      const attestationPayload = params?.attestationPayload ?? {
+        schemaId: "0x2049fef3764ceceb65a9a4a001b3824dac1d05cf5a46c3f4436cf23d280b87de",
+        expirationDate: Math.floor(Date.now() / 1000) + 2592000,
+        subject: "0x6eCfD8252C19aC2Bf4bd1cBdc026C001C93E179D",
+        attestationData: [{ hasCompletedTutorial: true }],
+      };
+      const validationPayloads = params?.validationPayloads ?? [];
+      console.log(await this.veraxSdk.portal.simulateAttestV2(portalAddress, attestationPayload, validationPayloads));
+    }
+
+    if (methodName.toLowerCase() == "attestV2".toLowerCase() || methodName == "") {
+      let params;
+      if (argv !== "") params = JSON.parse(argv);
+      const portalAddress = params?.portalAddress
+        ? (params.portalAddress as Address)
+        : "0xA93162E5de5c1dcb4762cda08A26aeE4C5b9F264";
+      const attestationPayload = params?.attestationPayload ?? {
+        schemaId: "0x2049fef3764ceceb65a9a4a001b3824dac1d05cf5a46c3f4436cf23d280b87de",
+        expirationDate: Math.floor(Date.now() / 1000) + 2592000,
+        subject: "0x6eCfD8252C19aC2Bf4bd1cBdc026C001C93E179D",
+        attestationData: [{ hasCompletedTutorial: true }],
+      };
+      const validationPayloads = params?.validationPayloads ?? [];
+      console.log(
+        await this.veraxSdk.portal.attestV2(portalAddress, attestationPayload, validationPayloads, waitForConfirmation),
+      );
+    }
+
     if (methodName.toLowerCase() == "simulateBulkAttest".toLowerCase() || methodName == "") {
       let params;
       if (argv !== "") params = JSON.parse(argv);

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verax-attestation-registry/verax-sdk",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Verax Attestation Registry SDK to interact with the subgraph and the contracts",
   "keywords": [
     "linea-attestation-registry",

--- a/sdk/src/abi/DefaultPortal.ts
+++ b/sdk/src/abi/DefaultPortal.ts
@@ -1,26 +1,5 @@
 export const abiDefaultPortal = [
   {
-    inputs: [
-      {
-        internalType: "address[]",
-        name: "modules",
-        type: "address[]",
-      },
-      {
-        internalType: "address",
-        name: "router",
-        type: "address",
-      },
-    ],
-    stateMutability: "nonpayable",
-    type: "constructor",
-  },
-  {
-    inputs: [],
-    name: "OnlyPortalOwner",
-    type: "error",
-  },
-  {
     inputs: [],
     name: "AlreadyRevoked",
     type: "error",
@@ -71,333 +50,598 @@ export const abiDefaultPortal = [
     type: "error",
   },
   {
+    inputs: [],
+    name: "AttestationPayloadMissing",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "ModuleAddressInvalid",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "ModuleAlreadyExists",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "ModuleInvalid",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "ModuleNameMissing",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "ModuleNotRegistered",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "ModuleValidationPayloadMismatch",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "OnlyIssuer",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "PortalAddressInvalid",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "PortalAlreadyExists",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "PortalDescriptionMissing",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "PortalInvalid",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "PortalNameMissing",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "PortalNotRegistered",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "PortalOwnerNameMissing",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "SchemaAlreadyExists",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "SchemaNameMissing",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "SchemaStringMissing",
+    type: "error",
+  },
+  {
+    type: "function",
+    name: "attest",
     inputs: [
       {
-        components: [
-          {
-            internalType: "bytes32",
-            name: "schemaId",
-            type: "bytes32",
-          },
-          {
-            internalType: "uint64",
-            name: "expirationDate",
-            type: "uint64",
-          },
-          {
-            internalType: "bytes",
-            name: "subject",
-            type: "bytes",
-          },
-          {
-            internalType: "bytes",
-            name: "attestationData",
-            type: "bytes",
-          },
-        ],
-        internalType: "struct AttestationPayload",
         name: "attestationPayload",
         type: "tuple",
+        internalType: "struct AttestationPayload",
+        components: [
+          {
+            name: "schemaId",
+            type: "bytes32",
+            internalType: "bytes32",
+          },
+          {
+            name: "expirationDate",
+            type: "uint64",
+            internalType: "uint64",
+          },
+          {
+            name: "subject",
+            type: "bytes",
+            internalType: "bytes",
+          },
+          {
+            name: "attestationData",
+            type: "bytes",
+            internalType: "bytes",
+          },
+        ],
       },
       {
-        internalType: "bytes[]",
         name: "validationPayloads",
         type: "bytes[]",
+        internalType: "bytes[]",
       },
     ],
-    name: "attest",
     outputs: [],
     stateMutability: "payable",
-    type: "function",
   },
   {
-    inputs: [],
+    type: "function",
+    name: "attestV2",
+    inputs: [
+      {
+        name: "attestationPayload",
+        type: "tuple",
+        internalType: "struct AttestationPayload",
+        components: [
+          {
+            name: "schemaId",
+            type: "bytes32",
+            internalType: "bytes32",
+          },
+          {
+            name: "expirationDate",
+            type: "uint64",
+            internalType: "uint64",
+          },
+          {
+            name: "subject",
+            type: "bytes",
+            internalType: "bytes",
+          },
+          {
+            name: "attestationData",
+            type: "bytes",
+            internalType: "bytes",
+          },
+        ],
+      },
+      {
+        name: "validationPayloads",
+        type: "bytes[]",
+        internalType: "bytes[]",
+      },
+    ],
+    outputs: [],
+    stateMutability: "payable",
+  },
+  {
+    type: "function",
     name: "attestationRegistry",
+    inputs: [],
     outputs: [
       {
+        name: "",
+        type: "address",
         internalType: "contract AttestationRegistry",
-        name: "",
-        type: "address",
       },
     ],
     stateMutability: "view",
-    type: "function",
   },
   {
-    inputs: [
-      {
-        components: [
-          {
-            internalType: "bytes32",
-            name: "schemaId",
-            type: "bytes32",
-          },
-          {
-            internalType: "uint64",
-            name: "expirationDate",
-            type: "uint64",
-          },
-          {
-            internalType: "bytes",
-            name: "subject",
-            type: "bytes",
-          },
-          {
-            internalType: "bytes",
-            name: "attestationData",
-            type: "bytes",
-          },
-        ],
-        internalType: "struct AttestationPayload[]",
-        name: "attestationsPayloads",
-        type: "tuple[]",
-      },
-      {
-        internalType: "bytes[][]",
-        name: "validationPayloads",
-        type: "bytes[][]",
-      },
-    ],
+    type: "function",
     name: "bulkAttest",
-    outputs: [],
-    stateMutability: "nonpayable",
-    type: "function",
-  },
-  {
     inputs: [
       {
-        internalType: "bytes32[]",
-        name: "attestationIds",
-        type: "bytes32[]",
-      },
-      {
-        components: [
-          {
-            internalType: "bytes32",
-            name: "schemaId",
-            type: "bytes32",
-          },
-          {
-            internalType: "uint64",
-            name: "expirationDate",
-            type: "uint64",
-          },
-          {
-            internalType: "bytes",
-            name: "subject",
-            type: "bytes",
-          },
-          {
-            internalType: "bytes",
-            name: "attestationData",
-            type: "bytes",
-          },
-        ],
-        internalType: "struct AttestationPayload[]",
         name: "attestationsPayloads",
         type: "tuple[]",
+        internalType: "struct AttestationPayload[]",
+        components: [
+          {
+            name: "schemaId",
+            type: "bytes32",
+            internalType: "bytes32",
+          },
+          {
+            name: "expirationDate",
+            type: "uint64",
+            internalType: "uint64",
+          },
+          {
+            name: "subject",
+            type: "bytes",
+            internalType: "bytes",
+          },
+          {
+            name: "attestationData",
+            type: "bytes",
+            internalType: "bytes",
+          },
+        ],
       },
       {
-        internalType: "bytes[][]",
         name: "validationPayloads",
         type: "bytes[][]",
+        internalType: "bytes[][]",
       },
     ],
-    name: "bulkReplace",
     outputs: [],
     stateMutability: "nonpayable",
-    type: "function",
   },
   {
+    type: "function",
+    name: "bulkAttestV2",
     inputs: [
       {
-        internalType: "bytes32[]",
-        name: "attestationIds",
-        type: "bytes32[]",
+        name: "attestationPayloads",
+        type: "tuple[]",
+        internalType: "struct AttestationPayload[]",
+        components: [
+          {
+            name: "schemaId",
+            type: "bytes32",
+            internalType: "bytes32",
+          },
+          {
+            name: "expirationDate",
+            type: "uint64",
+            internalType: "uint64",
+          },
+          {
+            name: "subject",
+            type: "bytes",
+            internalType: "bytes",
+          },
+          {
+            name: "attestationData",
+            type: "bytes",
+            internalType: "bytes",
+          },
+        ],
+      },
+      {
+        name: "validationPayloads",
+        type: "bytes[][]",
+        internalType: "bytes[][]",
       },
     ],
-    name: "bulkRevoke",
     outputs: [],
     stateMutability: "nonpayable",
-    type: "function",
   },
   {
-    inputs: [],
+    type: "function",
+    name: "bulkReplace",
+    inputs: [
+      {
+        name: "attestationIds",
+        type: "bytes32[]",
+        internalType: "bytes32[]",
+      },
+      {
+        name: "attestationsPayloads",
+        type: "tuple[]",
+        internalType: "struct AttestationPayload[]",
+        components: [
+          {
+            name: "schemaId",
+            type: "bytes32",
+            internalType: "bytes32",
+          },
+          {
+            name: "expirationDate",
+            type: "uint64",
+            internalType: "uint64",
+          },
+          {
+            name: "subject",
+            type: "bytes",
+            internalType: "bytes",
+          },
+          {
+            name: "attestationData",
+            type: "bytes",
+            internalType: "bytes",
+          },
+        ],
+      },
+      {
+        name: "validationPayloads",
+        type: "bytes[][]",
+        internalType: "bytes[][]",
+      },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "bulkReplaceV2",
+    inputs: [
+      {
+        name: "attestationIds",
+        type: "bytes32[]",
+        internalType: "bytes32[]",
+      },
+      {
+        name: "attestationsPayloads",
+        type: "tuple[]",
+        internalType: "struct AttestationPayload[]",
+        components: [
+          {
+            name: "schemaId",
+            type: "bytes32",
+            internalType: "bytes32",
+          },
+          {
+            name: "expirationDate",
+            type: "uint64",
+            internalType: "uint64",
+          },
+          {
+            name: "subject",
+            type: "bytes",
+            internalType: "bytes",
+          },
+          {
+            name: "attestationData",
+            type: "bytes",
+            internalType: "bytes",
+          },
+        ],
+      },
+      {
+        name: "validationPayloads",
+        type: "bytes[][]",
+        internalType: "bytes[][]",
+      },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
+    name: "bulkRevoke",
+    inputs: [
+      {
+        name: "attestationIds",
+        type: "bytes32[]",
+        internalType: "bytes32[]",
+      },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
     name: "getAttester",
+    inputs: [],
     outputs: [
       {
-        internalType: "address",
         name: "",
         type: "address",
+        internalType: "address",
       },
     ],
     stateMutability: "view",
-    type: "function",
   },
   {
-    inputs: [],
+    type: "function",
     name: "getModules",
+    inputs: [],
     outputs: [
       {
-        internalType: "address[]",
         name: "",
         type: "address[]",
+        internalType: "address[]",
       },
     ],
     stateMutability: "view",
-    type: "function",
   },
   {
-    inputs: [],
+    type: "function",
     name: "moduleRegistry",
+    inputs: [],
     outputs: [
       {
-        internalType: "contract ModuleRegistry",
         name: "",
         type: "address",
+        internalType: "contract ModuleRegistry",
       },
     ],
     stateMutability: "view",
-    type: "function",
   },
   {
+    type: "function",
+    name: "modules",
     inputs: [
       {
-        internalType: "uint256",
         name: "",
         type: "uint256",
+        internalType: "uint256",
       },
     ],
-    name: "modules",
     outputs: [
       {
+        name: "",
+        type: "address",
         internalType: "address",
-        name: "",
-        type: "address",
       },
     ],
     stateMutability: "view",
-    type: "function",
   },
   {
-    inputs: [],
+    type: "function",
     name: "portalRegistry",
+    inputs: [],
     outputs: [
       {
-        internalType: "contract PortalRegistry",
         name: "",
         type: "address",
+        internalType: "contract PortalRegistry",
       },
     ],
     stateMutability: "view",
-    type: "function",
   },
   {
+    type: "function",
+    name: "replace",
     inputs: [
       {
-        internalType: "bytes32",
         name: "attestationId",
         type: "bytes32",
+        internalType: "bytes32",
       },
       {
-        components: [
-          {
-            internalType: "bytes32",
-            name: "schemaId",
-            type: "bytes32",
-          },
-          {
-            internalType: "uint64",
-            name: "expirationDate",
-            type: "uint64",
-          },
-          {
-            internalType: "bytes",
-            name: "subject",
-            type: "bytes",
-          },
-          {
-            internalType: "bytes",
-            name: "attestationData",
-            type: "bytes",
-          },
-        ],
-        internalType: "struct AttestationPayload",
         name: "attestationPayload",
         type: "tuple",
+        internalType: "struct AttestationPayload",
+        components: [
+          {
+            name: "schemaId",
+            type: "bytes32",
+            internalType: "bytes32",
+          },
+          {
+            name: "expirationDate",
+            type: "uint64",
+            internalType: "uint64",
+          },
+          {
+            name: "subject",
+            type: "bytes",
+            internalType: "bytes",
+          },
+          {
+            name: "attestationData",
+            type: "bytes",
+            internalType: "bytes",
+          },
+        ],
       },
       {
-        internalType: "bytes[]",
         name: "validationPayloads",
         type: "bytes[]",
+        internalType: "bytes[]",
       },
     ],
-    name: "replace",
     outputs: [],
     stateMutability: "payable",
-    type: "function",
   },
   {
+    type: "function",
+    name: "replaceV2",
     inputs: [
       {
-        internalType: "bytes32",
         name: "attestationId",
         type: "bytes32",
+        internalType: "bytes32",
+      },
+      {
+        name: "attestationPayload",
+        type: "tuple",
+        internalType: "struct AttestationPayload",
+        components: [
+          {
+            name: "schemaId",
+            type: "bytes32",
+            internalType: "bytes32",
+          },
+          {
+            name: "expirationDate",
+            type: "uint64",
+            internalType: "uint64",
+          },
+          {
+            name: "subject",
+            type: "bytes",
+            internalType: "bytes",
+          },
+          {
+            name: "attestationData",
+            type: "bytes",
+            internalType: "bytes",
+          },
+        ],
+      },
+      {
+        name: "validationPayloads",
+        type: "bytes[]",
+        internalType: "bytes[]",
       },
     ],
-    name: "revoke",
     outputs: [],
-    stateMutability: "nonpayable",
-    type: "function",
+    stateMutability: "payable",
   },
   {
-    inputs: [],
+    type: "function",
+    name: "revoke",
+    inputs: [
+      {
+        name: "attestationId",
+        type: "bytes32",
+        internalType: "bytes32",
+      },
+    ],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+  {
+    type: "function",
     name: "router",
+    inputs: [],
     outputs: [
       {
-        internalType: "contract IRouter",
         name: "",
         type: "address",
+        internalType: "contract IRouter",
       },
     ],
     stateMutability: "view",
-    type: "function",
   },
   {
+    type: "function",
+    name: "supportsInterface",
     inputs: [
       {
-        internalType: "bytes4",
         name: "interfaceID",
         type: "bytes4",
+        internalType: "bytes4",
       },
     ],
-    name: "supportsInterface",
     outputs: [
       {
-        internalType: "bool",
         name: "",
         type: "bool",
+        internalType: "bool",
       },
     ],
     stateMutability: "pure",
-    type: "function",
   },
   {
+    type: "function",
+    name: "withdraw",
     inputs: [
       {
-        internalType: "address payable",
         name: "to",
         type: "address",
+        internalType: "address payable",
       },
       {
-        internalType: "uint256",
         name: "amount",
         type: "uint256",
+        internalType: "uint256",
       },
     ],
-    name: "withdraw",
     outputs: [],
     stateMutability: "nonpayable",
-    type: "function",
+  },
+  {
+    type: "error",
+    name: "OnlyPortalOwner",
+    inputs: [],
   },
 ];


### PR DESCRIPTION
## What does this PR do?

Introduces an `attestV2` function at the SDK level to leverage the new version of the Attestation process.

> [!NOTE]
> This function name is not ideal, and will be renamed to just `attest` once the legacy function is deprecated both at the SDK level and the smart contract level.

### Related ticket

Fixes #759 

### Type of change

- [X] Chore
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update

## Check list

- [ ] Unit tests for any smart contract change
- [ ] Contracts and functions are documented
