### PR TITLE
As a user, I want to easily access Verax documentation and website

### DIFF
--- a/explorer/src/pages/Home/components/Info/data.tsx
+++ b/explorer/src/pages/Home/components/Info/data.tsx
@@ -18,7 +18,7 @@ export const infoData = [
     title: t("home.info.aboutVerax"),
     button: {
       name: t("common.actions.learnMore"),
-      url: "https://ver.ax",
+      url: "https://www.ver.ax",
     },
     additionalClass: "bg-surface-darkGrey dark:bg-surface-darkGreyDark",
   },

--- a/explorer/src/pages/Home/components/Info/data.tsx
+++ b/explorer/src/pages/Home/components/Info/data.tsx
@@ -9,7 +9,7 @@ export const infoData = [
     title: t("home.info.issueYourAttestation"),
     button: {
       name: t("common.actions.getStarted"),
-      url: "https://github.com/Consensys/linea-attestation-registry",
+      url: "https://docs.ver.ax/verax-documentation/developer-guides/for-attestation-issuers",
     },
     additionalClass: "bg-surface-secondary dark:bg-surface-secondaryDark",
   },
@@ -18,7 +18,7 @@ export const infoData = [
     title: t("home.info.aboutVerax"),
     button: {
       name: t("common.actions.learnMore"),
-      url: "https://docs.ver.ax/verax-documentation/",
+      url: "https://ver.ax",
     },
     additionalClass: "bg-surface-darkGrey dark:bg-surface-darkGreyDark",
   },


### PR DESCRIPTION
## Description
Updates the Explorer's homepage blocks to provide direct access to Verax documentation and website, improving user experience and accessibility to key resources.

## Changes
- Left block now links directly to the Developer Guide for attestation issuers
- Right block now links to the Verax main landing page

## Links
- Resolves #781

## Testing
1. Visit the Explorer's homepage
2. Verify left block's "Get Started" button links to: https://docs.ver.ax/verax-documentation/developer-guides/for-attestation-issuers
3. Verify right block's "Learn More" button links to: https://ver.ax
