### PR TITLE
feat(contracts):  Fix Attestation ID generation in examples

### DIFF
--- a/contracts/src/AttestationRegistry.sol
+++ b/contracts/src/AttestationRegistry.sol
@@ -332,4 +332,12 @@ contract AttestationRegistry is OwnableUpgradeable {
     // Combine the chain prefix and the ID
     return bytes32(abi.encode(chainPrefix + id));
   }
+
+  /**
+   * @notice Get the next attestation ID including chain identifier
+   * @return The next attestation ID
+   */
+  function getNextAttestationId() public view returns (bytes32) {
+    return generateAttestationId(attestationIdCounter + 1);
+  } 
 }

--- a/contracts/src/AttestationRegistry.sol
+++ b/contracts/src/AttestationRegistry.sol
@@ -339,5 +339,5 @@ contract AttestationRegistry is OwnableUpgradeable {
    */
   function getNextAttestationId() public view returns (bytes32) {
     return generateAttestationId(attestationIdCounter + 1);
-  } 
+  }
 }

--- a/contracts/src/examples/portals/EASPortal.sol
+++ b/contracts/src/examples/portals/EASPortal.sol
@@ -71,9 +71,7 @@ contract EASPortal is AbstractPortal {
       if (!attestationRegistry.isRegistered(attestationRequest.data.refUID)) {
         revert ReferenceAttestationNotRegistered();
       }
-
-      uint32 attestationIdCounter = attestationRegistry.getAttestationIdCounter();
-      bytes32 attestationId = bytes32(abi.encode(attestationIdCounter));
+      bytes32 attestationId = attestationRegistry.getNextAttestationId();
 
       AttestationPayload memory relationshipAttestationPayload = AttestationPayload(
         _relationshipSchemaId,

--- a/contracts/src/stdlib/IndexerModuleV2.sol
+++ b/contracts/src/stdlib/IndexerModuleV2.sol
@@ -192,8 +192,7 @@ contract IndexerModuleV2 is AbstractModuleV2 {
     AttestationRegistry attestationRegistry = AttestationRegistry(router.getAttestationRegistry());
     return
       Attestation(
-        // TODO: Consider the chain prefix to generate the attestation ID
-        bytes32(abi.encode(attestationRegistry.getAttestationIdCounter() + 1)),
+        attestationRegistry.getNextAttestationId(),
         attestationPayload.schemaId,
         bytes32(0),
         attester,

--- a/contracts/test/AttestationRegistry.t.sol
+++ b/contracts/test/AttestationRegistry.t.sol
@@ -661,7 +661,7 @@ contract AttestationRegistryTest is Test {
     assertEq(attestationId, 0x000300000000000000000000000000000000000000000000000000000000000a);
   }
 
-    function test_getNextAttestationId(AttestationPayload memory attestationPayload) public {
+  function test_getNextAttestationId(AttestationPayload memory attestationPayload) public {
     vm.assume(attestationPayload.subject.length != 0);
     vm.assume(attestationPayload.attestationData.length != 0);
     SchemaRegistryMock schemaRegistryMock = SchemaRegistryMock(router.getSchemaRegistry());

--- a/contracts/test/AttestationRegistry.t.sol
+++ b/contracts/test/AttestationRegistry.t.sol
@@ -661,6 +661,29 @@ contract AttestationRegistryTest is Test {
     assertEq(attestationId, 0x000300000000000000000000000000000000000000000000000000000000000a);
   }
 
+    function test_getNextAttestationId(AttestationPayload memory attestationPayload) public {
+    vm.assume(attestationPayload.subject.length != 0);
+    vm.assume(attestationPayload.attestationData.length != 0);
+    SchemaRegistryMock schemaRegistryMock = SchemaRegistryMock(router.getSchemaRegistry());
+    attestationPayload.schemaId = schemaRegistryMock.getIdFromSchemaString("schemaString");
+    schemaRegistryMock.createSchema("name", "description", "context", "schemaString");
+    bytes32 nextAttestationId = attestationRegistry.getNextAttestationId();
+
+    bytes32 expectedNextAttestationId = bytes32(abi.encode(initialChainPrefix + 1));
+    assertEq(nextAttestationId, expectedNextAttestationId);
+
+    vm.startPrank(portal);
+
+    attestationRegistry.attest(attestationPayload, attester);
+
+    expectedNextAttestationId = bytes32(abi.encode(initialChainPrefix + 2));
+    nextAttestationId = attestationRegistry.getNextAttestationId();
+
+    assertEq(nextAttestationId, expectedNextAttestationId);
+
+    vm.stopPrank();
+  }
+
   function _createAttestation(
     AttestationPayload memory attestationPayload,
     uint256 id

--- a/contracts/test/examples/portals/EASPortal.t.sol
+++ b/contracts/test/examples/portals/EASPortal.t.sol
@@ -68,7 +68,7 @@ contract EASPortalTest is Test {
     emit AttestationRegistered();
     easPortal.attest(attestationRequestWithoutRefUID);
 
-    bytes32 attestationIdWithoutRefUID = bytes32(abi.encode(1));
+    bytes32 attestationIdWithoutRefUID = attestationRegistryMock.getNextAttestationId();
 
     // Create second EAS attestation request with RefUID
     EASPortal.AttestationRequestData memory attestationRequestDataWithRefUID = EASPortal.AttestationRequestData(

--- a/contracts/test/mocks/AttestationRegistryMock.sol
+++ b/contracts/test/mocks/AttestationRegistryMock.sol
@@ -84,4 +84,13 @@ contract AttestationRegistryMock {
   function getAttestation(bytes32 attestationId) public view returns (Attestation memory) {
     return attestations[attestationId];
   }
+
+  function generateAttestationId(uint256 id) internal view returns (bytes32) {
+    // This is a mock implementation, 1000 is considered as chain prefix
+    return bytes32(abi.encode(1000 + id));
+  }
+
+  function getNextAttestationId() public view returns (bytes32) {
+    return generateAttestationId(attestationIdCounter + 1);
+  } 
 }

--- a/contracts/test/mocks/AttestationRegistryMock.sol
+++ b/contracts/test/mocks/AttestationRegistryMock.sol
@@ -92,5 +92,5 @@ contract AttestationRegistryMock {
 
   function getNextAttestationId() public view returns (bytes32) {
     return generateAttestationId(attestationIdCounter + 1);
-  } 
+  }
 }

--- a/contracts/test/stdlib/IndexerModuleV2.t.sol
+++ b/contracts/test/stdlib/IndexerModuleV2.t.sol
@@ -63,11 +63,11 @@ contract IndexerModuleV2Test is Test {
 
   function test_run() public {
     address[] memory modules = new address[](0);
-    bytes32 expectedAtttestationId = attestationRegistry.getNextAttestationId();
+    bytes32 expectedAttestationId = attestationRegistry.getNextAttestationId();
     ValidPortalMock validPortal = new ValidPortalMock(modules, address(router));
     vm.prank(address(validPortal));
     vm.expectEmit({ emitter: address(indexerModule) });
-    emit AttestationIndexed(expectedAtttestationId);
+    emit AttestationIndexed(expectedAttestationId);
     indexerModule.run(
       payload3,
       bytes(""),
@@ -77,7 +77,7 @@ contract IndexerModuleV2Test is Test {
       address(validPortal),
       OperationType.Attest
     );
-    assertEq(indexerModule.getIndexedAttestationStatus(expectedAtttestationId), true);
+    assertEq(indexerModule.getIndexedAttestationStatus(expectedAttestationId), true);
   }
 
   function test_indexAttestation() public {

--- a/contracts/test/stdlib/IndexerModuleV2.t.sol
+++ b/contracts/test/stdlib/IndexerModuleV2.t.sol
@@ -63,10 +63,11 @@ contract IndexerModuleV2Test is Test {
 
   function test_run() public {
     address[] memory modules = new address[](0);
+    bytes32 expectedAtttestationId = attestationRegistry.getNextAttestationId();
     ValidPortalMock validPortal = new ValidPortalMock(modules, address(router));
     vm.prank(address(validPortal));
     vm.expectEmit({ emitter: address(indexerModule) });
-    emit AttestationIndexed(bytes32(abi.encode(3)));
+    emit AttestationIndexed(expectedAtttestationId);
     indexerModule.run(
       payload3,
       bytes(""),
@@ -76,7 +77,7 @@ contract IndexerModuleV2Test is Test {
       address(validPortal),
       OperationType.Attest
     );
-    assertEq(indexerModule.getIndexedAttestationStatus(bytes32(abi.encode(3))), true);
+    assertEq(indexerModule.getIndexedAttestationStatus(expectedAtttestationId), true);
   }
 
   function test_indexAttestation() public {


### PR DESCRIPTION
## What does this PR do?

It adds chain prefix in attestation id generation logic in the examples where it was missing.

### Related ticket

Fixes #787 

### Type of change

- [ ] Chore
- [x] Bug fix
- [x] New feature
- [ ] Documentation update

## Check list

- [x] Unit tests for any smart contract change
- [ ] Contracts and functions are documented
