### PR TITLE
feat(explorer): As a user, I want to see Expired and Revoked Attestations with a watermark on the Subject page

### DIFF
--- a/explorer/src/assets/watermarks/revoked-watermark.svg
+++ b/explorer/src/assets/watermarks/revoked-watermark.svg
@@ -1,0 +1,10 @@
+ <svg
+  viewBox="0 0 100 100"
+  preserveAspectRatio="none"
+  xmlns="http://www.w3.org/2000/svg">
+  <rect x="0" y="0" width="100" height="100" fill="none" stroke="#f87171" strokeWidth="1" rx="4" ry="4" />
+  <line x1="1" y1="1" x2="99" y2="99" stroke="#f87171" strokeWidth="1" />
+  <text x="50" y="50" fill="#f87171" fontSize="5" textAnchor="middle" transform="rotate(45, 50, 50)" dy="-.3em">
+    Revoked
+  </text>
+</svg>

--- a/explorer/src/assets/watermarks/revoked-watermark.svg
+++ b/explorer/src/assets/watermarks/revoked-watermark.svg
@@ -1,7 +1,4 @@
- <svg
-  viewBox="0 0 100 100"
-  preserveAspectRatio="none"
-  xmlns="http://www.w3.org/2000/svg">
+<svg viewBox="0 0 100 100" preserveAspectRatio="none" xmlns="http://www.w3.org/2000/svg">
   <rect x="0" y="0" width="100" height="100" fill="none" stroke="#f87171" strokeWidth="1" rx="4" ry="4" />
   <line x1="1" y1="1" x2="99" y2="99" stroke="#f87171" strokeWidth="1" />
   <text x="50" y="50" fill="#f87171" fontSize="5" textAnchor="middle" transform="rotate(45, 50, 50)" dy="-.3em">

--- a/explorer/src/pages/Attestation/components/AttestationCard/index.tsx
+++ b/explorer/src/pages/Attestation/components/AttestationCard/index.tsx
@@ -109,7 +109,12 @@ export const AttestationCard: React.FC<IAttestationCardProps> = ({
     >
       <div>
         {revoked && (
-          <RevokedWatermark className="absolute inset-0 w-full h-full pointer-events-none"></RevokedWatermark>
+          <div
+            className="absolute inset-0 flex items-center justify-center text-red-500 text-4xl md:text-6xl font-bold opacity-50 pointer-events-none"
+            style={{ transform: "rotate(-45deg)" }}
+          >
+            Revoked
+          </div>
         )}
         <div className="flex items-start gap-3 text-xl md:text-md font-semibold text-blackDefault dark:text-whiteDefault">
           <div className="w-[2.5rem] h-[2.5rem] md:w-[3rem] md:h-[3rem] flex items-center mr-2 justify-center">

--- a/explorer/src/pages/Attestation/components/AttestationCard/index.tsx
+++ b/explorer/src/pages/Attestation/components/AttestationCard/index.tsx
@@ -23,6 +23,7 @@ export const AttestationCard: React.FC<IAttestationCardProps> = ({
   portalId,
   issuanceDate,
   expiryDate,
+  revoked,
 }) => {
   const {
     sdk,
@@ -102,9 +103,12 @@ export const AttestationCard: React.FC<IAttestationCardProps> = ({
   return (
     <div
       key={`${id}`}
-      className="group flex flex-col justify-between gap-4 border border-border-card dark:border-border-cardDark rounded-xl p-4 md:p-6 hover:bg-surface-secondary dark:hover:bg-surface-secondaryDark transition md:min-h-[20rem]"
+      className={`relative group flex flex-col justify-between gap-4 border border-border-card dark:border-border-cardDark rounded-xl p-4 md:p-6 hover:bg-surface-secondary dark:hover:bg-surface-secondaryDark transition md:min-h-[20rem] ${(isExpired || revoked) && "bg-surface-darkGrey dark:bg-surface-darkGreyDark"}`}
     >
       <div>
+        {revoked && (
+          <RevokedWatermark className="absolute inset-0 w-full h-full pointer-events-none"></RevokedWatermark>
+        )}
         <div className="flex items-start gap-3 text-xl md:text-md font-semibold text-blackDefault dark:text-whiteDefault">
           <div className="w-[2.5rem] h-[2.5rem] md:w-[3rem] md:h-[3rem] flex items-center mr-2 justify-center">
             {displayLogo()}

--- a/explorer/src/pages/Attestation/components/AttestationCard/index.tsx
+++ b/explorer/src/pages/Attestation/components/AttestationCard/index.tsx
@@ -103,7 +103,9 @@ export const AttestationCard: React.FC<IAttestationCardProps> = ({
   return (
     <div
       key={`${id}`}
-      className={`relative group flex flex-col justify-between gap-4 border border-border-card dark:border-border-cardDark rounded-xl p-4 md:p-6 hover:bg-surface-secondary dark:hover:bg-surface-secondaryDark transition md:min-h-[20rem] ${(isExpired || revoked) && "bg-surface-darkGrey dark:bg-surface-darkGreyDark"}`}
+      className={`relative group flex flex-col justify-between gap-4 border border-border-card dark:border-border-cardDark rounded-xl p-4 md:p-6 hover:bg-surface-secondary dark:hover:bg-surface-secondaryDark transition md:min-h-[20rem] ${
+        (isExpired || revoked) && "bg-surface-darkGrey dark:bg-surface-darkGreyDark"
+      }`}
     >
       <div>
         {revoked && (

--- a/explorer/src/pages/Attestation/components/AttestationCard/interface.ts
+++ b/explorer/src/pages/Attestation/components/AttestationCard/interface.ts
@@ -4,4 +4,5 @@ export interface IAttestationCardProps {
   portalId: string;
   issuanceDate: number;
   expiryDate?: number;
+  revoked: boolean;
 }

--- a/explorer/src/pages/Attestations/components/CardView/index.tsx
+++ b/explorer/src/pages/Attestations/components/CardView/index.tsx
@@ -15,6 +15,7 @@ export const CardView: React.FC<ICardViewProps> = ({ attestationsList }) => {
               portalId={attestation.portal.id}
               issuanceDate={attestation.attestedDate}
               expiryDate={attestation.expirationDate}
+              revoked={attestation.revoked}
             />
           );
         })}

--- a/explorer/src/pages/Attestations/components/CardView/interface.ts
+++ b/explorer/src/pages/Attestations/components/CardView/interface.ts
@@ -9,5 +9,6 @@ export interface ICardViewProps {
     };
     attestedDate: number;
     expirationDate?: number;
+    revoked: boolean;
   }>;
 }


### PR DESCRIPTION
## What does this PR do?

For revoked attestations a watermark with red colour and revoked text is added.
For expired attestations card is greyed out

### Related ticket

Fixes #755 

### Type of change

- [ ] Chore
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update

## Check list

- [ ] Unit tests for any smart contract change
- [ ] Contracts and functions are documented
