### PR TITLE
fix(explorer): Fix Attestation ID search redirects

### DIFF
--- a/explorer/src/pages/Search/index.tsx
+++ b/explorer/src/pages/Search/index.tsx
@@ -10,7 +10,7 @@ import { DEFAULT_SEARCH_ELEMENTS } from "@/constants/components";
 import { EQueryParams } from "@/enums/queryParams";
 import { Page, SearchElementProps } from "@/interfaces/components";
 import { useNetworkContext } from "@/providers/network-provider/context.ts";
-import { CHAIN_ID_ROUTE, toAttestationsBySubject } from "@/routes/constants";
+import { CHAIN_ID_ROUTE, toAttestationById } from "@/routes/constants";
 import { parseSearch } from "@/utils/searchUtils";
 
 import { SearchAttestationsReceived } from "./components/SearchAttestationsReceived";
@@ -41,7 +41,7 @@ export const Search = () => {
     setIsLoaded(newIsLoaded);
     setNotFound(newIsLoaded && newCount === 0);
     if (isOnlyAttestationsFound(searchElements)) {
-      navigate(toAttestationsBySubject(search ?? "").replace(CHAIN_ID_ROUTE, network), {
+      navigate(toAttestationById(search ?? "").replace(CHAIN_ID_ROUTE, network), {
         state: { from: location.pathname },
       });
     }


### PR DESCRIPTION
## What does this PR do?

Resolves the issue where searching for an Attestation ID in the explorer search bar redirects users to an empty subject page instead of the correct individual attestation page.


https://github.com/user-attachments/assets/644d4514-8eb2-4ac0-aa69-acaf8f857ed4



### Related ticket

Fixes #872 

### Type of change

- [ ] Chore
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update

## Check list

- [ ] Unit tests for any smart contract change
- [ ] Contracts and functions are documented
