### PR TITLE
chore(sdk): Upgrade viem version in the SDK for better compatibility on Linea

### DIFF
--- a/explorer/package.json
+++ b/explorer/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@radix-ui/react-dropdown-menu": "^2.0.6",
     "@tanstack/react-table": "^8.10.7",
-    "@verax-attestation-registry/verax-sdk": "2.1.0",
+    "@verax-attestation-registry/verax-sdk": "2.1.1",
     "@wagmi/core": "^1.4.7",
     "abitype": "^0.10.3",
     "class-variance-authority": "^0.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,8 +90,8 @@ importers:
         specifier: ^8.10.7
         version: 8.17.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@verax-attestation-registry/verax-sdk':
-        specifier: 2.1.0
-        version: 2.1.0(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(@types/node@20.12.12)(@types/react@18.3.2)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.6.2)(typescript@5.2.2)
+        specifier: 2.1.1
+        version: 2.1.1(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(@types/node@20.12.12)(@types/react@18.3.2)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.6.2)(typescript@5.2.2)
       '@wagmi/core':
         specifier: ^1.4.7
         version: 1.4.13(@types/react@18.3.2)(encoding@0.1.13)(immer@10.0.2)(react@18.3.1)(typescript@5.2.2)(viem@1.18.9(typescript@5.2.2))
@@ -282,22 +282,22 @@ importers:
     dependencies:
       '@graphql-mesh/cache-localforage':
         specifier: ^0.95.8
