### PR TITLE
chore(contracts): Add tests to cover the bulkRevoke function in AbstractPortal and AbstractPortalV2

### DIFF
--- a/contracts/test/DefaultPortal.t.sol
+++ b/contracts/test/DefaultPortal.t.sol
@@ -323,6 +323,17 @@ contract DefaultPortalTest is Test {
     defaultPortal.bulkRevoke(attestationsToRevoke);
   }
 
+  function test_bulkRevoke_OnlyOwner() public {
+    bytes32[] memory attestationsToRevoke = new bytes32[](2);
+    attestationsToRevoke[0] = bytes32("1");
+    attestationsToRevoke[1] = bytes32("2");
+
+    // Revoke the attestation as a random user
+    vm.prank(makeAddr("random"));
+    vm.expectRevert(AbstractPortal.OnlyPortalOwner.selector);
+    defaultPortal.bulkRevoke(attestationsToRevoke);
+  }
+
   function test_supportsInterface() public view {
     bool isIERC165Supported = defaultPortal.supportsInterface(type(ERC165Upgradeable).interfaceId);
     assertEq(isIERC165Supported, true);

--- a/contracts/test/DefaultPortalV2.t.sol
+++ b/contracts/test/DefaultPortalV2.t.sol
@@ -243,6 +243,17 @@ contract DefaultPortalV2Test is Test {
     defaultPortal.bulkRevoke(attestationsToRevoke);
   }
 
+  function test_bulkRevoke_OnlyOwner() public {
+    bytes32[] memory attestationsToRevoke = new bytes32[](2);
+    attestationsToRevoke[0] = bytes32("1");
+    attestationsToRevoke[1] = bytes32("2");
+
+    // Revoke the attestation as a random user
+    vm.prank(makeAddr("random"));
+    vm.expectRevert(AbstractPortalV2.OnlyPortalOwner.selector);
+    defaultPortal.bulkRevoke(attestationsToRevoke);
+  }
+
   function test_supportsInterface() public view {
     bool isIERC165Supported = defaultPortal.supportsInterface(type(ERC165Upgradeable).interfaceId);
     assertEq(isIERC165Supported, true);


### PR DESCRIPTION
## What does this PR do?

Adds a couple of tests to cover the `bulkRevoke` functions and hooks on the Abstract Portals.

### Related ticket

Fixes #821 

### Type of change

- [X] Chore
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update

## Check list

- [ ] Unit tests for any smart contract change
- [ ] Contracts and functions are documented
