### PR TITLE
fix(sdk): AttestV2 doesn't support customABI

### DIFF
--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verax-attestation-registry/verax-sdk",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Verax Attestation Registry SDK to interact with the subgraph and the contracts",
   "keywords": [
     "linea-attestation-registry",


### PR DESCRIPTION
## What does this PR do?

Adds support for passing a custom ABI to the `attestV2` function.
This lets anyone benefit from error decoding on their custom Portal.

### Related ticket

Fixes #856 

### Type of change

- [ ] Chore
- [X] Bug fix
- [ ] New feature
- [ ] Documentation update

## Check list

- [ ] Unit tests for any smart contract change
- [ ] Contracts and functions are documented
