### PR TITLE
fix(explorer): Fix attestation ID search redirection

### DIFF
--- a/explorer/src/pages/Search/index.tsx
+++ b/explorer/src/pages/Search/index.tsx
@@ -10,7 +10,7 @@ import { DEFAULT_SEARCH_ELEMENTS } from "@/constants/components";
 import { EQueryParams } from "@/enums/queryParams";
 import { Page, SearchElementProps } from "@/interfaces/components";
 import { useNetworkContext } from "@/providers/network-provider/context.ts";
-import { CHAIN_ID_ROUTE, toAttestationsBySubject } from "@/routes/constants";
+import { CHAIN_ID_ROUTE, toAttestationById, toAttestationsBySubject } from "@/routes/constants";
 import { parseSearch } from "@/utils/searchUtils";
 
 import { SearchAttestationsReceived } from "./components/SearchAttestationsReceived";
@@ -40,12 +40,24 @@ export const Search = () => {
     setCount(newCount);
     setIsLoaded(newIsLoaded);
     setNotFound(newIsLoaded && newCount === 0);
-    if (isOnlyAttestationsFound(searchElements)) {
-      navigate(toAttestationsBySubject(search ?? "").replace(CHAIN_ID_ROUTE, network), {
-        state: { from: location.pathname },
-      });
+
+    // Check if the search is an attestation ID (either full hex or raw number)
+    const isAttestationId = parsedString.attestationIds && parsedString.attestationIds.length > 0;
+
+    if (isLoaded && isOnlyAttestationsFound(searchElements)) {
+      if (isAttestationId && parsedString.attestationIds) {
+        // If it's an attestation ID, navigate to the attestation page
+        navigate(toAttestationById(parsedString.attestationIds[0]).replace(CHAIN_ID_ROUTE, network), {
+          state: { from: location.pathname },
+        });
+      } else {
+        // Otherwise, navigate to the subject page
+        navigate(toAttestationsBySubject(search ?? "").replace(CHAIN_ID_ROUTE, network), {
+          state: { from: location.pathname },
+        });
+      }
     }
-  }, [searchElements, navigate, network, search]);
+  }, [searchElements, navigate, network, search, parsedString]);
 
   const updateSearchElement = (page: Page, count: number, loaded: boolean) => {
     setSearchElements((prev) => ({ ...prev, [page]: { loaded, count } }));

--- a/explorer/src/pages/Search/index.tsx
+++ b/explorer/src/pages/Search/index.tsx
@@ -57,7 +57,7 @@ export const Search = () => {
         });
       }
     }
-  }, [searchElements, navigate, network, search, parsedString]);
+  }, [searchElements, navigate, network, search, parsedString, isLoaded]);
 
   const updateSearchElement = (page: Page, count: number, loaded: boolean) => {
     setSearchElements((prev) => ({ ...prev, [page]: { loaded, count } }));

--- a/snap/packages/site/package.json
+++ b/snap/packages/site/package.json
@@ -10,7 +10,7 @@
     "lint": "pnpm run lint:eslint && pnpm run lint:misc --check",
     "lint:eslint": "eslint . --cache --ext js,ts",
     "lint:fix": "pnpm run lint:eslint --fix && pnpm run lint:misc --write",
-    "lint:misc": "prettier '**/*.json' '**/*.md' '!CHANGELOG.md' --ignore-path .gitignore",
+    "lint:misc": "prettier \"**/*.json\" \"**/*.md\" \"!CHANGELOG.md\" --ignore-path .gitignore",
     "start": "GATSBY_TELEMETRY_DISABLED=1 gatsby develop"
   },
   "browserslist": {

--- a/snap/packages/snap/package.json
+++ b/snap/packages/snap/package.json
@@ -20,7 +20,7 @@
     "lint": "pnpm run lint:eslint && pnpm run lint:misc --check",
     "lint:eslint": "eslint . --cache --ext js,ts",
     "lint:fix": "pnpm run lint:eslint --fix && pnpm run lint:misc --write",
-    "lint:misc": "prettier '**/*.json' '**/*.md' '!CHANGELOG.md' --ignore-path .gitignore",
+    "lint:misc": "prettier \"**/*.json\" \"**/*.md\" \"!CHANGELOG.md\" --ignore-path .gitignore",
     "prepublishOnly": "mm-snap manifest",
     "serve": "mm-snap serve",
     "start": "mm-snap watch",


### PR DESCRIPTION
## What does this PR do?

This PR implements automatic navigation from the search page when attestation-specific results are found. When the search results only contain attestations (no modules, portals, or schemas), the user is automatically redirected to:

- The attestation details page if the search term matches an attestation ID
- The subject's attestations page if the search term matches other attestation criteria

### Related ticket

Fixes #872

### Type of change

- [ ] Chore
- [X] Bug fix
- [ ] New feature
- [ ] Documentation update

## Previews
![Screenshot (62)](https://github.com/user-attachments/assets/866d04fa-9241-4468-9a83-1d703a48425d)
![Screenshot (63)](https://github.com/user-attachments/assets/0b00d5e5-f3b6-4665-a404-90a5940e11f4)