-        version: 0.95.8(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-mesh/utils@0.95.8(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(graphql@16.8.1)(tslib@2.6.2)
+        version: 0.95.8(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-mesh/utils@0.95.8(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(graphql@16.8.1)(tslib@2.6.2)
       '@graphql-mesh/cross-helpers':
         specifier: ^0.4.1
         version: 0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)
       '@graphql-mesh/graphql':
         specifier: ^0.95.8
-        version: 0.95.8(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/store@0.95.8(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4)(@graphql-mesh/utils@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-mesh/utils@0.95.8(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(@types/node@20.12.12)(@types/react@18.3.2)(encoding@0.1.13)(graphql-ws@5.16.0(graphql@16.8.1))(graphql@16.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.6.2)
+        version: 0.95.8(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/store@0.95.8(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4)(@graphql-mesh/utils@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-mesh/utils@0.95.8(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(@types/node@20.12.12)(@types/react@18.3.2)(encoding@0.1.13)(graphql-ws@5.16.0(graphql@16.8.1))(graphql@16.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.6.2)
       '@graphql-mesh/http':
         specifier: ^0.96.14
-        version: 0.96.14(lgcvyqvw5jfq24ksksqkso5bj4)
+        version: 0.96.14(2imhrm62xh3xtkhuwlbd6uytny)
       '@graphql-mesh/merger-bare':
         specifier: ^0.95.8
-        version: 0.95.8(@graphql-mesh/store@0.95.8(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4)(@graphql-mesh/utils@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-mesh/utils@0.95.8(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2)
+        version: 0.95.8(@graphql-mesh/store@0.95.8(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4)(@graphql-mesh/utils@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-mesh/utils@0.95.8(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2)
       '@graphql-mesh/runtime':
         specifier: ^0.96.13
-        version: 0.96.13(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-mesh/utils@0.95.8(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2)
+        version: 0.96.13(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-mesh/utils@0.95.8(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2)
       '@graphql-mesh/store':
         specifier: ^0.95.8
         version: 0.95.8(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4)(@graphql-mesh/utils@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2)
@@ -317,8 +317,8 @@ importers:
         specifier: ^16.8.1
         version: 16.8.1
       viem:
-        specifier: ^2.9.26
-        version: 2.10.8(typescript@5.4.5)
+        specifier: ^2.21.35
+        version: 2.21.35(typescript@5.4.5)
     devDependencies:
       '@babel/plugin-transform-runtime':
         specifier: ^7.23.3
@@ -331,7 +331,7 @@ importers:
         version: 7.24.1(@babel/core@7.24.5)
       '@graphprotocol/client-cli':
         specifier: ^3.0.0
-        version: 3.0.3(wpvr23lje62ptmf7n66k6skwj4)
+        version: 3.0.3(52z6ub6ny3fwtngvox32ud4rz4)
       '@types/jest':
         specifier: ^29.5.8
         version: 29.5.12
@@ -580,11 +580,11 @@ packages:
   '@adobe/css-tools@4.3.3':
     resolution: {integrity: sha512-rE0Pygv0sEZ4vBWHlAgJLGDU7Pm8xoO6p3wsEceb7GYAjScrOHpEo8KK/eVkAcnSM+slAEtXjA2JpdjLp4fJQQ==}
 
-  '@adraffy/ens-normalize@1.10.0':
-    resolution: {integrity: sha512-nA9XHtlAkYfJxY7bce8DcN7eKxWWCWkU+1GR9d+U6MbNpfwQp8TI7vqOsBsMcHoT4mBu2kypKoSKnghEzOOq5Q==}
-
   '@adraffy/ens-normalize@1.10.1':
     resolution: {integrity: sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==}
+
+  '@adraffy/ens-normalize@1.11.0':
+    resolution: {integrity: sha512-/3DDPKHqqIqxUULp8yP4zODUY1i+2xvVWsv8A79xGWdCAG+8sb0hRh0Rk2QyOJUnnbyPUAZYcpBuRe3nS2OIUg==}
 
   '@adraffy/ens-normalize@1.9.4':
     resolution: {integrity: sha512-UK0bHA7hh9cR39V+4gl2/NnBBjoXIxkuWAPCaY4X7fbH4L/azIi7ilWOCjMUYfpJgraLUAqkRi2BqrjME8Rynw==}
@@ -2854,6 +2854,10 @@ packages:
   '@noble/curves@1.4.0':
     resolution: {integrity: sha512-p+4cb332SFCrReJkCYe8Xzm0OWi4Jji5jVdIZRL/PmacmDkFNw6MrrV+gGpiPxLHbV+zKFRywUWbaseT+tZRXg==}
 
+  '@noble/curves@1.6.0':
+    resolution: {integrity: sha512-TlaHRXDehJuRNR9TfZDNQ45mMEd5dwUwmicsafcIX4SsNiqnCHKjE/1alYPd/lDRVhxdhUAlv8uEhMCI5zjIJQ==}
+    engines: {node: ^14.21.3 || >=16}
+
   '@noble/hashes@1.2.0':
     resolution: {integrity: sha512-FZfhjEDbT5GRswV3C6uvLPHMiVD6lQBmpoX5+eSiPaMTXte/IKqI5dykDxzZB/WBeK/CDuQRBWarPdi3FNY2zQ==}
 
@@ -2868,6 +2872,10 @@ packages:
   '@noble/hashes@1.4.0':
     resolution: {integrity: sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==}
     engines: {node: '>= 16'}
+
+  '@noble/hashes@1.5.0':
+    resolution: {integrity: sha512-1j6kQFb7QRru7eKN3ZDvRcP13rugwdxZqCjbiAVZfIJwgj2A65UmT4TgARXGlXgnRkORLTDTrO19ZErt7+QXgA==}
+    engines: {node: ^14.21.3 || >=16}
 
   '@noble/secp256k1@1.7.1':
     resolution: {integrity: sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw==}
@@ -3806,6 +3814,9 @@ packages:
   '@scure/base@1.1.6':
     resolution: {integrity: sha512-ok9AWwhcgYuGG3Zfhyqg+zwl+Wn5uE+dwC0NV/2qQkx4dABbb/bx96vWu8NSj+BNjjSjno+JRYRjle1jV08k3g==}
 
+  '@scure/base@1.1.9':
+    resolution: {integrity: sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==}
+
   '@scure/bip32@1.1.5':
     resolution: {integrity: sha512-XyNh1rB0SkEqd3tXcXMi+Xe1fvg+kUIcoRIEujP1Jgv7DqW2r9lg3Ah0NkFaCs9sTkQAQA8kw7xiRXzENi9Rtw==}
 
@@ -3815,6 +3826,9 @@ packages:
   '@scure/bip32@1.3.3':
     resolution: {integrity: sha512-LJaN3HwRbfQK0X1xFSi0Q9amqOgzQnnDngIt+ZlsBC3Bm7/nE7K0kwshZHyaru79yIVRv/e1mQAjZyuZG6jOFQ==}
 
+  '@scure/bip32@1.5.0':
+    resolution: {integrity: sha512-8EnFYkqEQdnkuGBVpCzKxyIwDCBLDVj3oiX0EKUFre/tOjL/Hqba1D6n/8RcmaQy4f95qQFrO2A8Sr6ybh4NRw==}
+
   '@scure/bip39@1.1.1':
     resolution: {integrity: sha512-t+wDck2rVkh65Hmv280fYdVdY25J9YeEUIgn2LG1WM6gxFkGzcksoDiUkWVpVp3Oex9xGC68JU2dSbUfwZ2jPg==}
 
@@ -3823,6 +3837,9 @@ packages:
 
   '@scure/bip39@1.2.2':
     resolution: {integrity: sha512-HYf9TUXG80beW+hGAt3TRM8wU6pQoYur9iNypTROm42dorCGmLnFe3eWjz3gOq6G62H2WRh0FCzAR1PI+29zIA==}
+
+  '@scure/bip39@1.4.0':
+    resolution: {integrity: sha512-BEEm6p8IueV/ZTfQLp/0vhw4NPnT9oWf5+28nvmeUICjP99f4vr2d+qc7AVGDDtwRep6ifR43Yed9ERVmiITzw==}
 
   '@sentry/core@5.30.0':
     resolution: {integrity: sha512-TmfrII8w1PQZSZgPpUESqjB+jC6MvZJZdLtE/0hZ+SrnKhW3x5WlYLvTXZpcWePYBku7rl2wn1RZu6uT0qCTeg==}
@@ -4638,8 +4655,8 @@ packages:
   '@ungap/structured-clone@1.2.0':
     resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
 
-  '@verax-attestation-registry/verax-sdk@2.1.0':
-    resolution: {integrity: sha512-aKIcfh7zI9B6npCqgKpOLnXOKcrz6OSUdVS+iQ+2Y4tmhVux4nHU//PU3io5p+Nf0muwo7bfnvBvYYkVTLrkNQ==}
+  '@verax-attestation-registry/verax-sdk@2.1.1':
+    resolution: {integrity: sha512-QuSmWHlVtlat9zU7/KFHHf47Ftn5Tzn649zBQfiv/ymWAKXIw9mluhYj9XUGD/cTddK6CUY3Pwhyj++idUldig==}
 
   '@vercel/webpack-asset-relocator-loader@1.7.3':
     resolution: {integrity: sha512-vizrI18v8Lcb1PmNNUBz7yxPxxXoOeuaVEjTG9MjvDrphjiSxFZrRJ5tIghk+qdLFRCXI5HBCshgobftbmrC5g==}
@@ -4970,8 +4987,8 @@ packages:
       zod:
         optional: true
 
-  abitype@1.0.0:
-    resolution: {integrity: sha512-NMeMah//6bJ56H5XRj8QCV4AwuW6hB6zqz2LnhhLdcWVQOsXki6/Pn3APeqxCma62nXIcmZWdu1DlHWS74umVQ==}
+  abitype@1.0.6:
+    resolution: {integrity: sha512-MMSqYh4+C/aVqI2RQaWqbvI4Kxo5cQV40WQ4QFtDnNzCkqChm8MuENhElmynZlO0qUy/ObkEUaXtKqYnx1Kp3A==}
     peerDependencies:
       typescript: '>=5.0.4'
       zod: ^3 >=3.22.0
@@ -8592,8 +8609,8 @@ packages:
     peerDependencies:
       ws: '>=8.17.1'
 
-  isows@1.0.4:
-    resolution: {integrity: sha512-hEzjY+x9u9hPmBom9IIAqdJCwNLax+xrPb51vEPpERoFlIxgmZcHzsT5jKG06nvInKOBGvReAVz80Umed5CczQ==}
+  isows@1.0.6:
+    resolution: {integrity: sha512-lPHCayd40oW98/I0uvgaHKWCSvkzY27LjWLbtzOm64yQ+G3Q5npjjbdppU65iZXkK1Zt+kH9pfegli0AYfwYYw==}
     peerDependencies:
       ws: '>=8.17.1'
 
@@ -12286,8 +12303,8 @@ packages:
       typescript:
         optional: true
 
-  viem@2.10.8:
-    resolution: {integrity: sha512-ttCXlDmjjcZ8M/eJezXFzDtHj+RFOjEQ3elmXnCC7suXo/y8CuIM1LrIoyUFk7LKIE5E+bzmWUErS4u/MQBtpQ==}
+  viem@2.21.35:
+    resolution: {integrity: sha512-f3EFc5JILeA9veuNymUN8HG/nKP9ykC0NCgwFrZWuxcCc822GaP0IEnkRBsHGqmjwbz//FxJFmvtx7TBcdVs0A==}
     peerDependencies:
       typescript: '>=5.0.4'
     peerDependenciesMeta:
@@ -12385,6 +12402,9 @@ packages:
   web3-utils@1.7.0:
     resolution: {integrity: sha512-O8Tl4Ky40Sp6pe89Olk2FsaUkgHyb5QAXuaKo38ms3CxZZ4d3rPGfjP9DNKGm5+IUgAZBNpF1VmlSmNCqfDI1w==}
     engines: {node: '>=8.0.0'}
+
+  webauthn-p256@0.0.10:
+    resolution: {integrity: sha512-EeYD+gmIT80YkSIDb2iWq0lq2zbHo1CxHlQTeJ+KkCILWpVy3zASH3ByD4bopzfk0uCwXxLqKGLqp2W4O28VFA==}
 
   webcrypto-core@1.7.9:
     resolution: {integrity: sha512-FE+a4PPkOmBbgNDIyRmcHhgXn+2ClRl3JzJdDu/P4+B8y81LqKe6RAsI9b3lAOHe1T1BMkSjsRHTYRikImZnVA==}
@@ -12640,9 +12660,9 @@ snapshots:
 
   '@adobe/css-tools@4.3.3': {}
 
-  '@adraffy/ens-normalize@1.10.0': {}
-
   '@adraffy/ens-normalize@1.10.1': {}
+
+  '@adraffy/ens-normalize@1.11.0': {}
 
   '@adraffy/ens-normalize@1.9.4': {}
 
@@ -12684,7 +12704,7 @@ snapshots:
       '@babel/generator': 7.24.5
       '@babel/parser': 7.24.5
       '@babel/runtime': 7.24.5
-      '@babel/traverse': 7.24.5
+      '@babel/traverse': 7.24.5(supports-color@5.5.0)
       '@babel/types': 7.24.5
       babel-preset-fbjs: 3.4.0(@babel/core@7.24.5)
       chalk: 4.1.2
@@ -12750,10 +12770,10 @@ snapshots:
       '@babel/helpers': 7.24.5
       '@babel/parser': 7.24.5
       '@babel/template': 7.24.0
-      '@babel/traverse': 7.24.5
+      '@babel/traverse': 7.24.5(supports-color@5.5.0)
       '@babel/types': 7.24.5
       convert-source-map: 2.0.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -12816,7 +12836,7 @@ snapshots:
       '@babel/core': 7.24.5
       '@babel/helper-compilation-targets': 7.23.6
       '@babel/helper-plugin-utils': 7.24.5
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       lodash.debounce: 4.0.8
       resolve: 1.22.8
     transitivePeerDependencies:
@@ -12897,7 +12917,7 @@ snapshots:
   '@babel/helpers@7.24.5':
     dependencies:
       '@babel/template': 7.24.0
-      '@babel/traverse': 7.24.5
+      '@babel/traverse': 7.24.5(supports-color@5.5.0)
       '@babel/types': 7.24.5
     transitivePeerDependencies:
       - supports-color
@@ -13568,21 +13588,6 @@ snapshots:
       '@babel/parser': 7.24.5
       '@babel/types': 7.24.5
 
-  '@babel/traverse@7.24.5':
-    dependencies:
-      '@babel/code-frame': 7.24.2
-      '@babel/generator': 7.24.5
-      '@babel/helper-environment-visitor': 7.22.20
-      '@babel/helper-function-name': 7.23.0
-      '@babel/helper-hoist-variables': 7.22.5
-      '@babel/helper-split-export-declaration': 7.24.5
-      '@babel/parser': 7.24.5
-      '@babel/types': 7.24.5
-      debug: 4.3.4(supports-color@8.1.1)
-      globals: 11.12.0
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/traverse@7.24.5(supports-color@5.5.0)':
     dependencies:
       '@babel/code-frame': 7.24.2
@@ -13755,7 +13760,7 @@ snapshots:
   '@eslint/eslintrc@0.4.3':
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       espree: 7.3.1
       globals: 13.24.0
       ignore: 4.0.6
@@ -13769,7 +13774,7 @@ snapshots:
   '@eslint/eslintrc@2.1.4':
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       espree: 9.6.1
       globals: 13.24.0
       ignore: 5.3.1
@@ -14129,7 +14134,7 @@ snapshots:
       html-entities: 2.5.2
       strip-ansi: 6.0.1
 
-  '@graphprotocol/client-add-source-name@2.0.3(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/delegate@10.0.10(graphql@16.8.1))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(@graphql-tools/wrap@10.0.5(graphql@16.8.1))(graphql@16.8.1)':
+  '@graphprotocol/client-add-source-name@2.0.3(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/delegate@10.0.10(graphql@16.8.1))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(@graphql-tools/wrap@10.0.5(graphql@16.8.1))(graphql@16.8.1)':
     dependencies:
       '@graphql-mesh/types': 0.98.4(@graphql-mesh/store@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2)
       '@graphql-tools/delegate': 10.0.10(graphql@16.8.1)
@@ -14139,7 +14144,7 @@ snapshots:
       lodash: 4.17.21
       tslib: 2.6.2
 
-  '@graphprotocol/client-auto-pagination@2.0.3(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/delegate@10.0.10(graphql@16.8.1))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(@graphql-tools/wrap@10.0.5(graphql@16.8.1))(graphql@16.8.1)':
+  '@graphprotocol/client-auto-pagination@2.0.3(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/delegate@10.0.10(graphql@16.8.1))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(@graphql-tools/wrap@10.0.5(graphql@16.8.1))(graphql@16.8.1)':
     dependencies:
       '@graphql-mesh/types': 0.98.4(@graphql-mesh/store@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2)
       '@graphql-tools/delegate': 10.0.10(graphql@16.8.1)
@@ -14149,9 +14154,9 @@ snapshots:
       lodash: 4.17.21
       tslib: 2.6.2
 
-  '@graphprotocol/client-auto-type-merging@2.0.3(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-mesh/utils@0.95.8(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/delegate@10.0.10(graphql@16.8.1))(graphql@16.8.1)':
+  '@graphprotocol/client-auto-type-merging@2.0.3(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-mesh/utils@0.95.8(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/delegate@10.0.10(graphql@16.8.1))(graphql@16.8.1)':
     dependencies:
-      '@graphql-mesh/transform-type-merging': 0.98.4(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-mesh/utils@0.95.8(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(graphql@16.8.1)(tslib@2.6.2)
+      '@graphql-mesh/transform-type-merging': 0.98.4(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-mesh/utils@0.95.8(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(graphql@16.8.1)(tslib@2.6.2)
       '@graphql-mesh/types': 0.98.4(@graphql-mesh/store@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2)
       '@graphql-tools/delegate': 10.0.10(graphql@16.8.1)
       graphql: 16.8.1
@@ -14170,15 +14175,15 @@ snapshots:
       - '@graphql-mesh/cross-helpers'
       - '@graphql-mesh/store'
 
-  '@graphprotocol/client-cli@3.0.3(wpvr23lje62ptmf7n66k6skwj4)':
+  '@graphprotocol/client-cli@3.0.3(52z6ub6ny3fwtngvox32ud4rz4)':
     dependencies:
-      '@graphprotocol/client-add-source-name': 2.0.3(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/delegate@10.0.10(graphql@16.8.1))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(@graphql-tools/wrap@10.0.5(graphql@16.8.1))(graphql@16.8.1)
-      '@graphprotocol/client-auto-pagination': 2.0.3(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/delegate@10.0.10(graphql@16.8.1))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(@graphql-tools/wrap@10.0.5(graphql@16.8.1))(graphql@16.8.1)
-      '@graphprotocol/client-auto-type-merging': 2.0.3(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-mesh/utils@0.95.8(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/delegate@10.0.10(graphql@16.8.1))(graphql@16.8.1)
+      '@graphprotocol/client-add-source-name': 2.0.3(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/delegate@10.0.10(graphql@16.8.1))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(@graphql-tools/wrap@10.0.5(graphql@16.8.1))(graphql@16.8.1)
+      '@graphprotocol/client-auto-pagination': 2.0.3(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/delegate@10.0.10(graphql@16.8.1))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(@graphql-tools/wrap@10.0.5(graphql@16.8.1))(graphql@16.8.1)
+      '@graphprotocol/client-auto-type-merging': 2.0.3(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-mesh/utils@0.95.8(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/delegate@10.0.10(graphql@16.8.1))(graphql@16.8.1)
       '@graphprotocol/client-block-tracking': 2.0.2(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/store@0.95.8(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4)(@graphql-mesh/utils@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/delegate@10.0.10(graphql@16.8.1))(graphql@16.8.1)
       '@graphprotocol/client-polling-live': 2.0.1(@envelop/core@5.0.1)(@graphql-tools/merge@9.0.4(graphql@16.8.1))(graphql@16.8.1)
       '@graphql-mesh/cli': 0.90.5(@swc/core@1.3.78)(@types/node@20.12.12)(encoding@0.1.13)(graphql-tag@2.12.6(graphql@16.8.1))(graphql-yoga@5.3.1(graphql@16.8.1))(graphql@16.8.1)
-      '@graphql-mesh/graphql': 0.98.4(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/store@0.95.8(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4)(@graphql-mesh/utils@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-mesh/utils@0.95.8(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(@types/node@20.12.12)(@types/react@18.3.2)(encoding@0.1.13)(graphql-ws@5.16.0(graphql@16.8.1))(graphql@16.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.6.2)
+      '@graphql-mesh/graphql': 0.98.4(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/store@0.95.8(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4)(@graphql-mesh/utils@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-mesh/utils@0.95.8(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(@types/node@20.12.12)(@types/react@18.3.2)(encoding@0.1.13)(graphql-ws@5.16.0(graphql@16.8.1))(graphql@16.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.6.2)
       graphql: 16.8.1
       tslib: 2.6.2
     transitivePeerDependencies:
@@ -14225,7 +14230,7 @@ snapshots:
       binary-install-raw: 0.0.13(debug@4.3.4)
       chalk: 3.0.0
       chokidar: 3.5.3
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       docker-compose: 0.23.19
       dockerode: 2.5.8
       fs-extra: 9.1.0
@@ -14475,7 +14480,7 @@ snapshots:
       object-inspect: 1.12.3
       tslib: 2.6.2
 
-  '@graphql-mesh/cache-localforage@0.95.8(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-mesh/utils@0.95.8(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(graphql@16.8.1)(tslib@2.6.2)':
+  '@graphql-mesh/cache-localforage@0.95.8(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-mesh/utils@0.95.8(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(graphql@16.8.1)(tslib@2.6.2)':
     dependencies:
       '@graphql-mesh/types': 0.98.4(@graphql-mesh/store@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2)
       '@graphql-mesh/utils': 0.95.8(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2)
@@ -14483,10 +14488,10 @@ snapshots:
       localforage: 1.10.0
       tslib: 2.6.2
 
-  '@graphql-mesh/cache-localforage@0.98.4(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-mesh/utils@0.98.4(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(graphql@16.8.1)(tslib@2.6.2)':
+  '@graphql-mesh/cache-localforage@0.98.4(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-mesh/utils@0.98.4(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(graphql@16.8.1)(tslib@2.6.2)':
     dependencies:
       '@graphql-mesh/types': 0.98.4(@graphql-mesh/store@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2)
-      '@graphql-mesh/utils': 0.98.4(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2)
+      '@graphql-mesh/utils': 0.98.4(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2)
       graphql: 16.8.1
       localforage: 1.10.0
       tslib: 2.6.2
@@ -14499,13 +14504,13 @@ snapshots:
       '@graphql-codegen/typescript-generic-sdk': 3.1.0(encoding@0.1.13)(graphql-tag@2.12.6(graphql@16.8.1))(graphql@16.8.1)
       '@graphql-codegen/typescript-operations': 4.2.0(encoding@0.1.13)(graphql@16.8.1)
       '@graphql-codegen/typescript-resolvers': 4.0.6(encoding@0.1.13)(graphql@16.8.1)
-      '@graphql-mesh/config': 0.100.5(g7pzhuipz74xmdoqi4mxcjiuuu)
+      '@graphql-mesh/config': 0.100.5(vzhqso3vrlvjcufqpquyasy5y4)
       '@graphql-mesh/cross-helpers': 0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)
-      '@graphql-mesh/http': 0.99.5(mlfuhgj7hcbibuv76rsobih6bu)
-      '@graphql-mesh/runtime': 0.99.5(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-mesh/utils@0.98.4(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2)
-      '@graphql-mesh/store': 0.98.4(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4)(@graphql-mesh/utils@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2)
-      '@graphql-mesh/types': 0.98.4(@graphql-mesh/store@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2)
-      '@graphql-mesh/utils': 0.98.4(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2)
+      '@graphql-mesh/http': 0.99.5(sc66umcijetjcdjtbw7toc4fsu)
+      '@graphql-mesh/runtime': 0.99.5(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-mesh/utils@0.98.4(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2)
+      '@graphql-mesh/store': 0.98.4(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-mesh/utils@0.98.4(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2)
+      '@graphql-mesh/types': 0.98.4(@graphql-mesh/store@0.98.4(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-mesh/utils@0.98.4(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2)
+      '@graphql-mesh/utils': 0.98.4(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2)
       '@graphql-tools/utils': 10.2.0(graphql@16.8.1)
       ajv: 8.13.0
       change-case: 4.1.2
@@ -14537,17 +14542,17 @@ snapshots:
       - graphql-yoga
       - supports-color
 
-  '@graphql-mesh/config@0.100.5(g7pzhuipz74xmdoqi4mxcjiuuu)':
+  '@graphql-mesh/config@0.100.5(vzhqso3vrlvjcufqpquyasy5y4)':
     dependencies:
       '@envelop/core': 5.0.1
-      '@graphql-mesh/cache-localforage': 0.98.4(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-mesh/utils@0.98.4(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(graphql@16.8.1)(tslib@2.6.2)
+      '@graphql-mesh/cache-localforage': 0.98.4(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-mesh/utils@0.98.4(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(graphql@16.8.1)(tslib@2.6.2)
       '@graphql-mesh/cross-helpers': 0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)
-      '@graphql-mesh/merger-bare': 0.98.4(@graphql-mesh/store@0.98.4(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4)(@graphql-mesh/utils@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-mesh/utils@0.98.4(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2)
-      '@graphql-mesh/merger-stitching': 0.98.4(@graphql-mesh/store@0.98.4(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4)(@graphql-mesh/utils@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-mesh/utils@0.98.4(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2)
-      '@graphql-mesh/runtime': 0.99.5(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-mesh/utils@0.98.4(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2)
-      '@graphql-mesh/store': 0.98.4(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4)(@graphql-mesh/utils@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2)
+      '@graphql-mesh/merger-bare': 0.98.4(53vyp2636jfugnoezou6qctbmu)
+      '@graphql-mesh/merger-stitching': 0.98.4(53vyp2636jfugnoezou6qctbmu)
+      '@graphql-mesh/runtime': 0.99.5(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-mesh/utils@0.98.4(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2)
+      '@graphql-mesh/store': 0.98.4(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-mesh/utils@0.98.4(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2)
       '@graphql-mesh/types': 0.98.4(@graphql-mesh/store@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2)
-      '@graphql-mesh/utils': 0.98.4(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2)
+      '@graphql-mesh/utils': 0.98.4(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2)
       '@graphql-tools/code-file-loader': 8.1.2(graphql@16.8.1)
       '@graphql-tools/graphql-file-loader': 8.0.1(graphql@16.8.1)
       '@graphql-tools/load': 8.0.2(graphql@16.8.1)
@@ -14571,10 +14576,10 @@ snapshots:
 
   '@graphql-mesh/fusion-runtime@0.3.5(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/store@0.95.8(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4)(@graphql-mesh/utils@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(graphql@16.8.1)':
     dependencies:
-      '@graphql-mesh/runtime': 0.99.5(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-mesh/utils@0.98.4(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2)
-      '@graphql-mesh/transport-common': 0.2.4(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(graphql@16.8.1)(tslib@2.6.2)
+      '@graphql-mesh/runtime': 0.99.5(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-mesh/utils@0.98.4(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2)
+      '@graphql-mesh/transport-common': 0.2.4(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(graphql@16.8.1)(tslib@2.6.2)
       '@graphql-mesh/types': 0.98.4(@graphql-mesh/store@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2)
-      '@graphql-mesh/utils': 0.98.4(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2)
+      '@graphql-mesh/utils': 0.98.4(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2)
       '@graphql-tools/delegate': 10.0.10(graphql@16.8.1)
       '@graphql-tools/stitch': 9.2.8(graphql@16.8.1)
       '@graphql-tools/stitching-directives': 3.0.2(graphql@16.8.1)
@@ -14587,7 +14592,7 @@ snapshots:
       - '@graphql-mesh/cross-helpers'
       - '@graphql-mesh/store'
 
-  '@graphql-mesh/graphql@0.95.8(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/store@0.95.8(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4)(@graphql-mesh/utils@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-mesh/utils@0.95.8(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(@types/node@20.12.12)(@types/react@18.3.2)(encoding@0.1.13)(graphql-ws@5.16.0(graphql@16.8.1))(graphql@16.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.6.2)':
+  '@graphql-mesh/graphql@0.95.8(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/store@0.95.8(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4)(@graphql-mesh/utils@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-mesh/utils@0.95.8(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(@types/node@20.12.12)(@types/react@18.3.2)(encoding@0.1.13)(graphql-ws@5.16.0(graphql@16.8.1))(graphql@16.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.6.2)':
     dependencies:
       '@graphql-mesh/cross-helpers': 0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)
       '@graphql-mesh/store': 0.95.8(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4)(@graphql-mesh/utils@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2)
@@ -14612,7 +14617,7 @@ snapshots:
       - subscriptions-transport-ws
       - utf-8-validate
 
-  '@graphql-mesh/graphql@0.98.4(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/store@0.95.8(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4)(@graphql-mesh/utils@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-mesh/utils@0.95.8(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(@types/node@20.12.12)(@types/react@18.3.2)(encoding@0.1.13)(graphql-ws@5.16.0(graphql@16.8.1))(graphql@16.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.6.2)':
+  '@graphql-mesh/graphql@0.98.4(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/store@0.95.8(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4)(@graphql-mesh/utils@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-mesh/utils@0.95.8(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(@types/node@20.12.12)(@types/react@18.3.2)(encoding@0.1.13)(graphql-ws@5.16.0(graphql@16.8.1))(graphql@16.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.6.2)':
     dependencies:
       '@graphql-mesh/cross-helpers': 0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)
       '@graphql-mesh/store': 0.95.8(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4)(@graphql-mesh/utils@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2)
@@ -14637,10 +14642,10 @@ snapshots:
       - subscriptions-transport-ws
       - utf-8-validate
 
-  '@graphql-mesh/http@0.96.14(lgcvyqvw5jfq24ksksqkso5bj4)':
+  '@graphql-mesh/http@0.96.14(2imhrm62xh3xtkhuwlbd6uytny)':
     dependencies:
       '@graphql-mesh/cross-helpers': 0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)
-      '@graphql-mesh/runtime': 0.96.13(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-mesh/utils@0.95.8(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2)
+      '@graphql-mesh/runtime': 0.96.13(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-mesh/utils@0.95.8(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2)
       '@graphql-mesh/types': 0.98.4(@graphql-mesh/store@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2)
       '@graphql-mesh/utils': 0.95.8(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2)
       '@whatwg-node/server': 0.9.34
@@ -14648,21 +14653,21 @@ snapshots:
       graphql-yoga: 5.3.1(graphql@16.8.1)
       tslib: 2.6.2
 
-  '@graphql-mesh/http@0.99.5(mlfuhgj7hcbibuv76rsobih6bu)':
+  '@graphql-mesh/http@0.99.5(sc66umcijetjcdjtbw7toc4fsu)':
     dependencies:
       '@graphql-mesh/cross-helpers': 0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)
-      '@graphql-mesh/runtime': 0.99.5(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-mesh/utils@0.98.4(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2)
+      '@graphql-mesh/runtime': 0.99.5(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-mesh/utils@0.98.4(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2)
       '@graphql-mesh/types': 0.98.4(@graphql-mesh/store@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2)
-      '@graphql-mesh/utils': 0.98.4(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2)
+      '@graphql-mesh/utils': 0.98.4(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2)
       '@graphql-tools/utils': 10.2.0(graphql@16.8.1)
       '@whatwg-node/server': 0.9.34
       graphql: 16.8.1
       graphql-yoga: 5.3.1(graphql@16.8.1)
       tslib: 2.6.2
 
-  '@graphql-mesh/merger-bare@0.95.8(@graphql-mesh/store@0.95.8(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4)(@graphql-mesh/utils@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-mesh/utils@0.95.8(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2)':
+  '@graphql-mesh/merger-bare@0.95.8(@graphql-mesh/store@0.95.8(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4)(@graphql-mesh/utils@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-mesh/utils@0.95.8(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2)':
     dependencies:
-      '@graphql-mesh/merger-stitching': 0.95.8(@graphql-mesh/store@0.95.8(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4)(@graphql-mesh/utils@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-mesh/utils@0.95.8(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2)
+      '@graphql-mesh/merger-stitching': 0.95.8(@graphql-mesh/store@0.95.8(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4)(@graphql-mesh/utils@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-mesh/utils@0.95.8(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2)
       '@graphql-mesh/types': 0.98.4(@graphql-mesh/store@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2)
       '@graphql-mesh/utils': 0.95.8(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2)
       '@graphql-tools/schema': 10.0.0(graphql@16.8.1)
@@ -14672,11 +14677,11 @@ snapshots:
     transitivePeerDependencies:
       - '@graphql-mesh/store'
 
-  '@graphql-mesh/merger-bare@0.98.4(@graphql-mesh/store@0.98.4(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4)(@graphql-mesh/utils@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-mesh/utils@0.98.4(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2)':
+  '@graphql-mesh/merger-bare@0.98.4(53vyp2636jfugnoezou6qctbmu)':
     dependencies:
-      '@graphql-mesh/merger-stitching': 0.98.4(@graphql-mesh/store@0.98.4(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4)(@graphql-mesh/utils@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-mesh/utils@0.98.4(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2)
+      '@graphql-mesh/merger-stitching': 0.98.4(53vyp2636jfugnoezou6qctbmu)
       '@graphql-mesh/types': 0.98.4(@graphql-mesh/store@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2)
-      '@graphql-mesh/utils': 0.98.4(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2)
+      '@graphql-mesh/utils': 0.98.4(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2)
       '@graphql-tools/schema': 10.0.3(graphql@16.8.1)
       '@graphql-tools/utils': 10.2.0(graphql@16.8.1)
       graphql: 16.8.1
@@ -14684,7 +14689,7 @@ snapshots:
     transitivePeerDependencies:
       - '@graphql-mesh/store'
 
-  '@graphql-mesh/merger-stitching@0.95.8(@graphql-mesh/store@0.95.8(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4)(@graphql-mesh/utils@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-mesh/utils@0.95.8(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2)':
+  '@graphql-mesh/merger-stitching@0.95.8(@graphql-mesh/store@0.95.8(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4)(@graphql-mesh/utils@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-mesh/utils@0.95.8(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2)':
     dependencies:
       '@graphql-mesh/store': 0.95.8(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4)(@graphql-mesh/utils@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2)
       '@graphql-mesh/types': 0.98.4(@graphql-mesh/store@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2)
@@ -14696,11 +14701,11 @@ snapshots:
       graphql: 16.8.1
       tslib: 2.6.2
 
-  '@graphql-mesh/merger-stitching@0.98.4(@graphql-mesh/store@0.98.4(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4)(@graphql-mesh/utils@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-mesh/utils@0.98.4(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2)':
+  '@graphql-mesh/merger-stitching@0.98.4(53vyp2636jfugnoezou6qctbmu)':
     dependencies:
-      '@graphql-mesh/store': 0.98.4(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4)(@graphql-mesh/utils@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2)
+      '@graphql-mesh/store': 0.98.4(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-mesh/utils@0.98.4(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2)
       '@graphql-mesh/types': 0.98.4(@graphql-mesh/store@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2)
-      '@graphql-mesh/utils': 0.98.4(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2)
+      '@graphql-mesh/utils': 0.98.4(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2)
       '@graphql-tools/delegate': 10.0.10(graphql@16.8.1)
       '@graphql-tools/schema': 10.0.3(graphql@16.8.1)
       '@graphql-tools/stitch': 9.2.8(graphql@16.8.1)
@@ -14708,7 +14713,7 @@ snapshots:
       graphql: 16.8.1
       tslib: 2.6.2
 
-  '@graphql-mesh/runtime@0.96.13(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-mesh/utils@0.95.8(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2)':
+  '@graphql-mesh/runtime@0.96.13(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-mesh/utils@0.95.8(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2)':
     dependencies:
       '@envelop/core': 5.0.1
       '@envelop/extended-validation': 4.0.0(@envelop/core@5.0.1)(graphql@16.8.1)
@@ -14727,7 +14732,7 @@ snapshots:
       graphql-jit: 0.8.2(graphql@16.8.1)
       tslib: 2.6.2
 
-  '@graphql-mesh/runtime@0.99.5(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-mesh/utils@0.98.4(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2)':
+  '@graphql-mesh/runtime@0.99.5(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-mesh/utils@0.98.4(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2)':
     dependencies:
       '@envelop/core': 5.0.1
       '@envelop/extended-validation': 4.0.0(@envelop/core@5.0.1)(graphql@16.8.1)
@@ -14735,7 +14740,7 @@ snapshots:
       '@graphql-mesh/cross-helpers': 0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)
       '@graphql-mesh/string-interpolation': 0.5.4(graphql@16.8.1)(tslib@2.6.2)
       '@graphql-mesh/types': 0.98.4(@graphql-mesh/store@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2)
-      '@graphql-mesh/utils': 0.98.4(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2)
+      '@graphql-mesh/utils': 0.98.4(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2)
       '@graphql-tools/batch-delegate': 9.0.2(graphql@16.8.1)
       '@graphql-tools/delegate': 10.0.10(graphql@16.8.1)
       '@graphql-tools/executor': 1.2.6(graphql@16.8.1)
@@ -14756,12 +14761,12 @@ snapshots:
       graphql: 16.8.1
       tslib: 2.6.2
 
-  '@graphql-mesh/store@0.98.4(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4)(@graphql-mesh/utils@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2)':
+  '@graphql-mesh/store@0.98.4(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-mesh/utils@0.98.4(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2)':
     dependencies:
       '@graphql-inspector/core': 5.0.2(graphql@16.8.1)
       '@graphql-mesh/cross-helpers': 0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)
       '@graphql-mesh/types': 0.98.4(@graphql-mesh/store@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2)
-      '@graphql-mesh/utils': 0.98.4(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2)
+      '@graphql-mesh/utils': 0.98.4(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2)
       '@graphql-tools/utils': 10.2.0(graphql@16.8.1)
       graphql: 16.8.1
       tslib: 2.6.2
@@ -14774,7 +14779,7 @@ snapshots:
       lodash.get: 4.4.2
       tslib: 2.6.2
 
-  '@graphql-mesh/transform-type-merging@0.98.4(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-mesh/utils@0.95.8(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(graphql@16.8.1)(tslib@2.6.2)':
+  '@graphql-mesh/transform-type-merging@0.98.4(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-mesh/utils@0.95.8(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(graphql@16.8.1)(tslib@2.6.2)':
     dependencies:
       '@graphql-mesh/types': 0.98.4(@graphql-mesh/store@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2)
       '@graphql-mesh/utils': 0.95.8(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2)
@@ -14783,7 +14788,7 @@ snapshots:
       graphql: 16.8.1
       tslib: 2.6.2
 
-  '@graphql-mesh/transport-common@0.2.4(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(graphql@16.8.1)(tslib@2.6.2)':
+  '@graphql-mesh/transport-common@0.2.4(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(graphql@16.8.1)(tslib@2.6.2)':
     dependencies:
       '@graphql-mesh/types': 0.98.4(@graphql-mesh/store@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2)
       '@graphql-tools/delegate': 10.0.10(graphql@16.8.1)
@@ -14794,6 +14799,16 @@ snapshots:
   '@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2)':
     dependencies:
       '@graphql-mesh/store': 0.95.8(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4)(@graphql-mesh/utils@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2)
+      '@graphql-tools/batch-delegate': 9.0.2(graphql@16.8.1)
+      '@graphql-tools/delegate': 10.0.10(graphql@16.8.1)
+      '@graphql-tools/utils': 10.2.0(graphql@16.8.1)
+      '@graphql-typed-document-node/core': 3.2.0(graphql@16.8.1)
+      graphql: 16.8.1
+      tslib: 2.6.2
+
+  '@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.98.4(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-mesh/utils@0.98.4(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2)':
+    dependencies:
+      '@graphql-mesh/store': 0.98.4(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-mesh/utils@0.98.4(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2)
       '@graphql-tools/batch-delegate': 9.0.2(graphql@16.8.1)
       '@graphql-tools/delegate': 10.0.10(graphql@16.8.1)
       '@graphql-tools/utils': 10.2.0(graphql@16.8.1)
@@ -14817,7 +14832,7 @@ snapshots:
       tiny-lru: 11.2.6
       tslib: 2.6.2
 
-  '@graphql-mesh/utils@0.98.4(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2)':
+  '@graphql-mesh/utils@0.98.4(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2)':
     dependencies:
       '@graphql-mesh/cross-helpers': 0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)
       '@graphql-mesh/string-interpolation': 0.5.4(graphql@16.8.1)(tslib@2.6.2)
@@ -14965,7 +14980,7 @@ snapshots:
     dependencies:
       '@babel/parser': 7.24.5
       '@babel/plugin-syntax-import-assertions': 7.24.1(@babel/core@7.24.5)
-      '@babel/traverse': 7.24.5
+      '@babel/traverse': 7.24.5(supports-color@5.5.0)
       '@babel/types': 7.24.5
       '@graphql-tools/utils': 9.2.1(graphql@16.8.1)
       graphql: 16.8.1
@@ -14979,7 +14994,7 @@ snapshots:
       '@babel/core': 7.24.5
       '@babel/parser': 7.24.5
       '@babel/plugin-syntax-import-assertions': 7.24.1(@babel/core@7.24.5)
-      '@babel/traverse': 7.24.5
+      '@babel/traverse': 7.24.5(supports-color@5.5.0)
       '@babel/types': 7.24.5
       '@graphql-tools/utils': 10.2.0(graphql@16.8.1)
       graphql: 16.8.1
@@ -15181,7 +15196,7 @@ snapshots:
   '@humanwhocodes/config-array@0.11.14':
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -15189,7 +15204,7 @@ snapshots:
   '@humanwhocodes/config-array@0.5.0':
     dependencies:
       '@humanwhocodes/object-schema': 1.2.1
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -16018,7 +16033,7 @@ snapshots:
     dependencies:
       '@ethereumjs/tx': 4.2.0
       '@types/debug': 4.1.12
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       semver: 7.6.2
       superstruct: 1.0.4
     transitivePeerDependencies:
@@ -16030,7 +16045,7 @@ snapshots:
       '@noble/hashes': 1.4.0
       '@scure/base': 1.1.6
       '@types/debug': 4.1.12
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       pony-cause: 2.1.11
       semver: 7.6.2
       superstruct: 1.0.4
@@ -16132,6 +16147,10 @@ snapshots:
     dependencies:
       '@noble/hashes': 1.4.0
 
+  '@noble/curves@1.6.0':
+    dependencies:
+      '@noble/hashes': 1.5.0
+
   '@noble/hashes@1.2.0': {}
 
   '@noble/hashes@1.3.2': {}
@@ -16139,6 +16158,8 @@ snapshots:
   '@noble/hashes@1.3.3': {}
 
   '@noble/hashes@1.4.0': {}
+
+  '@noble/hashes@1.5.0': {}
 
   '@noble/secp256k1@1.7.1': {}
 
@@ -16222,7 +16243,7 @@ snapshots:
 
   '@nomicfoundation/hardhat-ethers@3.0.6(ethers@6.12.1)(hardhat@2.22.4(ts-node@10.9.2(@swc/core@1.3.78)(@types/node@18.19.33)(typescript@5.4.5))(typescript@5.4.5))':
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       ethers: 6.12.1
       hardhat: 2.22.4(ts-node@10.9.2(@swc/core@1.3.78)(@types/node@18.19.33)(typescript@5.4.5))(typescript@5.4.5)
       lodash.isequal: 4.5.0
@@ -16231,7 +16252,7 @@ snapshots:
 
   '@nomicfoundation/hardhat-ethers@3.0.6(ethers@6.12.1)(hardhat@2.22.4(ts-node@10.9.2(@swc/core@1.3.78)(@types/node@20.12.12)(typescript@5.4.5))(typescript@5.4.5))':
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       ethers: 6.12.1
       hardhat: 2.22.4(ts-node@10.9.2(@swc/core@1.3.78)(@types/node@20.12.12)(typescript@5.4.5))(typescript@5.4.5)
       lodash.isequal: 4.5.0
@@ -16262,7 +16283,7 @@ snapshots:
       '@nomicfoundation/ignition-core': 0.15.4
       '@nomicfoundation/ignition-ui': 0.15.4
       chalk: 4.1.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       fs-extra: 10.1.0
       hardhat: 2.22.4(ts-node@10.9.2(@swc/core@1.3.78)(@types/node@18.19.33)(typescript@5.4.5))(typescript@5.4.5)
       prompts: 2.4.2
@@ -16328,7 +16349,7 @@ snapshots:
       '@ethersproject/address': 5.7.0
       cbor: 8.1.0
       chalk: 2.4.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       hardhat: 2.22.4(ts-node@10.9.2(@swc/core@1.3.78)(@types/node@18.19.33)(typescript@5.4.5))(typescript@5.4.5)
       lodash.clonedeep: 4.5.0
       semver: 6.3.1
@@ -16343,7 +16364,7 @@ snapshots:
       '@ethersproject/address': 5.7.0
       cbor: 8.1.0
       chalk: 2.4.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       hardhat: 2.22.4(ts-node@10.9.2(@swc/core@1.3.78)(@types/node@20.12.12)(typescript@5.4.5))(typescript@5.4.5)
       lodash.clonedeep: 4.5.0
       semver: 6.3.1
@@ -16357,7 +16378,7 @@ snapshots:
       '@ethersproject/address': 5.6.1
       '@nomicfoundation/solidity-analyzer': 0.1.1
       cbor: 9.0.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       ethers: 6.12.1
       fs-extra: 10.1.0
       immer: 10.0.2
@@ -16506,7 +16527,7 @@ snapshots:
     dependencies:
       '@oclif/core': 2.16.0(@swc/core@1.3.78)(@types/node@20.12.12)(typescript@5.4.5)
       chalk: 4.1.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
@@ -16593,7 +16614,7 @@ snapshots:
       '@openzeppelin/defender-sdk-deploy-client': 1.13.0(debug@4.3.4)(encoding@0.1.13)
       '@openzeppelin/upgrades-core': 1.33.1
       chalk: 4.1.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       ethereumjs-util: 7.1.5
       ethers: 6.12.1
       hardhat: 2.22.4(ts-node@10.9.2(@swc/core@1.3.78)(@types/node@20.12.12)(typescript@5.4.5))(typescript@5.4.5)
@@ -16617,7 +16638,7 @@ snapshots:
       '@openzeppelin/defender-sdk-network-client': 1.13.0(debug@4.3.4)(encoding@0.1.13)
       '@openzeppelin/upgrades-core': 1.33.1
       chalk: 4.1.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       ethereumjs-util: 7.1.5
       ethers: 6.12.1
       hardhat: 2.22.4(ts-node@10.9.2(@swc/core@1.3.78)(@types/node@18.19.33)(typescript@5.4.5))(typescript@5.4.5)
@@ -16636,7 +16657,7 @@ snapshots:
       cbor: 9.0.2
       chalk: 4.1.2
       compare-versions: 6.1.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       ethereumjs-util: 7.1.5
       minimist: 1.2.8
       proper-lockfile: 4.1.2
@@ -17376,6 +17397,8 @@ snapshots:
 
   '@scure/base@1.1.6': {}
 
+  '@scure/base@1.1.9': {}
+
   '@scure/bip32@1.1.5':
     dependencies:
       '@noble/hashes': 1.2.0
@@ -17394,6 +17417,12 @@ snapshots:
       '@noble/hashes': 1.3.3
       '@scure/base': 1.1.6
 
+  '@scure/bip32@1.5.0':
+    dependencies:
+      '@noble/curves': 1.6.0
+      '@noble/hashes': 1.5.0
+      '@scure/base': 1.1.9
+
   '@scure/bip39@1.1.1':
     dependencies:
       '@noble/hashes': 1.2.0
@@ -17408,6 +17437,11 @@ snapshots:
     dependencies:
       '@noble/hashes': 1.3.3
       '@scure/base': 1.1.6
+
+  '@scure/bip39@1.4.0':
+    dependencies:
+      '@noble/hashes': 1.5.0
+      '@scure/base': 1.1.9
 
   '@sentry/core@5.30.0':
     dependencies:
@@ -18196,7 +18230,7 @@ snapshots:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/type-utils': 5.62.0(eslint@7.32.0)(typescript@4.9.5)
       '@typescript-eslint/utils': 5.62.0(eslint@7.32.0)(typescript@4.9.5)
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       eslint: 7.32.0
       graphemer: 1.4.0
       ignore: 5.3.1
@@ -18215,7 +18249,7 @@ snapshots:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/type-utils': 5.62.0(eslint@8.57.0)(typescript@4.9.5)
       '@typescript-eslint/utils': 5.62.0(eslint@8.57.0)(typescript@4.9.5)
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       eslint: 8.57.0
       graphemer: 1.4.0
       ignore: 5.3.1
@@ -18235,7 +18269,7 @@ snapshots:
       '@typescript-eslint/type-utils': 6.21.0(eslint@8.57.0)(typescript@5.2.2)
       '@typescript-eslint/utils': 6.21.0(eslint@8.57.0)(typescript@5.2.2)
       '@typescript-eslint/visitor-keys': 6.21.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       eslint: 8.57.0
       graphemer: 1.4.0
       ignore: 5.3.1
@@ -18252,7 +18286,7 @@ snapshots:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@4.9.5)
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       eslint: 7.32.0
     optionalDependencies:
       typescript: 4.9.5
@@ -18264,7 +18298,7 @@ snapshots:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@4.9.5)
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       eslint: 8.57.0
     optionalDependencies:
       typescript: 4.9.5
@@ -18277,7 +18311,7 @@ snapshots:
       '@typescript-eslint/types': 6.21.0
       '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.2.2)
       '@typescript-eslint/visitor-keys': 6.21.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       eslint: 8.57.0
     optionalDependencies:
       typescript: 5.2.2
@@ -18298,7 +18332,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@4.9.5)
       '@typescript-eslint/utils': 5.62.0(eslint@7.32.0)(typescript@4.9.5)
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       eslint: 7.32.0
       tsutils: 3.21.0(typescript@4.9.5)
     optionalDependencies:
@@ -18310,7 +18344,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@4.9.5)
       '@typescript-eslint/utils': 5.62.0(eslint@8.57.0)(typescript@4.9.5)
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       eslint: 8.57.0
       tsutils: 3.21.0(typescript@4.9.5)
     optionalDependencies:
@@ -18322,7 +18356,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.2.2)
       '@typescript-eslint/utils': 6.21.0(eslint@8.57.0)(typescript@5.2.2)
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       eslint: 8.57.0
       ts-api-utils: 1.3.0(typescript@5.2.2)
     optionalDependencies:
@@ -18338,7 +18372,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/visitor-keys': 5.62.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.6.2
@@ -18352,7 +18386,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 6.21.0
       '@typescript-eslint/visitor-keys': 6.21.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.3
@@ -18419,21 +18453,21 @@ snapshots:
 
   '@ungap/structured-clone@1.2.0': {}
 
-  '@verax-attestation-registry/verax-sdk@2.1.0(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(@types/node@20.12.12)(@types/react@18.3.2)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.6.2)(typescript@5.2.2)':
+  '@verax-attestation-registry/verax-sdk@2.1.1(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(@types/node@20.12.12)(@types/react@18.3.2)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.6.2)(typescript@5.2.2)':
     dependencies:
-      '@graphql-mesh/cache-localforage': 0.95.8(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-mesh/utils@0.95.8(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(graphql@16.8.1)(tslib@2.6.2)
+      '@graphql-mesh/cache-localforage': 0.95.8(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-mesh/utils@0.95.8(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(graphql@16.8.1)(tslib@2.6.2)
       '@graphql-mesh/cross-helpers': 0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)
-      '@graphql-mesh/graphql': 0.95.8(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/store@0.95.8(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4)(@graphql-mesh/utils@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-mesh/utils@0.95.8(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(@types/node@20.12.12)(@types/react@18.3.2)(encoding@0.1.13)(graphql-ws@5.16.0(graphql@16.8.1))(graphql@16.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.6.2)
-      '@graphql-mesh/http': 0.96.14(lgcvyqvw5jfq24ksksqkso5bj4)
-      '@graphql-mesh/merger-bare': 0.95.8(@graphql-mesh/store@0.95.8(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4)(@graphql-mesh/utils@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-mesh/utils@0.95.8(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2)
-      '@graphql-mesh/runtime': 0.96.13(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-mesh/utils@0.95.8(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2)
+      '@graphql-mesh/graphql': 0.95.8(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/store@0.95.8(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4)(@graphql-mesh/utils@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-mesh/utils@0.95.8(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(@types/node@20.12.12)(@types/react@18.3.2)(encoding@0.1.13)(graphql-ws@5.16.0(graphql@16.8.1))(graphql@16.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.6.2)
+      '@graphql-mesh/http': 0.96.14(2imhrm62xh3xtkhuwlbd6uytny)
+      '@graphql-mesh/merger-bare': 0.95.8(@graphql-mesh/store@0.95.8(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4)(@graphql-mesh/utils@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-mesh/utils@0.95.8(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2)
+      '@graphql-mesh/runtime': 0.96.13(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4(@graphql-mesh/store@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-mesh/utils@0.95.8(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2))(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2)
       '@graphql-mesh/store': 0.95.8(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4)(@graphql-mesh/utils@0.95.8)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2)
       '@graphql-mesh/utils': 0.95.8(@graphql-mesh/cross-helpers@0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1))(@graphql-mesh/types@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)(tslib@2.6.2)
       '@whatwg-node/fetch': 0.9.17
       axios: 1.7.4(debug@4.3.4)
       dotenv: 16.4.5
       graphql: 16.8.1
-      viem: 2.10.8(typescript@5.2.2)
+      viem: 2.21.35(typescript@5.2.2)
     transitivePeerDependencies:
       - '@graphql-mesh/types'
       - '@graphql-tools/utils'
@@ -19373,11 +19407,11 @@ snapshots:
     optionalDependencies:
       typescript: 5.2.2
 
-  abitype@1.0.0(typescript@5.2.2):
+  abitype@1.0.6(typescript@5.2.2):
     optionalDependencies:
       typescript: 5.2.2
 
-  abitype@1.0.0(typescript@5.4.5):
+  abitype@1.0.6(typescript@5.4.5):
     optionalDependencies:
       typescript: 5.4.5
 
@@ -19436,13 +19470,13 @@ snapshots:
 
   agent-base@6.0.2:
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
   agent-base@7.1.1:
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
     optional: true
@@ -19788,7 +19822,7 @@ snapshots:
     dependencies:
       '@babel/code-frame': 7.24.2
       '@babel/parser': 7.24.5
-      '@babel/traverse': 7.24.5
+      '@babel/traverse': 7.24.5(supports-color@5.5.0)
       '@babel/types': 7.24.5
       eslint: 8.57.0
       eslint-visitor-keys: 1.3.0
@@ -21270,7 +21304,7 @@ snapshots:
   detect-port@1.6.1:
     dependencies:
       address: 1.2.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -21340,7 +21374,7 @@ snapshots:
 
   dns-over-http-resolver@1.2.3(node-fetch@2.7.0(encoding@0.1.13)):
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       native-fetch: 3.0.0(node-fetch@2.7.0(encoding@0.1.13))
       receptacle: 1.3.2
     transitivePeerDependencies:
@@ -21499,7 +21533,7 @@ snapshots:
   engine.io-client@6.5.3:
     dependencies:
       '@socket.io/component-emitter': 3.1.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       engine.io-parser: 5.2.2
       ws: 8.18.0
       xmlhttprequest-ssl: 2.0.0
@@ -21519,7 +21553,7 @@ snapshots:
       base64id: 2.0.0
       cookie: 0.4.2
       cors: 2.8.5
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       engine.io-parser: 5.2.2
       ws: 8.18.0
     transitivePeerDependencies:
@@ -21782,7 +21816,7 @@ snapshots:
 
   eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.2.2))(eslint-plugin-import@2.29.1)(eslint@8.57.0):
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       enhanced-resolve: 5.16.1
       eslint: 8.57.0
       eslint-module-utils: 2.8.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.2.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.2.2))(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0)
@@ -21937,7 +21971,7 @@ snapshots:
       '@es-joy/jsdoccomment': 0.37.1
       are-docs-informative: 0.0.2
       comment-parser: 1.3.1
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       escape-string-regexp: 4.0.0
       eslint: 8.57.0
       esquery: 1.5.0
@@ -22074,7 +22108,7 @@ snapshots:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       doctrine: 3.0.0
       enquirer: 2.4.1
       escape-string-regexp: 4.0.0
@@ -22124,7 +22158,7 @@ snapshots:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.2
@@ -22685,7 +22719,7 @@ snapshots:
 
   follow-redirects@1.15.6(debug@4.3.4):
     optionalDependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
 
   for-each@0.3.3:
     dependencies:
@@ -22967,7 +23001,7 @@ snapshots:
   gatsby-plugin-page-creator@5.13.1(encoding@0.1.13)(gatsby@5.13.4(babel-eslint@10.1.0(eslint@8.57.0))(encoding@0.1.13)(eslint-plugin-jest@27.9.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.5))(eslint@8.57.0)(typescript@4.9.5))(eslint@8.57.0)(jest@29.7.0(babel-plugin-macros@3.1.0))(typescript@4.9.5))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(type-fest@0.21.3)(typescript@4.9.5))(graphql@16.8.1):
     dependencies:
       '@babel/runtime': 7.24.5
-      '@babel/traverse': 7.24.5
+      '@babel/traverse': 7.24.5(supports-color@5.5.0)
       '@sindresorhus/slugify': 1.1.2
       chokidar: 3.6.0
       fs-exists-cached: 1.0.0
@@ -23077,7 +23111,7 @@ snapshots:
       '@babel/helper-plugin-utils': 7.24.5
       '@babel/parser': 7.24.5
       '@babel/runtime': 7.24.5
-      '@babel/traverse': 7.24.5
+      '@babel/traverse': 7.24.5(supports-color@5.5.0)
       '@babel/types': 7.24.5
       '@builder.io/partytown': 0.7.6
       '@gatsbyjs/reach-router': 2.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -23127,7 +23161,7 @@ snapshots:
       css-minimizer-webpack-plugin: 2.0.0(webpack@5.91.0)
       css.escape: 1.5.1
       date-fns: 2.30.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       deepmerge: 4.3.1
       detect-port: 1.6.1
       devcert: 1.2.2
@@ -23687,7 +23721,7 @@ snapshots:
       chalk: 2.4.2
       chokidar: 3.6.0
       ci-info: 2.0.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       enquirer: 2.4.1
       env-paths: 2.2.1
       ethereum-cryptography: 1.2.0
@@ -23741,7 +23775,7 @@ snapshots:
       chalk: 2.4.2
       chokidar: 3.6.0
       ci-info: 2.0.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       enquirer: 2.4.1
       env-paths: 2.2.1
       ethereum-cryptography: 1.2.0
@@ -23897,7 +23931,7 @@ snapshots:
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.1
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
     optional: true
@@ -23923,14 +23957,14 @@ snapshots:
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
   https-proxy-agent@7.0.4:
     dependencies:
       agent-base: 7.1.1
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
     optional: true
@@ -24095,7 +24129,7 @@ snapshots:
       any-signal: 2.1.2
       blob-to-it: 1.0.4
       browser-readablestream-to-it: 1.0.3
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       err-code: 3.0.1
       ipfs-core-types: 0.9.0(node-fetch@2.7.0(encoding@0.1.13))
       ipfs-unixfs: 6.0.9
@@ -24124,7 +24158,7 @@ snapshots:
       '@ipld/dag-pb': 2.1.18
       abort-controller: 3.0.0
       any-signal: 2.1.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       err-code: 3.0.1
       ipfs-core-types: 0.9.0(node-fetch@2.7.0(encoding@0.1.13))
       ipfs-core-utils: 0.13.0(encoding@0.1.13)(node-fetch@2.7.0(encoding@0.1.13))
@@ -24435,7 +24469,7 @@ snapshots:
     dependencies:
       ws: 8.18.0
 
-  isows@1.0.4(ws@8.18.0):
+  isows@1.0.6(ws@8.18.0):
     dependencies:
       ws: 8.18.0
 
@@ -24469,7 +24503,7 @@ snapshots:
 
   istanbul-lib-source-maps@4.0.1:
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       istanbul-lib-coverage: 3.2.2
       source-map: 0.6.1
     transitivePeerDependencies:
@@ -27384,7 +27418,7 @@ snapshots:
 
   socket.io-adapter@2.5.4:
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       ws: 8.18.0
     transitivePeerDependencies:
       - bufferutil
@@ -27394,7 +27428,7 @@ snapshots:
   socket.io-client@4.7.1:
     dependencies:
       '@socket.io/component-emitter': 3.1.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       engine.io-client: 6.5.3
       socket.io-parser: 4.2.4
     transitivePeerDependencies:
@@ -27405,7 +27439,7 @@ snapshots:
   socket.io-parser@4.2.4:
     dependencies:
       '@socket.io/component-emitter': 3.1.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -27414,7 +27448,7 @@ snapshots:
       accepts: 1.3.8
       base64id: 2.0.0
       cors: 2.8.5
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       engine.io: 6.5.4
       socket.io-adapter: 2.5.4
       socket.io-parser: 4.2.4
@@ -27426,7 +27460,7 @@ snapshots:
   socks-proxy-agent@8.0.3:
     dependencies:
       agent-base: 7.1.1
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       socks: 2.8.3
     transitivePeerDependencies:
       - supports-color
@@ -28392,7 +28426,7 @@ snapshots:
   typechain@8.3.2(typescript@5.4.5):
     dependencies:
       '@types/prettier': 2.7.3
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       fs-extra: 7.0.1
       glob: 7.1.7
       js-sha3: 0.8.0
@@ -28727,15 +28761,16 @@ snapshots:
       - utf-8-validate
       - zod
 
-  viem@2.10.8(typescript@5.2.2):
+  viem@2.21.35(typescript@5.2.2):
     dependencies:
-      '@adraffy/ens-normalize': 1.10.0
-      '@noble/curves': 1.2.0
-      '@noble/hashes': 1.3.2
-      '@scure/bip32': 1.3.2
-      '@scure/bip39': 1.2.1
-      abitype: 1.0.0(typescript@5.2.2)
-      isows: 1.0.4(ws@8.18.0)
+      '@adraffy/ens-normalize': 1.11.0
+      '@noble/curves': 1.6.0
+      '@noble/hashes': 1.5.0
+      '@scure/bip32': 1.5.0
+      '@scure/bip39': 1.4.0
+      abitype: 1.0.6(typescript@5.2.2)
+      isows: 1.0.6(ws@8.18.0)
+      webauthn-p256: 0.0.10
       ws: 8.18.0
     optionalDependencies:
       typescript: 5.2.2
@@ -28744,15 +28779,16 @@ snapshots:
       - utf-8-validate
       - zod
 
-  viem@2.10.8(typescript@5.4.5):
+  viem@2.21.35(typescript@5.4.5):
     dependencies:
-      '@adraffy/ens-normalize': 1.10.0
-      '@noble/curves': 1.2.0
-      '@noble/hashes': 1.3.2
-      '@scure/bip32': 1.3.2
-      '@scure/bip39': 1.2.1
-      abitype: 1.0.0(typescript@5.4.5)
-      isows: 1.0.4(ws@8.18.0)
+      '@adraffy/ens-normalize': 1.11.0
+      '@noble/curves': 1.6.0
+      '@noble/hashes': 1.5.0
+      '@scure/bip32': 1.5.0
+      '@scure/bip39': 1.4.0
+      abitype: 1.0.6(typescript@5.4.5)
+      isows: 1.0.6(ws@8.18.0)
+      webauthn-p256: 0.0.10
       ws: 8.18.0
     optionalDependencies:
       typescript: 5.4.5
@@ -28778,7 +28814,7 @@ snapshots:
 
   vite-tsconfig-paths@4.3.2(typescript@5.2.2)(vite@4.5.3(@types/node@20.12.12)(terser@5.31.0)):
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@5.5.0)
       globrex: 0.1.2
       tsconfck: 3.0.3(typescript@5.2.2)
     optionalDependencies:
@@ -28871,6 +28907,11 @@ snapshots:
       number-to-bn: 1.7.0
       randombytes: 2.1.0
       utf8: 3.0.0
+
+  webauthn-p256@0.0.10:
+    dependencies:
+      '@noble/curves': 1.6.0
+      '@noble/hashes': 1.5.0
 
   webcrypto-core@1.7.9:
     dependencies:

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verax-attestation-registry/verax-sdk",
-  "version": "2.1.0",
+  "version": "2.1.2",
   "description": "Verax Attestation Registry SDK to interact with the subgraph and the contracts",
   "keywords": [
     "linea-attestation-registry",
@@ -50,7 +50,7 @@
     "axios": "^1.7.4",
     "dotenv": "^16.3.1",
     "graphql": "^16.8.1",
-    "viem": "^2.9.26"
+    "viem": "^2.21.35"
   },
   "devDependencies": {
     "@babel/plugin-transform-runtime": "^7.23.3",


### PR DESCRIPTION
## What does this PR do?

- Upgrades viem to its latest version in the SDK, to benefit from `linea_gasEstimate` and increase compatibility on Linea, making transaction more accurately estimated and more likely to succeed
- Uses the new SDK version for the Explorer

### Related ticket

Fixes #779 

### Type of change

- [X] Chore
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update

## Check list

- [ ] Unit tests for any smart contract change
- [ ] Contracts and functions are documented
