### PR TITLE
chore(contracts): Frequent Use of `memory` Parameters Where `calldata` Would Be Possible

### DIFF
--- a/contracts/src/AttestationRegistry.sol
+++ b/contracts/src/AttestationRegistry.sol
@@ -324,7 +324,7 @@ contract AttestationRegistry is OwnableUpgradeable {
    * @param ids ID of the attestations
    * @return The _owner's balance of the attestation for a given address (i.e. balance for each (owner, id) pair)
    */
-  function balanceOfBatch(address[] memory accounts, uint256[] memory ids) public view returns (uint256[] memory) {
+  function balanceOfBatch(address[] calldata accounts, uint256[] calldata ids) public view returns (uint256[] memory) {
     if (accounts.length != ids.length) revert ArrayLengthMismatch();
     uint256[] memory result = new uint256[](accounts.length);
     for (uint256 i = 0; i < accounts.length; i = uncheckedInc256(i)) {
@@ -348,8 +348,8 @@ contract AttestationRegistry is OwnableUpgradeable {
    * @return The next attestation ID
    */
   function getNextAttestationId() public view returns (bytes32) {
-    uint256 nextattestationId = attestationIdCounter + 1;
-    bytes32 id = generateAttestationId(nextattestationId);
+    uint256 nextAttestationId = attestationIdCounter + 1;
+    bytes32 id = generateAttestationId(nextAttestationId);
     assert(id != 0x0 && !isRegistered(id));
     return id;
   }

--- a/contracts/src/ModuleRegistry.sol
+++ b/contracts/src/ModuleRegistry.sol
@@ -98,8 +98,8 @@ contract ModuleRegistry is OwnableUpgradeable {
    * @dev the module is stored in a mapping, the number of modules is incremented and an event is emitted
    */
   function register(
-    string memory name,
-    string memory description,
+    string calldata name,
+    string calldata description,
     address moduleAddress
   ) public onlyAllowlisted(msg.sender) {
     if (bytes(name).length == 0) revert ModuleNameMissing();
@@ -124,9 +124,9 @@ contract ModuleRegistry is OwnableUpgradeable {
    * @dev check if modules are registered and execute run method for each module
    */
   function runModules(
-    address[] memory modulesAddresses,
-    AttestationPayload memory attestationPayload,
-    bytes[] memory validationPayloads,
+    address[] calldata modulesAddresses,
+    AttestationPayload calldata attestationPayload,
+    bytes[] calldata validationPayloads,
     uint256 value
   ) public {
     // If no module provided, bypass module validation
@@ -153,9 +153,9 @@ contract ModuleRegistry is OwnableUpgradeable {
    * @dev check if modules are registered and execute the V2 run method for each module
    */
   function runModulesV2(
-    address[] memory modulesAddresses,
-    AttestationPayload memory attestationPayload,
-    bytes[] memory validationPayloads,
+    address[] calldata modulesAddresses,
+    AttestationPayload calldata attestationPayload,
+    bytes[] calldata validationPayloads,
     uint256 value,
     address initialCaller,
     address attester,
@@ -193,9 +193,9 @@ contract ModuleRegistry is OwnableUpgradeable {
    *                  If you need to check the attestation ID, please use the `attest` method.
    */
   function bulkRunModules(
-    address[] memory modulesAddresses,
-    AttestationPayload[] memory attestationsPayloads,
-    bytes[][] memory validationPayloads
+    address[] calldata modulesAddresses,
+    AttestationPayload[] calldata attestationsPayloads,
+    bytes[][] calldata validationPayloads
   ) public {
     for (uint32 i = 0; i < attestationsPayloads.length; i = uncheckedInc32(i)) {
       runModules(modulesAddresses, attestationsPayloads[i], validationPayloads[i], 0);
@@ -214,9 +214,9 @@ contract ModuleRegistry is OwnableUpgradeable {
    *                  If you need to check the attestation ID, please use the `attestV2` method.
    */
   function bulkRunModulesV2(
-    address[] memory modulesAddresses,
-    AttestationPayload[] memory attestationPayloads,
-    bytes[][] memory validationPayloads,
+    address[] calldata modulesAddresses,
+    AttestationPayload[] calldata attestationPayloads,
+    bytes[][] calldata validationPayloads,
     address initialCaller,
     address attester,
     OperationType operationType

--- a/contracts/src/PortalRegistry.sol
+++ b/contracts/src/PortalRegistry.sol
@@ -156,10 +156,10 @@ contract PortalRegistry is OwnableUpgradeable {
    */
   function register(
     address id,
-    string memory name,
-    string memory description,
+    string calldata name,
+    string calldata description,
     bool isRevocable,
-    string memory ownerName
+    string calldata ownerName
   ) public onlyAllowlisted(msg.sender) {
     // Check if portal already exists
     if (portals[id].id != address(0)) revert PortalAlreadyExists();

--- a/contracts/src/SchemaRegistry.sol
+++ b/contracts/src/SchemaRegistry.sol
@@ -116,7 +116,7 @@ contract SchemaRegistry is OwnableUpgradeable {
    * @return the schema ID
    * @dev encodes a schema string to unique bytes
    */
-  function getIdFromSchemaString(string memory schema) public pure returns (bytes32) {
+  function getIdFromSchemaString(string calldata schema) public pure returns (bytes32) {
     return keccak256(abi.encodePacked(schema));
   }
 
@@ -133,10 +133,10 @@ contract SchemaRegistry is OwnableUpgradeable {
    *      The caller is assigned as the creator of the Schema, via the `schemasIssuers` mapping
    */
   function createSchema(
-    string memory name,
-    string memory description,
-    string memory context,
-    string memory schemaString
+    string calldata name,
+    string calldata description,
+    string calldata context,
+    string calldata schemaString
   ) public onlyAllowlisted(msg.sender) {
     if (bytes(name).length == 0) revert SchemaNameMissing();
     if (bytes(schemaString).length == 0) revert SchemaStringMissing();
@@ -159,7 +159,7 @@ contract SchemaRegistry is OwnableUpgradeable {
    * @dev Retrieve the Schema with given ID and update its context with new value and an event is emitted
    *      The caller must be the creator of the given Schema (through the `schemaIssuers` mapping)
    */
-  function updateContext(bytes32 schemaId, string memory context) public {
+  function updateContext(bytes32 schemaId, string calldata context) public {
     if (!isRegistered(schemaId)) revert SchemaNotRegistered();
     if (schemasIssuers[schemaId] != msg.sender) revert OnlyAssignedIssuer();
     if (keccak256(abi.encodePacked(schemas[schemaId].context)) == keccak256(abi.encodePacked(context))) {

--- a/contracts/src/abstracts/AbstractModuleV2.sol
+++ b/contracts/src/abstracts/AbstractModuleV2.sol
@@ -24,8 +24,8 @@ abstract contract AbstractModuleV2 is ERC165 {
    * @param portal The issuing Portal's address
    */
   function run(
-    AttestationPayload memory attestationPayload,
-    bytes memory validationPayload,
+    AttestationPayload calldata attestationPayload,
+    bytes calldata validationPayload,
     address initialCaller,
     uint256 value,
     address attester,

--- a/contracts/src/examples/modules/ERC712ModuleV2.sol
+++ b/contracts/src/examples/modules/ERC712ModuleV2.sol
@@ -35,8 +35,8 @@ contract ERC712ModuleV2 is AbstractModuleV2 {
    * @param initialCaller - The initial transaction sender
    */
   function run(
-    AttestationPayload memory /*attestationPayload*/,
-    bytes memory validationPayload,
+    AttestationPayload calldata /*attestationPayload*/,
+    bytes calldata validationPayload,
     address initialCaller,
     uint256 /*value*/,
     address /*attester*/,

--- a/contracts/src/examples/modules/MerkleProofModuleV2.sol
+++ b/contracts/src/examples/modules/MerkleProofModuleV2.sol
@@ -17,8 +17,8 @@ contract MerkleProofModuleV2 is AbstractModuleV2 {
    * @param validationPayload - validationPayload containing the serialized hash.The last one is the 'Root'.
    */
   function run(
-    AttestationPayload memory attestationPayload,
-    bytes memory validationPayload,
+    AttestationPayload calldata attestationPayload,
+    bytes calldata validationPayload,
     address /*initialCaller*/,
     uint256 /*value*/,
     address /*attester*/,

--- a/contracts/src/examples/portals/EASPortal.sol
+++ b/contracts/src/examples/portals/EASPortal.sol
@@ -53,7 +53,7 @@ contract EASPortal is AbstractPortalV2 {
    * @param attestationRequest the EAS payload to attest
    * @dev If a related EAS attestation exists, it will also be attested on Verax and linked via the dedicated Schema
    */
-  function attest(AttestationRequest memory attestationRequest) public payable {
+  function attest(AttestationRequest calldata attestationRequest) public payable {
     bytes[] memory validationPayload = new bytes[](0);
 
     AttestationPayload memory attestationPayload = AttestationPayload(

--- a/contracts/src/examples/portals/NFTPortal.sol
+++ b/contracts/src/examples/portals/NFTPortal.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.21;
 import { ERC721 } from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 import { IERC721, ERC721 } from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 import { AbstractPortalV2 } from "../../abstracts/AbstractPortalV2.sol";
-import { AttestationPayload } from "../../types/Structs.sol";
+import { Attestation, AttestationPayload } from "../../types/Structs.sol";
 
 /**
  * @title NFT Portal

--- a/contracts/src/examples/portals/NFTPortal.sol
+++ b/contracts/src/examples/portals/NFTPortal.sol
@@ -4,8 +4,7 @@ pragma solidity 0.8.21;
 import { ERC721 } from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 import { IERC721, ERC721 } from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 import { AbstractPortalV2 } from "../../abstracts/AbstractPortalV2.sol";
-import { Attestation, AttestationPayload } from "../../types/Structs.sol";
-import { IPortal } from "../../interfaces/IPortal.sol";
+import { AttestationPayload } from "../../types/Structs.sol";
 
 /**
  * @title NFT Portal

--- a/contracts/src/stdlib/ECDSAModuleV2.sol
+++ b/contracts/src/stdlib/ECDSAModuleV2.sol
@@ -50,8 +50,8 @@ contract ECDSAModuleV2 is AbstractModuleV2 {
    */
   function setAuthorizedSigners(
     address portal,
-    address[] memory signers,
-    bool[] memory authorizationStatus
+    address[] calldata signers,
+    bool[] calldata authorizationStatus
   ) public onlyPortalOwner(portal) {
     if (signers.length != authorizationStatus.length) revert ArrayLengthMismatch();
 
@@ -70,8 +70,8 @@ contract ECDSAModuleV2 is AbstractModuleV2 {
    * @notice If the signer of the transaction payload is not an expected address, an error is thrown
    */
   function run(
-    AttestationPayload memory attestationPayload,
-    bytes memory validationPayload,
+    AttestationPayload calldata attestationPayload,
+    bytes calldata validationPayload,
     address /*initialCaller*/,
     uint256 /*value*/,
     address /*attester*/,

--- a/contracts/src/stdlib/ERC1271ModuleV2.sol
+++ b/contracts/src/stdlib/ERC1271ModuleV2.sol
@@ -57,8 +57,8 @@ contract ERC1271ModuleV2 is AbstractModuleV2 {
    */
   function setAuthorizedSigners(
     address portal,
-    address[] memory signers,
-    bool[] memory authorizationStatus
+    address[] calldata signers,
+    bool[] calldata authorizationStatus
   ) public onlyPortalOwner(portal) {
     if (signers.length != authorizationStatus.length) revert ArrayLengthMismatch();
 
@@ -77,8 +77,8 @@ contract ERC1271ModuleV2 is AbstractModuleV2 {
    * @notice If the signer of the transaction payload is not an expected address, an error is thrown
    */
   function run(
-    AttestationPayload memory attestationPayload,
-    bytes memory validationPayload,
+    AttestationPayload calldata attestationPayload,
+    bytes calldata validationPayload,
     address /*initialCaller*/,
     uint256 /*value*/,
     address /*attester*/,

--- a/contracts/src/stdlib/FeeModuleV2.sol
+++ b/contracts/src/stdlib/FeeModuleV2.sol
@@ -44,7 +44,11 @@ contract FeeModuleV2 is AbstractModuleV2 {
    * @dev The length of `schemaIds` and `attestationFees` must be the same
    *      Only the Portal owner can call this function to set the fees on his Portal
    */
-  function setFees(address portal, bytes32[] memory schemaIds, uint256[] memory fees) public onlyPortalOwner(portal) {
+  function setFees(
+    address portal,
+    bytes32[] calldata schemaIds,
+    uint256[] calldata fees
+  ) public onlyPortalOwner(portal) {
     if (schemaIds.length != fees.length) revert ArrayLengthMismatch();
 
     for (uint256 i = 0; i < schemaIds.length; i++) {
@@ -61,8 +65,8 @@ contract FeeModuleV2 is AbstractModuleV2 {
    * @notice If the provided fee is not enough, an error is thrown
    */
   function run(
-    AttestationPayload memory attestationPayload,
-    bytes memory /*validationPayload*/,
+    AttestationPayload calldata attestationPayload,
+    bytes calldata /*validationPayload*/,
     address /*initialCaller*/,
     uint256 value,
     address /*attester*/,

--- a/contracts/src/stdlib/IndexerModuleV2.sol
+++ b/contracts/src/stdlib/IndexerModuleV2.sol
@@ -57,8 +57,8 @@ contract IndexerModuleV2 is AbstractModuleV2 {
    * @notice If the signer of the transaction payload is not an expected address, an error is thrown
    */
   function run(
-    AttestationPayload memory attestationPayload,
-    bytes memory /*validationPayload*/,
+    AttestationPayload calldata attestationPayload,
+    bytes calldata /*validationPayload*/,
     address /*initialCaller*/,
     uint256 /*value*/,
     address attester,
@@ -185,7 +185,7 @@ contract IndexerModuleV2 is AbstractModuleV2 {
    * @return The built attestation.
    */
   function _buildAttestation(
-    AttestationPayload memory attestationPayload,
+    AttestationPayload calldata attestationPayload,
     address attester,
     address portal
   ) internal view returns (Attestation memory) {

--- a/contracts/src/stdlib/IssuersModuleV2.sol
+++ b/contracts/src/stdlib/IssuersModuleV2.sol
@@ -28,8 +28,8 @@ contract IssuersModuleV2 is AbstractModuleV2 {
    * @notice If the Attestation subject is not an Issuer, an error is thrown
    */
   function run(
-    AttestationPayload memory attestationPayload,
-    bytes memory /*validationPayload*/,
+    AttestationPayload calldata attestationPayload,
+    bytes calldata /*validationPayload*/,
     address /*initialCaller*/,
     uint256 /*value*/,
     address /*attester*/,

--- a/contracts/src/stdlib/SchemaModuleV2.sol
+++ b/contracts/src/stdlib/SchemaModuleV2.sol
@@ -45,8 +45,8 @@ contract SchemaModuleV2 is AbstractModuleV2 {
    */
   function setAuthorizedSchemaIds(
     address portal,
-    bytes32[] memory schemaIds,
-    bool[] memory authorizedStatus
+    bytes32[] calldata schemaIds,
+    bool[] calldata authorizedStatus
   ) public onlyPortalOwner(portal) {
     if (schemaIds.length != authorizedStatus.length) revert ArrayLengthMismatch();
 
@@ -64,8 +64,8 @@ contract SchemaModuleV2 is AbstractModuleV2 {
    * @notice If the Schema used in the attestation payload is not authorized for the Portal, an error is thrown
    */
   function run(
-    AttestationPayload memory attestationPayload,
-    bytes memory /*_validationPayload*/,
+    AttestationPayload calldata attestationPayload,
+    bytes calldata /*_validationPayload*/,
     address /*initialCaller*/,
     uint256 /*value*/,
     address /*attester*/,

--- a/contracts/src/stdlib/SenderModuleV2.sol
+++ b/contracts/src/stdlib/SenderModuleV2.sol
@@ -44,8 +44,8 @@ contract SenderModuleV2 is AbstractModuleV2 {
    */
   function setAuthorizedSenders(
     address portal,
-    address[] memory senders,
-    bool[] memory authorizedStatus
+    address[] calldata senders,
+    bool[] calldata authorizedStatus
   ) public onlyPortalOwner(portal) {
     if (senders.length != authorizedStatus.length) revert ArrayLengthMismatch();
 
@@ -63,8 +63,8 @@ contract SenderModuleV2 is AbstractModuleV2 {
    * @notice If the transaction sender is not the expected address, an error is thrown
    */
   function run(
-    AttestationPayload memory /*attestationPayload*/,
-    bytes memory /*validationPayload*/,
+    AttestationPayload calldata /*attestationPayload*/,
+    bytes calldata /*validationPayload*/,
     address initialCaller,
     uint256 /*value*/,
     address /*attester*/,

--- a/contracts/test/mocks/CorrectModuleV2Mock.sol
+++ b/contracts/test/mocks/CorrectModuleV2Mock.sol
@@ -16,8 +16,8 @@ contract CorrectModuleV2 is AbstractModuleV2 {
 
   /// @inheritdoc AbstractModuleV2
   function run(
-    AttestationPayload memory /*attestationPayload*/,
-    bytes memory /*validationPayload*/,
+    AttestationPayload calldata /*attestationPayload*/,
+    bytes calldata /*validationPayload*/,
     address /*initialCaller*/,
     uint256 /*value*/,
     address /*attester*/,

--- a/contracts/test/mocks/PortalRegistryNotAllowlistedMock.sol
+++ b/contracts/test/mocks/PortalRegistryNotAllowlistedMock.sol
@@ -19,8 +19,7 @@ contract PortalRegistryNotAllowlistedMock {
     bool isRevocable,
     string calldata ownerName
   ) external {
-    Portal memory newPortal = Portal(id, msg.sender, new address[](0), isRevocable, name, description, ownerName);
-    portals[id] = newPortal;
+    portals[id] = Portal(id, msg.sender, new address[](0), isRevocable, name, description, ownerName);
     emit PortalRegistered(name, description, id);
   }
 


### PR DESCRIPTION
## What does this PR do?

### Related ticket

Fixes #897 

### Type of change

- [X] Chore
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update

## Check list

- [ ] Unit tests for any smart contract change
- [ ] Contracts and functions are documented
