### PR TITLE
chore(contracts): Replacing an Attestation should revoke first and create the new attestation later

### DIFF
--- a/contracts/src/AttestationRegistry.sol
+++ b/contracts/src/AttestationRegistry.sol
@@ -182,8 +182,8 @@ contract AttestationRegistry is RouterManager {
    * @param attester the account address issuing the attestation
    */
   function replace(bytes32 attestationId, AttestationPayload calldata attestationPayload, address attester) public {
-    attest(attestationPayload, attester);
     revoke(attestationId);
+    attest(attestationPayload, attester);
     bytes32 replacedBy = generateAttestationId(attestationIdCounter);
     attestations[attestationId].replacedBy = replacedBy;
 


### PR DESCRIPTION
## What does this PR do?

### Related ticket

Fixes #840 

### Type of change

- [X] Chore
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update

## Check list

- [ ] Unit tests for any smart contract change
- [ ] Contracts and functions are documented
