### PR TITLE
chore(contracts): Remove `updateChainPrefix` Function to Prevent Risks

### DIFF
--- a/contracts/script/deploy/deployEverything.ts
+++ b/contracts/script/deploy/deployEverything.ts
@@ -36,7 +36,7 @@ async function main() {
 
   console.log("Deploying AttestationRegistry...");
   const AttestationRegistry = await ethers.getContractFactory("AttestationRegistry");
-  const attestationRegistry = await upgrades.deployProxy(AttestationRegistry);
+  const attestationRegistry = await upgrades.deployProxy(AttestationRegistry, [networkConfig.chainPrefix]);
   await attestationRegistry.waitForDeployment();
   const attestationRegistryProxyAddress = await attestationRegistry.getAddress();
   const attestationRegistryImplementationAddress = await upgrades.erc1967.getImplementationAddress(
@@ -131,10 +131,6 @@ async function main() {
 
   console.log("Updating AttestationRegistry with the Router address...");
   await attestationRegistry.updateRouter(routerProxyAddress);
-  console.log("AttestationRegistry updated!");
-
-  console.log("Updating AttestationRegistry with the chain prefix...");
-  await attestationRegistry.updateChainPrefix(networkConfig.chainPrefix);
   console.log("AttestationRegistry updated!");
 
   console.log("Updating ModuleRegistry with the Router address...");

--- a/contracts/src/AttestationRegistry.sol
+++ b/contracts/src/AttestationRegistry.sol
@@ -90,17 +90,6 @@ contract AttestationRegistry is RouterManager {
   }
 
   /**
-   * @notice Changes the chain prefix for the attestation IDs
-   * @dev Only the registry owner can call this method
-   */
-  function updateChainPrefix(uint256 _chainPrefix) public onlyOwner {
-    if (_chainPrefix == chainPrefix) revert ChainPrefixAlreadyUpdated();
-
-    chainPrefix = _chainPrefix;
-    emit ChainPrefixUpdated(_chainPrefix);
-  }
-
-  /**
    * @notice Registers an attestation in the AttestationRegistry.
    * @param attestationPayload The payload used to create and register the attestation.
    * @param attester The address of the account issuing the attestation.

--- a/contracts/test/AttestationRegistry.t.sol
+++ b/contracts/test/AttestationRegistry.t.sol
@@ -9,18 +9,21 @@ import { PortalRegistry } from "../src/PortalRegistry.sol";
 import { SchemaRegistryMock } from "./mocks/SchemaRegistryMock.sol";
 import { Attestation, AttestationPayload } from "../src/types/Structs.sol";
 import { Router } from "../src/Router.sol";
-import { AttestationRegistryHarness } from "./harness/AttestationRegistryHarness.sol";
+import { TransparentUpgradeableProxy } from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 
 contract AttestationRegistryTest is Test {
   address public portal = makeAddr("portal");
   address public user = makeAddr("user");
   address public attester = makeAddr("attester");
+  address public proxyAdmin = makeAddr("proxyAdmin");
   Router public router;
   AttestationRegistry public attestationRegistry;
-  AttestationRegistryHarness public attestationRegistryHarness;
   address public portalRegistryAddress;
   address public schemaRegistryAddress;
-  uint256 public initialChainPrefix = 0x0000000000000000000000000000000000000000000000000000000000000000;
+  uint256 public initialChainPrefix = 0x0003000000000000000000000000000000000000000000000000000000000000;
+  bytes32 public attestationId1 = bytes32(abi.encode(initialChainPrefix + 1));
+  bytes32 public attestationId2 = bytes32(abi.encode(initialChainPrefix + 2));
+  bytes32 public attestationId3 = bytes32(abi.encode(initialChainPrefix + 3));
 
   event Initialized(uint8 version);
   event AttestationRegistered(bytes32 indexed attestationId);
@@ -36,13 +39,17 @@ contract AttestationRegistryTest is Test {
     router = new Router();
     router.initialize();
 
-    attestationRegistryHarness = new AttestationRegistryHarness();
-    attestationRegistry = new AttestationRegistry();
+    TransparentUpgradeableProxy proxy = new TransparentUpgradeableProxy(
+      address(new AttestationRegistry()),
+      address(proxyAdmin),
+      abi.encodeWithSelector(AttestationRegistry.initialize.selector, initialChainPrefix)
+    );
+
+    attestationRegistry = AttestationRegistry(payable(address(proxy)));
     router.updateAttestationRegistry(address(attestationRegistry));
 
     portalRegistryAddress = address(new PortalRegistryMock());
     schemaRegistryAddress = address(new SchemaRegistryMock());
-    vm.prank(address(0));
     attestationRegistry.updateRouter(address(router));
 
     router.updatePortalRegistry(portalRegistryAddress);
@@ -60,10 +67,6 @@ contract AttestationRegistryTest is Test {
     uint256 chainPrefix = attestationRegistry.getChainPrefix();
     assertEq(chainPrefix, initialChainPrefix);
 
-    // Check Chain Prefix value in the harness contract
-    uint256 chainPrefixHarness = attestationRegistryHarness.getChainPrefix();
-    assertEq(chainPrefixHarness, initialChainPrefix);
-
     // Check AttestationRegistry address
     address testAttestationRegistry = address(router.getAttestationRegistry());
     assertEq(testAttestationRegistry, address(attestationRegistry));
@@ -79,7 +82,18 @@ contract AttestationRegistryTest is Test {
 
   function test_initialize_ContractAlreadyInitialized() public {
     vm.expectRevert("Initializable: contract is already initialized");
-    attestationRegistry.initialize();
+    attestationRegistry.initialize(initialChainPrefix);
+  }
+
+  function test_initialize_chainPrefixCorrect() public {
+    vm.expectEmit(true, true, true, true);
+    emit ChainPrefixUpdated(initialChainPrefix);
+
+    new TransparentUpgradeableProxy(
+      address(new AttestationRegistry()),
+      proxyAdmin,
+      abi.encodeWithSelector(AttestationRegistry.initialize.selector, initialChainPrefix)
+    );
   }
 
   function test_updateRouter() public {
@@ -212,10 +226,9 @@ contract AttestationRegistryTest is Test {
     payloadsToAttest[1] = attestationsPayloads[1];
 
     vm.expectEmit(true, true, true, true);
-    emit AttestationRegistered(attestationRegistryHarness.exposed_generateAttestationId(1));
+    emit AttestationRegistered(attestationId1);
     vm.expectEmit(true, true, true, true);
-    emit AttestationRegistered(attestationRegistryHarness.exposed_generateAttestationId(2));
-    vm.prank(address(0));
+    emit AttestationRegistered(attestationId2);
     attestationRegistry.massImport(payloadsToAttest, portal);
   }
 
@@ -230,7 +243,7 @@ contract AttestationRegistryTest is Test {
     vm.prank(portal);
     attestationRegistry.attest(attestationPayload, attester);
 
-    bytes32 attestationIdReplacing = attestationRegistryHarness.exposed_generateAttestationId(2);
+    bytes32 attestationIdReplacing = attestationId2;
 
     vm.prank(portal);
     vm.expectEmit(true, true, true, true);
@@ -293,7 +306,7 @@ contract AttestationRegistryTest is Test {
     bytes32[] memory attestationIds = new bytes32[](3);
     attestationIds[0] = attestation1.attestationId;
     attestationIds[1] = attestation2.attestationId;
-    attestationIds[2] = attestationRegistryHarness.exposed_generateAttestationId((3));
+    attestationIds[2] = attestationId3;
 
     vm.startPrank(portal);
     attestationRegistry.bulkAttest(payloadsToAttest, attester);
@@ -311,10 +324,10 @@ contract AttestationRegistryTest is Test {
     vm.startPrank(portal, attester);
     attestationRegistry.attest(attestationPayload, attester);
     // Assert initial state is a valid attestation
-    bytes32 attestationId = attestationRegistryHarness.exposed_generateAttestationId((1));
+    bytes32 attestationId = attestationId1;
     Attestation memory registeredAttestation = attestationRegistry.getAttestation(attestationId);
 
-    assertEq(registeredAttestation.attestationId, attestationRegistryHarness.exposed_generateAttestationId(1));
+    assertEq(registeredAttestation.attestationId, attestationId1);
     assertFalse(registeredAttestation.revoked);
     assertEq(registeredAttestation.revocationDate, 0);
     assertEq(registeredAttestation.portal, portal);
@@ -326,9 +339,7 @@ contract AttestationRegistryTest is Test {
     vm.stopPrank();
 
     // Assert final state is a revoked attestation
-    Attestation memory revokedAttestation = attestationRegistry.getAttestation(
-      attestationRegistryHarness.exposed_generateAttestationId(1)
-    );
+    Attestation memory revokedAttestation = attestationRegistry.getAttestation(attestationId1);
     assertTrue(revokedAttestation.revoked);
     assertEq(revokedAttestation.revocationDate, block.timestamp);
   }
@@ -342,7 +353,7 @@ contract AttestationRegistryTest is Test {
     vm.startPrank(portal, attester);
     attestationRegistry.attest(attestationPayload, attester);
 
-    bytes32 attestationIdToRevoke = attestationRegistryHarness.exposed_generateAttestationId(1);
+    bytes32 attestationIdToRevoke = attestationId1;
 
     vm.expectEmit();
     emit AttestationRevoked(attestationIdToRevoke);
@@ -355,7 +366,7 @@ contract AttestationRegistryTest is Test {
   }
 
   function test_revoke_AttestationNotAttested() public {
-    bytes32 attestationIdToRevoke = attestationRegistryHarness.exposed_generateAttestationId(1);
+    bytes32 attestationIdToRevoke = attestationId1;
     vm.expectRevert(AttestationRegistry.AttestationNotAttested.selector);
     attestationRegistry.revoke(attestationIdToRevoke);
   }
@@ -370,7 +381,7 @@ contract AttestationRegistryTest is Test {
     vm.prank(portal);
     attestationRegistry.attest(attestationPayload, attester);
 
-    bytes32 attestationIdToRevoke = attestationRegistryHarness.exposed_generateAttestationId(1);
+    bytes32 attestationIdToRevoke = bytes32(abi.encode(initialChainPrefix + 1));
     vm.expectRevert(AttestationRegistry.OnlyAttestingPortal.selector);
     vm.prank(user);
     attestationRegistry.revoke(attestationIdToRevoke);
@@ -396,7 +407,7 @@ contract AttestationRegistryTest is Test {
 
     attestationRegistry.attest(attestationPayload, attester);
 
-    bytes32 attestationIdToRevoke = attestationRegistryHarness.exposed_generateAttestationId(1);
+    bytes32 attestationIdToRevoke = attestationId1;
 
     vm.expectRevert(AttestationRegistry.AttestationNotRevocable.selector);
     attestationRegistry.revoke(attestationIdToRevoke);
@@ -424,10 +435,6 @@ contract AttestationRegistryTest is Test {
     attestationRegistry.attest(attestationPayloads[0], attester);
     attestationRegistry.attest(attestationPayloads[1], attester);
     attestationRegistry.attest(attestationPayloads[2], attester);
-
-    bytes32 attestationId1 = attestationRegistryHarness.exposed_generateAttestationId((1));
-    bytes32 attestationId2 = attestationRegistryHarness.exposed_generateAttestationId((2));
-    bytes32 attestationId3 = attestationRegistryHarness.exposed_generateAttestationId((3));
 
     // Assert initial state is a valid attestation
     Attestation memory registeredAttestation1 = attestationRegistry.getAttestation(attestationId1);
@@ -487,7 +494,7 @@ contract AttestationRegistryTest is Test {
   function test_isRegistered(AttestationPayload memory attestationPayload) public {
     vm.assume(attestationPayload.subject.length != 0);
     vm.assume(attestationPayload.attestationData.length != 0);
-    bool isRegistered = attestationRegistry.isRegistered(attestationRegistryHarness.exposed_generateAttestationId(1));
+    bool isRegistered = attestationRegistry.isRegistered(attestationId1);
     assertFalse(isRegistered);
     SchemaRegistryMock schemaRegistryMock = SchemaRegistryMock(router.getSchemaRegistry());
     attestationPayload.schemaId = schemaRegistryMock.getIdFromSchemaString("schemaString");
@@ -518,7 +525,7 @@ contract AttestationRegistryTest is Test {
   }
 
   function test_getAttestation_AttestationNotAttested() public {
-    bytes32 attestationIdNotAttested = attestationRegistryHarness.exposed_generateAttestationId((1));
+    bytes32 attestationIdNotAttested = attestationId1;
     vm.expectRevert(AttestationRegistry.AttestationNotAttested.selector);
     attestationRegistry.getAttestation(attestationIdNotAttested);
   }
@@ -528,7 +535,6 @@ contract AttestationRegistryTest is Test {
     for (uint16 i = 1; i <= 5; i++) {
       vm.expectEmit(true, true, true, true);
       emit VersionUpdated(i);
-      vm.prank(address(0));
       uint256 version = attestationRegistry.incrementVersionNumber();
       assertEq(version, i);
       uint16 newVersion = attestationRegistry.getVersionNumber();
@@ -589,7 +595,7 @@ contract AttestationRegistryTest is Test {
     vm.startPrank(portal);
     attestationRegistry.attest(attestationPayload, attester);
     vm.startPrank(portal);
-    attestationRegistry.revoke(0x0000000000000000000000000000000000000000000000000000000000000001);
+    attestationRegistry.revoke(0x0003000000000000000000000000000000000000000000000000000000000001);
 
     uint256 balance = attestationRegistry.balanceOf(address(1), 1);
     assertEq(balance, 0);
@@ -702,14 +708,6 @@ contract AttestationRegistryTest is Test {
     attestationRegistry.balanceOfBatch(owners, ids);
   }
 
-  function test_attestationRegistry() public view {
-    bytes32 attestationId = attestationRegistryHarness.exposed_generateAttestationId(0);
-    assertEq(attestationId, 0x0000000000000000000000000000000000000000000000000000000000000000);
-
-    attestationId = attestationRegistryHarness.exposed_generateAttestationId(10);
-    assertEq(attestationId, 0x000000000000000000000000000000000000000000000000000000000000000a);
-  }
-
   function test_getNextAttestationId(AttestationPayload memory attestationPayload) public {
     vm.assume(attestationPayload.subject.length != 0);
     vm.assume(attestationPayload.attestationData.length != 0);
@@ -742,7 +740,7 @@ contract AttestationRegistryTest is Test {
     schemaRegistryMock.createSchema("name", "description", "context", "schemaString");
 
     Attestation memory attestation = Attestation(
-      attestationRegistryHarness.exposed_generateAttestationId(id),
+      bytes32(abi.encode(initialChainPrefix + id)),
       attestationPayload.schemaId,
       bytes32(0),
       attester,

--- a/contracts/test/AttestationRegistry.t.sol
+++ b/contracts/test/AttestationRegistry.t.sol
@@ -20,7 +20,7 @@ contract AttestationRegistryTest is Test {
   AttestationRegistryHarness public attestationRegistryHarness;
   address public portalRegistryAddress;
   address public schemaRegistryAddress;
-  uint256 public initialChainPrefix = 0x0003000000000000000000000000000000000000000000000000000000000000;
+  uint256 public initialChainPrefix = 0x0000000000000000000000000000000000000000000000000000000000000000;
 
   event Initialized(uint8 version);
   event AttestationRegistered(bytes32 indexed attestationId);
@@ -44,10 +44,6 @@ contract AttestationRegistryTest is Test {
     schemaRegistryAddress = address(new SchemaRegistryMock());
     vm.prank(address(0));
     attestationRegistry.updateRouter(address(router));
-    vm.prank(address(0));
-    attestationRegistry.updateChainPrefix(initialChainPrefix);
-    vm.prank(address(0));
-    attestationRegistryHarness.updateChainPrefix(initialChainPrefix);
 
     router.updatePortalRegistry(portalRegistryAddress);
     router.updateSchemaRegistry(schemaRegistryAddress);
@@ -115,39 +111,6 @@ contract AttestationRegistryTest is Test {
     vm.expectRevert(AttestationRegistry.RouterAlreadyUpdated.selector);
     vm.prank(address(0));
     testAttestationRegistry.updateRouter(address(1));
-  }
-
-  function test_updateChainPrefix() public {
-    AttestationRegistry testAttestationRegistry = new AttestationRegistry();
-
-    vm.expectEmit(true, true, true, true);
-    emit ChainPrefixUpdated(initialChainPrefix);
-    vm.prank(address(0));
-    testAttestationRegistry.updateChainPrefix(initialChainPrefix);
-
-    uint256 chainPrefix = testAttestationRegistry.getChainPrefix();
-    assertEq(chainPrefix, initialChainPrefix);
-
-    vm.expectEmit(true, true, true, true);
-    emit ChainPrefixUpdated(0x0001000000000000000000000000000000000000000000000000000000000000);
-    vm.prank(address(0));
-    testAttestationRegistry.updateChainPrefix(0x0001000000000000000000000000000000000000000000000000000000000000);
-
-    chainPrefix = testAttestationRegistry.getChainPrefix();
-    assertEq(chainPrefix, 0x0001000000000000000000000000000000000000000000000000000000000000);
-  }
-
-  function test_updateChainPrefix_ChainPrefixAlreadyUpdated() public {
-    AttestationRegistry testAttestationRegistry = new AttestationRegistry();
-
-    vm.expectEmit(true, true, true, true);
-    emit ChainPrefixUpdated(initialChainPrefix);
-    vm.prank(address(0));
-    testAttestationRegistry.updateChainPrefix(initialChainPrefix);
-
-    vm.expectRevert(AttestationRegistry.ChainPrefixAlreadyUpdated.selector);
-    vm.prank(address(0));
-    testAttestationRegistry.updateChainPrefix(initialChainPrefix);
   }
 
   function test_attest(AttestationPayload memory attestationPayload) public {
@@ -626,7 +589,7 @@ contract AttestationRegistryTest is Test {
     vm.startPrank(portal);
     attestationRegistry.attest(attestationPayload, attester);
     vm.startPrank(portal);
-    attestationRegistry.revoke(0x0003000000000000000000000000000000000000000000000000000000000001);
+    attestationRegistry.revoke(0x0000000000000000000000000000000000000000000000000000000000000001);
 
     uint256 balance = attestationRegistry.balanceOf(address(1), 1);
     assertEq(balance, 0);
@@ -741,10 +704,10 @@ contract AttestationRegistryTest is Test {
 
   function test_attestationRegistry() public view {
     bytes32 attestationId = attestationRegistryHarness.exposed_generateAttestationId(0);
-    assertEq(attestationId, 0x0003000000000000000000000000000000000000000000000000000000000000);
+    assertEq(attestationId, 0x0000000000000000000000000000000000000000000000000000000000000000);
 
     attestationId = attestationRegistryHarness.exposed_generateAttestationId(10);
-    assertEq(attestationId, 0x000300000000000000000000000000000000000000000000000000000000000a);
+    assertEq(attestationId, 0x000000000000000000000000000000000000000000000000000000000000000a);
   }
 
   function test_getNextAttestationId(AttestationPayload memory attestationPayload) public {


### PR DESCRIPTION
## What does this PR do?

### Related ticket

Fixes #878 

### Type of change

- [X] Chore
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update

## Check list

- [ ] Unit tests for any smart contract change
- [ ] Contracts and functions are documented
