### PR TITLE
feat(contracts): Implement a default withdraw function

### DIFF
--- a/contracts/src/DefaultPortal.sol
+++ b/contracts/src/DefaultPortal.sol
@@ -17,7 +17,4 @@ contract DefaultPortal is AbstractPortal {
    * @dev This sets the addresses for the AttestationRegistry, ModuleRegistry and PortalRegistry
    */
   constructor(address[] memory modules, address router) AbstractPortal(modules, router) {}
-
-  /// @inheritdoc AbstractPortal
-  function withdraw(address payable to, uint256 amount) external override {}
 }

--- a/contracts/src/abstracts/AbstractPortal.sol
+++ b/contracts/src/abstracts/AbstractPortal.sol
@@ -43,7 +43,7 @@ abstract contract AbstractPortal is IPortal {
     moduleRegistry = ModuleRegistry(router.getModuleRegistry());
     portalRegistry = PortalRegistry(router.getPortalRegistry());
   }
-  
+
   /**
    * @notice Withdraw funds from the Portal
    * @param to the address to send the funds to
@@ -52,7 +52,7 @@ abstract contract AbstractPortal is IPortal {
    */
   function withdraw(address payable to, uint256 amount) external virtual {
     if (msg.sender != portalRegistry.getPortalByAddress(address(this)).ownerAddress) revert OnlyPortalOwner();
-    (bool s, ) = to.call{value: amount}("");
+    (bool s, ) = to.call{ value: amount }("");
     if (!s) revert WithdrawFail();
   }
 

--- a/contracts/test/DefaultPortal.t.sol
+++ b/contracts/test/DefaultPortal.t.sol
@@ -21,6 +21,7 @@ contract DefaultPortalTest is Test {
   AttestationRegistryMock public attestationRegistryMock = new AttestationRegistryMock();
   Router public router = new Router();
   address public portalOwner = makeAddr("portalOwner");
+  address public recipient = makeAddr("recipient");
 
   event Initialized(uint8 version);
   event PortalRegistered(string name, string description, address portalAddress);
@@ -327,5 +328,42 @@ contract DefaultPortalTest is Test {
     assertEq(isIERC165Supported, true);
     bool isAbstractPortalSupported = defaultPortal.supportsInterface(type(AbstractPortal).interfaceId);
     assertEq(isAbstractPortalSupported, true);
+  }
+
+  function test_withdraw_byOwner() public {
+    // Fund the portal contract with 1 ether
+    vm.deal(address(defaultPortal), 1 ether);
+
+    // Set the amount to withdraw
+    uint256 withdrawAmount = 0.5 ether;
+    uint256 recipientInitialBalance = recipient.balance;
+
+    // Attempt withdrawal by the owner
+    vm.prank(portalOwner);
+    defaultPortal.withdraw(payable(recipient), withdrawAmount);
+
+    // Verify the recipient's balance has increased by the withdrawal amount
+    assertEq(recipient.balance, recipientInitialBalance + withdrawAmount);
+}
+
+  function test_withdrawFail_OnlyPortalOwner() public {
+    // Attempt withdrawal by a non-owner address
+    uint256 withdrawAmount = 0.5 ether;
+    vm.prank(makeAddr("nonOwner"));
+    vm.expectRevert(AbstractPortal.OnlyPortalOwner.selector);
+
+    defaultPortal.withdraw(payable(recipient), withdrawAmount);
+  }
+
+  function test_withdrawFail_InsufficientBalance() public {
+    // Fund the portal contract with less than the requested amount
+    vm.deal(address(defaultPortal), 0.25 ether);
+
+    // Attempt withdrawal of 0.5 ether
+    uint256 withdrawAmount = 0.5 ether;
+    vm.prank(portalOwner);
+    vm.expectRevert(AbstractPortal.WithdrawFail.selector);
+
+    defaultPortal.withdraw(payable(recipient), withdrawAmount);
   }
 }

--- a/contracts/test/DefaultPortal.t.sol
+++ b/contracts/test/DefaultPortal.t.sol
@@ -344,7 +344,7 @@ contract DefaultPortalTest is Test {
 
     // Verify the recipient's balance has increased by the withdrawal amount
     assertEq(recipient.balance, recipientInitialBalance + withdrawAmount);
-}
+  }
 
   function test_withdrawFail_OnlyPortalOwner() public {
     // Attempt withdrawal by a non-owner address


### PR DESCRIPTION
## What does this PR do?

This PR implements default behaviour of withdraw function at Abstract Portal level
Default portal will also use the same behaviour for withdrawal function

### Related ticket

Fixes #790 

### Type of change

- [ ] Chore
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update

## Check list

- [x] Unit tests for any smart contract change
- [ ] Contracts and functions are documented
