### PR TITLE
fix(contracts): Deployment script doesn't work as intended for PortalRegistry

### DIFF
--- a/contracts/script/upgrade/checkImplementations.ts
+++ b/contracts/script/upgrade/checkImplementations.ts
@@ -21,8 +21,7 @@ async function main() {
 
   console.log("Checking PortalRegistry...");
   const PortalRegistry = await ethers.getContractFactory("PortalRegistry");
-  // @ts-expect-error-next-line - constructorArgs is not part of the type
-  await upgrades.validateImplementation(PortalRegistry, { constructorArgs: [false] });
+  await upgrades.validateImplementation(PortalRegistry);
   console.log("PortalRegistry OK");
 
   console.log("Checking SchemaRegistry...");

--- a/contracts/script/upgrade/checkUpgradeability.ts
+++ b/contracts/script/upgrade/checkUpgradeability.ts
@@ -31,10 +31,8 @@ async function main() {
   const portalRegistryProxyAddress = process.env.PORTAL_REGISTRY_ADDRESS ?? "";
   const PortalRegistry = await ethers.getContractFactory("PortalRegistry");
 
-  // @ts-expect-error-next-line - constructorArgs is not part of the type
   await upgrades.validateUpgrade(portalRegistryProxyAddress, PortalRegistry, {
     kind: "transparent",
-    constructorArgs: [false],
   });
 
   console.log("Checking SchemaRegistry...");

--- a/contracts/src/PortalRegistry.sol
+++ b/contracts/src/PortalRegistry.sol
@@ -64,16 +64,17 @@ contract PortalRegistry is RouterManager {
   event IsTestnetUpdated(bool isTestnet);
 
   /// @custom:oz-upgrades-unsafe-allow constructor
-  constructor(bool _isTestnet) {
+  constructor() {
     _disableInitializers();
-    isTestnet = _isTestnet;
   }
 
   /**
-   * @notice Contract initialization
+   * @notice Contract initialization with testnet status
+   * @param _isTestnet Boolean indicating if the deployment is on a testnet
    */
-  function initialize() public initializer {
+  function initialize(bool _isTestnet) public initializer {
     __Ownable_init();
+    isTestnet = _isTestnet;
   }
 
   /**

--- a/contracts/test/PortalRegistry.t.sol
+++ b/contracts/test/PortalRegistry.t.sol
@@ -84,7 +84,7 @@ contract PortalRegistryTest is Test {
   }
 
   function test_updateRouter_RouterAlreadyUpdated() public {
-    PortalRegistry testPortalRegistry = new PortalRegistry(false);
+    PortalRegistry testPortalRegistry = new PortalRegistry();
     vm.expectEmit(true, true, true, true);
     emit RouterUpdated(address(1));
     vm.prank(address(0));
@@ -137,7 +137,7 @@ contract PortalRegistryTest is Test {
     vm.expectRevert(PortalRegistry.IssuerAlreadySet.selector);
     portalRegistry.setIssuer(issuerAddress);
   }
-  
+
   function test_setIsTestnet() public {
     PortalRegistry testnetPortalRegistry = new PortalRegistry();
 

--- a/contracts/test/PortalRegistry.t.sol
+++ b/contracts/test/PortalRegistry.t.sol
@@ -40,7 +40,7 @@ contract PortalRegistryTest is Test {
     router = new Router();
     router.initialize();
 
-    portalRegistry = new PortalRegistry(false);
+    portalRegistry = new PortalRegistry();
     router.updatePortalRegistry(address(portalRegistry));
 
     moduleRegistryAddress = address(new ModuleRegistryMock());
@@ -61,11 +61,11 @@ contract PortalRegistryTest is Test {
 
   function test_initialize_ContractAlreadyInitialized() public {
     vm.expectRevert("Initializable: contract is already initialized");
-    portalRegistry.initialize();
+    portalRegistry.initialize(false);
   }
 
   function test_updateRouter() public {
-    PortalRegistry testPortalRegistry = new PortalRegistry(false);
+    PortalRegistry testPortalRegistry = new PortalRegistry();
 
     vm.expectEmit(true, true, true, true);
     emit RouterUpdated(address(1));
@@ -76,7 +76,7 @@ contract PortalRegistryTest is Test {
   }
 
   function test_updateRouter_RouterInvalid() public {
-    PortalRegistry testPortalRegistry = new PortalRegistry(false);
+    PortalRegistry testPortalRegistry = new PortalRegistry();
 
     vm.expectRevert(RouterManager.RouterInvalid.selector);
     vm.prank(address(0));
@@ -137,33 +137,20 @@ contract PortalRegistryTest is Test {
     vm.expectRevert(PortalRegistry.IssuerAlreadySet.selector);
     portalRegistry.setIssuer(issuerAddress);
   }
+  
+  function test_setIsTestnet() public {
+    PortalRegistry testnetPortalRegistry = new PortalRegistry();
 
-  function test_setIsTestnet_true() public {
-    bool isTestnet = portalRegistry.getIsTestnet();
+    bool isTestnet = testnetPortalRegistry.getIsTestnet();
     assertEq(isTestnet, false);
 
     vm.prank(address(0));
     vm.expectEmit();
     emit IsTestnetUpdated(true);
-    portalRegistry.setIsTestnet(true);
-
-    isTestnet = portalRegistry.getIsTestnet();
-    assertEq(isTestnet, true);
-  }
-
-  function test_setIsTestnet_false() public {
-    PortalRegistry testnetPortalRegistry = new PortalRegistry(true);
-
-    bool isTestnet = testnetPortalRegistry.getIsTestnet();
-    assertEq(isTestnet, true);
-
-    vm.prank(address(0));
-    vm.expectEmit();
-    emit IsTestnetUpdated(false);
-    testnetPortalRegistry.setIsTestnet(false);
+    testnetPortalRegistry.setIsTestnet(true);
 
     isTestnet = testnetPortalRegistry.getIsTestnet();
-    assertEq(isTestnet, false);
+    assertEq(isTestnet, true);
   }
 
   function test_setIsTestnet_OnlyOwner() public {
@@ -358,13 +345,16 @@ contract PortalRegistryTest is Test {
   }
 
   function test_isAllowlisted_Testnet() public {
-    PortalRegistry testnetPortalRegistry = new PortalRegistry(true);
+    PortalRegistry testnetPortalRegistry = new PortalRegistry();
+    vm.prank(address(0));
+    testnetPortalRegistry.setIsTestnet(true);
+
     address userAddress = makeAddr("User");
     assertEq(testnetPortalRegistry.isAllowlisted(userAddress), true);
   }
 
   function test_isAllowlisted_Testnet_fail() public {
-    PortalRegistry mainnetPortalRegistry = new PortalRegistry(false);
+    PortalRegistry mainnetPortalRegistry = new PortalRegistry();
     address userAddress = makeAddr("User");
     assertEq(mainnetPortalRegistry.isAllowlisted(userAddress), false);
   }
@@ -383,7 +373,10 @@ contract PortalRegistryTest is Test {
   }
 
   function test_isAllowlisted_TestnetAndIssuer() public {
-    PortalRegistry testnetPortalRegistry = new PortalRegistry(true);
+    PortalRegistry testnetPortalRegistry = new PortalRegistry();
+    vm.prank(address(0));
+    testnetPortalRegistry.setIsTestnet(true);
+
     address userAddress = makeAddr("User");
     vm.prank(address(0));
     testnetPortalRegistry.setIssuer(userAddress);
@@ -391,7 +384,7 @@ contract PortalRegistryTest is Test {
   }
 
   function test_isAllowlisted_TestnetAndIssuer_fail() public {
-    PortalRegistry mainnetPortalRegistry = new PortalRegistry(false);
+    PortalRegistry mainnetPortalRegistry = new PortalRegistry();
     address userAddress = makeAddr("User");
     assertEq(mainnetPortalRegistry.isAllowlisted(userAddress), false);
   }

--- a/contracts/test/integration/AttestationRegistryMass.t.sol
+++ b/contracts/test/integration/AttestationRegistryMass.t.sol
@@ -38,7 +38,7 @@ contract AttestationRegistryMassTest is Test {
     vm.prank(address(0));
     attestationRegistry.updateRouter(address(router));
 
-    portalRegistry = new PortalRegistry(false);
+    portalRegistry = new PortalRegistry();
     router.updatePortalRegistry(address(portalRegistry));
     vm.prank(address(0));
     portalRegistry.updateRouter(address(router));

--- a/contracts/test/integration/IssuersPortal.t.sol
+++ b/contracts/test/integration/IssuersPortal.t.sol
@@ -16,7 +16,7 @@ contract IssuersPortalTest is Test {
   address public issuerAddress = makeAddr("issuer");
   Router public router = new Router();
   SchemaRegistry public schemaRegistry = new SchemaRegistry();
-  PortalRegistry public portalRegistry = new PortalRegistry(false);
+  PortalRegistry public portalRegistry = new PortalRegistry();
   ModuleRegistry public moduleRegistry = new ModuleRegistry();
   AttestationRegistry public attestationRegistry = new AttestationRegistry();
   IssuersModuleV2 public issuersModule;


### PR DESCRIPTION
## What does this PR do?

Moves the `isTestnet` param from the constructor to the `initialize` function

### Related ticket

Fixes #807 

### Type of change

- [ ] Chore
- [X] Bug fix
- [ ] New feature
- [ ] Documentation update

## Check list

- [X] Unit tests for any smart contract change
- [X] Contracts and functions are documented
