### PR TITLE
chore(contracts): Revert when no change happens in a state-changing function

### DIFF
--- a/contracts/src/AttestationReader.sol
+++ b/contracts/src/AttestationReader.sol
@@ -17,8 +17,12 @@ contract AttestationReader is RouterManager {
   IRouter public router;
   IEAS public easRegistry;
 
+  /// @notice Error thrown when the Router address remains unchanged
+  error RouterAlreadyUpdated();
   /// @notice Error thrown when an invalid EAS registry address is given
   error EASAddressInvalid();
+  /// @notice Error thrown when the EAS registry address remains unchanged
+  error EASRegistryAddressAlreadyUpdated();
 
   /// @notice Event emitted when the EAS registry address is updated
   event EASRegistryAddressUpdated(address easRegistryAddress);
@@ -40,6 +44,8 @@ contract AttestationReader is RouterManager {
    * @param _router the new Router address
    */
   function _setRouter(address _router) internal override {
+    if (_router == address(router)) revert RouterAlreadyUpdated();
+
     router = IRouter(_router);
   }
 
@@ -50,6 +56,8 @@ contract AttestationReader is RouterManager {
    */
   function updateEASRegistryAddress(address _easRegistryAddress) public onlyOwner {
     if (_easRegistryAddress == address(0)) revert EASAddressInvalid();
+    if (_easRegistryAddress == address(easRegistry)) revert EASRegistryAddressAlreadyUpdated();
+
     easRegistry = IEAS(_easRegistryAddress);
     emit EASRegistryAddressUpdated(_easRegistryAddress);
   }

--- a/contracts/src/AttestationRegistry.sol
+++ b/contracts/src/AttestationRegistry.sol
@@ -23,6 +23,10 @@ contract AttestationRegistry is RouterManager {
 
   uint256 private chainPrefix;
 
+  /// @notice Error thrown when the Router address remains unchanged
+  error RouterAlreadyUpdated();
+  /// @notice Error thrown when the chain prefix remains unchanged
+  error ChainPrefixAlreadyUpdated();
   /// @notice Error thrown when a non-portal tries to call a method that can only be called by a portal
   error OnlyPortal();
   /// @notice Error thrown when an attestation is not registered in the AttestationRegistry
@@ -80,6 +84,8 @@ contract AttestationRegistry is RouterManager {
    * @param _router the new Router address
    */
   function _setRouter(address _router) internal override {
+    if (_router == address(router)) revert RouterAlreadyUpdated();
+
     router = IRouter(_router);
   }
 
@@ -88,6 +94,8 @@ contract AttestationRegistry is RouterManager {
    * @dev Only the registry owner can call this method
    */
   function updateChainPrefix(uint256 _chainPrefix) public onlyOwner {
+    if (_chainPrefix == chainPrefix) revert ChainPrefixAlreadyUpdated();
+
     chainPrefix = _chainPrefix;
     emit ChainPrefixUpdated(_chainPrefix);
   }

--- a/contracts/src/ModuleRegistry.sol
+++ b/contracts/src/ModuleRegistry.sol
@@ -24,6 +24,8 @@ contract ModuleRegistry is RouterManager {
   /// @dev Deprecated: The `moduleAddresses` variable is no longer used. It was used to store the modules addresses.
   address[] public moduleAddresses;
 
+  /// @notice Error thrown when the Router address remains unchanged
+  error RouterAlreadyUpdated();
   /// @notice Error thrown when a non-allowlisted user tries to call a forbidden method
   error OnlyAllowlisted();
   /// @notice Error thrown when an identical Module was already registered
@@ -70,6 +72,8 @@ contract ModuleRegistry is RouterManager {
    * @param _router the new Router address
    */
   function _setRouter(address _router) internal override {
+    if (_router == address(router)) revert RouterAlreadyUpdated();
+
     router = IRouter(_router);
   }
 

--- a/contracts/src/PortalRegistry.sol
+++ b/contracts/src/PortalRegistry.sol
@@ -27,6 +27,12 @@ contract PortalRegistry is RouterManager {
 
   bool private isTestnet;
 
+  /// @notice Error thrown when the Router address remains unchanged
+  error RouterAlreadyUpdated();
+  /// @notice Error thrown when attempting to set an issuer that is already set
+  error IssuerAlreadySet();
+  /// @notice Error thrown when the testnet flag remains unchanged
+  error TestnetStatusAlreadyUpdated();
   /// @notice Error thrown when a non-allowlisted user tries to call a forbidden method
   error OnlyAllowlisted();
   /// @notice Error thrown when attempting to register a Portal twice
@@ -75,6 +81,8 @@ contract PortalRegistry is RouterManager {
    * @param _router the new Router address
    */
   function _setRouter(address _router) internal override {
+    if (_router == address(router)) revert RouterAlreadyUpdated();
+
     router = IRouter(_router);
   }
 
@@ -84,6 +92,7 @@ contract PortalRegistry is RouterManager {
    */
   function setIssuer(address issuer) public onlyOwner {
     if (issuer == address(0)) revert AddressInvalid();
+    if (issuers[issuer]) revert IssuerAlreadySet();
 
     issuers[issuer] = true;
     emit IssuerAdded(issuer);
@@ -94,6 +103,8 @@ contract PortalRegistry is RouterManager {
    * @param _isTestnet the flag defining the testnet status
    */
   function setIsTestnet(bool _isTestnet) public onlyOwner {
+    if (isTestnet == _isTestnet) revert TestnetStatusAlreadyUpdated();
+
     isTestnet = _isTestnet;
     emit IsTestnetUpdated(_isTestnet);
   }

--- a/contracts/test/AttestationReader.t.sol
+++ b/contracts/test/AttestationReader.t.sol
@@ -66,6 +66,18 @@ contract AttestationReaderTest is Test {
     testAttestationReader.updateRouter(address(0));
   }
 
+  function test_updateRouter_RouterAlreadyUpdated() public {
+    AttestationReader testAttestationReader = new AttestationReader();
+    vm.expectEmit(true, true, true, true);
+    emit RouterUpdated(address(1));
+    vm.prank(address(0));
+    testAttestationReader.updateRouter(address(1));
+
+    vm.expectRevert(AttestationReader.RouterAlreadyUpdated.selector);
+    vm.prank(address(0));
+    testAttestationReader.updateRouter(address(1));
+  }
+
   function test_updateEASRegistryAddress() public {
     AttestationReader testAttestationReader = new AttestationReader();
 
@@ -83,6 +95,18 @@ contract AttestationReaderTest is Test {
     vm.expectRevert(AttestationReader.EASAddressInvalid.selector);
     vm.prank(address(0));
     testAttestationReader.updateEASRegistryAddress(address(0));
+  }
+
+  function test_updateEASRegistryAddress_EASRegistryAddressAlreadyUpdated() public {
+    AttestationReader testAttestationReader = new AttestationReader();
+    vm.expectEmit(true, true, true, true);
+    emit EASRegistryAddressUpdated(address(1));
+    vm.prank(address(0));
+    testAttestationReader.updateEASRegistryAddress(address(1));
+
+    vm.expectRevert(AttestationReader.EASRegistryAddressAlreadyUpdated.selector);
+    vm.prank(address(0));
+    testAttestationReader.updateEASRegistryAddress(address(1));
   }
 
   function test_getAttestation_fromEAS() public {

--- a/contracts/test/AttestationRegistry.t.sol
+++ b/contracts/test/AttestationRegistry.t.sol
@@ -97,6 +97,26 @@ contract AttestationRegistryTest is Test {
     assertEq(routerAddress, address(1));
   }
 
+  function test_updateRouter_InvalidParameter() public {
+    AttestationRegistry testAttestationRegistry = new AttestationRegistry();
+
+    vm.expectRevert(RouterManager.RouterInvalid.selector);
+    vm.prank(address(0));
+    testAttestationRegistry.updateRouter(address(0));
+  }
+
+  function test_updateRouter_RouterAlreadyUpdated() public {
+    AttestationRegistry testAttestationRegistry = new AttestationRegistry();
+    vm.expectEmit(true, true, true, true);
+    emit RouterUpdated(address(1));
+    vm.prank(address(0));
+    testAttestationRegistry.updateRouter(address(1));
+
+    vm.expectRevert(AttestationRegistry.RouterAlreadyUpdated.selector);
+    vm.prank(address(0));
+    testAttestationRegistry.updateRouter(address(1));
+  }
+
   function test_updateChainPrefix() public {
     AttestationRegistry testAttestationRegistry = new AttestationRegistry();
 
@@ -117,12 +137,17 @@ contract AttestationRegistryTest is Test {
     assertEq(chainPrefix, 0x0001000000000000000000000000000000000000000000000000000000000000);
   }
 
-  function test_updateRouter_InvalidParameter() public {
+  function test_updateChainPrefix_ChainPrefixAlreadyUpdated() public {
     AttestationRegistry testAttestationRegistry = new AttestationRegistry();
 
-    vm.expectRevert(RouterManager.RouterInvalid.selector);
+    vm.expectEmit(true, true, true, true);
+    emit ChainPrefixUpdated(initialChainPrefix);
     vm.prank(address(0));
-    testAttestationRegistry.updateRouter(address(0));
+    testAttestationRegistry.updateChainPrefix(initialChainPrefix);
+
+    vm.expectRevert(AttestationRegistry.ChainPrefixAlreadyUpdated.selector);
+    vm.prank(address(0));
+    testAttestationRegistry.updateChainPrefix(initialChainPrefix);
   }
 
   function test_attest(AttestationPayload memory attestationPayload) public {

--- a/contracts/test/ModuleRegistry.t.sol
+++ b/contracts/test/ModuleRegistry.t.sol
@@ -71,6 +71,18 @@ contract ModuleRegistryTest is Test {
     testModuleRegistry.updateRouter(address(0));
   }
 
+  function test_updateRouter_RouterAlreadyUpdated() public {
+    ModuleRegistry testModuleRegistry = new ModuleRegistry();
+    vm.expectEmit(true, true, true, true);
+    emit RouterUpdated(address(1));
+    vm.prank(address(0));
+    testModuleRegistry.updateRouter(address(1));
+
+    vm.expectRevert(ModuleRegistry.RouterAlreadyUpdated.selector);
+    vm.prank(address(0));
+    testModuleRegistry.updateRouter(address(1));
+  }
+
   function test_isContractAddress() public view {
     // isContractAddress should return false for EOA address
     address eoaAddress = vm.addr(1);

--- a/contracts/test/PortalRegistry.t.sol
+++ b/contracts/test/PortalRegistry.t.sol
@@ -83,6 +83,18 @@ contract PortalRegistryTest is Test {
     testPortalRegistry.updateRouter(address(0));
   }
 
+  function test_updateRouter_RouterAlreadyUpdated() public {
+    PortalRegistry testPortalRegistry = new PortalRegistry(false);
+    vm.expectEmit(true, true, true, true);
+    emit RouterUpdated(address(1));
+    vm.prank(address(0));
+    testPortalRegistry.updateRouter(address(1));
+
+    vm.expectRevert(PortalRegistry.RouterAlreadyUpdated.selector);
+    vm.prank(address(0));
+    testPortalRegistry.updateRouter(address(1));
+  }
+
   function test_setIssuer() public {
     vm.startPrank(address(0));
     address issuerAddress = makeAddr("Issuer");
@@ -113,6 +125,17 @@ contract PortalRegistryTest is Test {
 
     bool isIssuer = portalRegistry.isIssuer(address(0));
     assertEq(isIssuer, false);
+  }
+
+  function test_setIssuer_IssuerAlreadySet() public {
+    vm.startPrank(address(0));
+    address issuerAddress = makeAddr("Issuer");
+    vm.expectEmit();
+    emit IssuerAdded(issuerAddress);
+    portalRegistry.setIssuer(issuerAddress);
+
+    vm.expectRevert(PortalRegistry.IssuerAlreadySet.selector);
+    portalRegistry.setIssuer(issuerAddress);
   }
 
   function test_setIsTestnet_true() public {
@@ -154,6 +177,15 @@ contract PortalRegistryTest is Test {
 
     isTestnet = portalRegistry.getIsTestnet();
     assertEq(isTestnet, false);
+  }
+
+  function test_setIsTestnet_TestnetStatusAlreadyUpdated() public {
+    bool isTestnet = portalRegistry.getIsTestnet();
+    assertEq(isTestnet, false);
+
+    vm.prank(address(0));
+    vm.expectRevert(PortalRegistry.TestnetStatusAlreadyUpdated.selector);
+    portalRegistry.setIsTestnet(false);
   }
 
   function test_removeIssuer() public {

--- a/contracts/test/SchemaRegistry.t.sol
+++ b/contracts/test/SchemaRegistry.t.sol
@@ -67,6 +67,19 @@ contract SchemaRegistryTest is Test {
     testSchemaRegistry.updateRouter(address(0));
   }
 
+  function test_updateRouter_RouterAlreadyUpdated() public {
+    SchemaRegistry testSchemaRegistry = new SchemaRegistry();
+
+    vm.expectEmit(true, true, true, true);
+    emit RouterUpdated(address(1));
+    vm.prank(address(0));
+    testSchemaRegistry.updateRouter(address(1));
+
+    vm.expectRevert(SchemaRegistry.RouterAlreadyUpdated.selector);
+    vm.prank(address(0));
+    testSchemaRegistry.updateRouter(address(1));
+  }
+
   function test_updateSchemaIssuer() public {
     vm.prank(user);
     schemaRegistry.createSchema(expectedName, expectedDescription, expectedContext, expectedString);
@@ -88,6 +101,19 @@ contract SchemaRegistryTest is Test {
     vm.prank(address(0));
     vm.expectRevert(SchemaRegistry.IssuerInvalid.selector);
     schemaRegistry.updateSchemaIssuer(expectedId, address(0));
+  }
+
+  function test_updateSchemaIssuer_SchemaIssuerAlreadySet() public {
+    vm.prank(user);
+    schemaRegistry.createSchema(expectedName, expectedDescription, expectedContext, expectedString);
+    vm.expectEmit(true, true, true, true);
+    emit SchemaIssuerUpdated(expectedId, address(2));
+    vm.prank(address(0));
+    schemaRegistry.updateSchemaIssuer(expectedId, address(2));
+
+    vm.prank(address(0));
+    vm.expectRevert(SchemaRegistry.SchemaIssuerAlreadySet.selector);
+    schemaRegistry.updateSchemaIssuer(expectedId, address(2));
   }
 
   function test_bulkUpdateSchemasIssuers() public {
@@ -202,6 +228,19 @@ contract SchemaRegistryTest is Test {
     schemaRegistry.createSchema(expectedName, expectedDescription, expectedContext, expectedString);
     schemaRegistry.updateContext(expectedId, "");
     assertEq(schemaRegistry.getSchema(expectedId).context, "");
+    vm.stopPrank();
+  }
+
+  function test_updateContext_SchemaContextAlreadyUpdated() public {
+    vm.expectEmit();
+    emit SchemaCreated(expectedId, expectedName, expectedDescription, expectedContext, expectedString);
+    vm.startPrank(user);
+    // create a schema
+    schemaRegistry.createSchema(expectedName, expectedDescription, expectedContext, expectedString);
+
+    vm.expectRevert(SchemaRegistry.SchemaContextAlreadyUpdated.selector);
+    // update the context with the same value
+    schemaRegistry.updateContext(expectedId, expectedContext);
     vm.stopPrank();
   }
 


### PR DESCRIPTION
## What does this PR do?

Updated registries with additional check - if there is no change in the state revert the transaction.

### Related ticket

Fixes #804 

### Type of change

- [x] Chore
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update

## Check list

- [x] Unit tests for any smart contract change
- [ ] Contracts and functions are documented
