### PR TITLE
feat(contracts): Create a script to deploy contract implementations only

### DIFF
--- a/contracts/script/deploy/deployImplementations.ts
+++ b/contracts/script/deploy/deployImplementations.ts
@@ -1,0 +1,101 @@
+import { ethers, run, upgrades } from "hardhat";
+import { getNetworkConfig } from "../utils";
+
+async function main() {
+  console.log(`START IMPLEMENTATIONS DEPLOYMENT`);
+
+  const network = await ethers.provider.getNetwork();
+  const networkConfig = getNetworkConfig(network.chainId);
+  console.log(
+    `Chain prefix for chain ID ${network.chainId} is ${networkConfig.chainPrefix} (${
+      networkConfig.isTestnet ? "testnet" : "mainnet"
+    })`,
+  );
+
+  console.log("Deploying Router implementation...");
+  const Router = await ethers.getContractFactory("Router");
+  const routerImplementation = await upgrades.deployImplementation(Router);
+  console.log(`Router implementation deployed at: ${routerImplementation}`);
+
+  await new Promise((resolve) => setTimeout(resolve, 5000));
+  await run("verify:verify", {
+    address: routerImplementation,
+  });
+
+  console.log(`\n----\n`);
+
+  console.log("Deploying AttestationRegistry implementation...");
+  const AttestationRegistry = await ethers.getContractFactory("AttestationRegistry");
+  const attestationRegistryImplementation = await upgrades.deployImplementation(AttestationRegistry);
+  console.log(`AttestationRegistry implementation deployed at: ${attestationRegistryImplementation}`);
+
+  await new Promise((resolve) => setTimeout(resolve, 5000));
+  await run("verify:verify", {
+    address: attestationRegistryImplementation,
+  });
+
+  console.log(`\n----\n`);
+
+  console.log("Deploying ModuleRegistry implementation...");
+  const ModuleRegistry = await ethers.getContractFactory("ModuleRegistry");
+  const moduleRegistryImplementation = await upgrades.deployImplementation(ModuleRegistry);
+  console.log(`ModuleRegistry implementation deployed at: ${moduleRegistryImplementation}`);
+
+  await new Promise((resolve) => setTimeout(resolve, 5000));
+  await run("verify:verify", {
+    address: moduleRegistryImplementation,
+  });
+
+  console.log(`\n----\n`);
+
+  console.log("Deploying PortalRegistry implementation...");
+  const PortalRegistry = await ethers.getContractFactory("PortalRegistry");
+  const portalRegistryImplementation = await upgrades.deployImplementation(PortalRegistry);
+  console.log(`PortalRegistry implementation deployed at: ${portalRegistryImplementation}`);
+
+  await new Promise((resolve) => setTimeout(resolve, 5000));
+  await run("verify:verify", {
+    address: portalRegistryImplementation,
+  });
+
+  console.log(`\n----\n`);
+
+  console.log("Deploying SchemaRegistry implementation...");
+  const SchemaRegistry = await ethers.getContractFactory("SchemaRegistry");
+  const schemaRegistryImplementation = await upgrades.deployImplementation(SchemaRegistry);
+  console.log(`SchemaRegistry implementation deployed at: ${schemaRegistryImplementation}`);
+
+  await new Promise((resolve) => setTimeout(resolve, 5000));
+  await run("verify:verify", {
+    address: schemaRegistryImplementation,
+  });
+
+  console.log(`\n----\n`);
+
+  console.log("Deploying AttestationReader implementation...");
+  const AttestationReader = await ethers.getContractFactory("AttestationReader");
+  const attestationReaderImplementation = await upgrades.deployImplementation(AttestationReader);
+  console.log(`AttestationReader implementation deployed at: ${attestationReaderImplementation}`);
+
+  await new Promise((resolve) => setTimeout(resolve, 5000));
+  await run("verify:verify", {
+    address: attestationReaderImplementation,
+  });
+
+  console.log(`\n----\n`);
+
+  console.log(`** IMPLEMENTATION ADDRESSES SUMMARY **`);
+  console.log(`Router: ${routerImplementation}`);
+  console.log(`AttestationRegistry: ${attestationRegistryImplementation}`);
+  console.log(`ModuleRegistry: ${moduleRegistryImplementation}`);
+  console.log(`PortalRegistry: ${portalRegistryImplementation}`);
+  console.log(`SchemaRegistry: ${schemaRegistryImplementation}`);
+  console.log(`AttestationReader: ${attestationReaderImplementation}`);
+
+  console.log(`END IMPLEMENTATIONS DEPLOYMENT`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/contracts/script/deploy/deployImplementations.ts
+++ b/contracts/script/deploy/deployImplementations.ts
@@ -1,4 +1,4 @@
-import { ethers, run, upgrades } from "hardhat";
+import { ethers, run } from "hardhat";
 import { getNetworkConfig } from "../utils";
 
 async function main() {
@@ -14,83 +14,80 @@ async function main() {
 
   console.log("Deploying Router implementation...");
   const Router = await ethers.getContractFactory("Router");
-  const routerImplementation = await upgrades.deployImplementation(Router);
-  console.log(`Router implementation deployed at: ${routerImplementation}`);
+  const router = await Router.deploy();
+  await router.waitForDeployment();
+  const routerAddress = await router.getAddress();
+  console.log(`Router implementation deployed at: ${routerAddress}`);
 
   await new Promise((resolve) => setTimeout(resolve, 5000));
   await run("verify:verify", {
-    address: routerImplementation,
+    address: routerAddress,
   });
 
   console.log(`\n----\n`);
 
   console.log("Deploying AttestationRegistry implementation...");
   const AttestationRegistry = await ethers.getContractFactory("AttestationRegistry");
-  const attestationRegistryImplementation = await upgrades.deployImplementation(AttestationRegistry);
-  console.log(`AttestationRegistry implementation deployed at: ${attestationRegistryImplementation}`);
+  const attestationRegistry = await AttestationRegistry.deploy();
+  await attestationRegistry.waitForDeployment();
+  const attestationRegistryAddress = await attestationRegistry.getAddress();
+  console.log(`AttestationRegistry implementation deployed at: ${attestationRegistryAddress}`);
 
   await new Promise((resolve) => setTimeout(resolve, 5000));
   await run("verify:verify", {
-    address: attestationRegistryImplementation,
+    address: attestationRegistryAddress,
   });
 
   console.log(`\n----\n`);
 
   console.log("Deploying ModuleRegistry implementation...");
   const ModuleRegistry = await ethers.getContractFactory("ModuleRegistry");
-  const moduleRegistryImplementation = await upgrades.deployImplementation(ModuleRegistry);
-  console.log(`ModuleRegistry implementation deployed at: ${moduleRegistryImplementation}`);
+  const moduleRegistry = await ModuleRegistry.deploy();
+  await moduleRegistry.waitForDeployment();
+  const moduleRegistryAddress = await moduleRegistry.getAddress();
+  console.log(`ModuleRegistry implementation deployed at: ${moduleRegistryAddress}`);
 
   await new Promise((resolve) => setTimeout(resolve, 5000));
   await run("verify:verify", {
-    address: moduleRegistryImplementation,
+    address: moduleRegistryAddress,
   });
 
   console.log(`\n----\n`);
 
   console.log("Deploying PortalRegistry implementation...");
   const PortalRegistry = await ethers.getContractFactory("PortalRegistry");
-  const portalRegistryImplementation = await upgrades.deployImplementation(PortalRegistry);
-  console.log(`PortalRegistry implementation deployed at: ${portalRegistryImplementation}`);
+  const portalRegistry = await PortalRegistry.deploy();
+  await portalRegistry.waitForDeployment();
+  const portalRegistryAddress = await portalRegistry.getAddress();
+  console.log(`PortalRegistry implementation deployed at: ${portalRegistryAddress}`);
 
   await new Promise((resolve) => setTimeout(resolve, 5000));
   await run("verify:verify", {
-    address: portalRegistryImplementation,
+    address: portalRegistryAddress,
   });
 
   console.log(`\n----\n`);
 
   console.log("Deploying SchemaRegistry implementation...");
   const SchemaRegistry = await ethers.getContractFactory("SchemaRegistry");
-  const schemaRegistryImplementation = await upgrades.deployImplementation(SchemaRegistry);
-  console.log(`SchemaRegistry implementation deployed at: ${schemaRegistryImplementation}`);
+  const schemaRegistry = await SchemaRegistry.deploy();
+  await schemaRegistry.waitForDeployment();
+  const schemaRegistryAddress = await schemaRegistry.getAddress();
+  console.log(`SchemaRegistry implementation deployed at: ${schemaRegistryAddress}`);
 
   await new Promise((resolve) => setTimeout(resolve, 5000));
   await run("verify:verify", {
-    address: schemaRegistryImplementation,
-  });
-
-  console.log(`\n----\n`);
-
-  console.log("Deploying AttestationReader implementation...");
-  const AttestationReader = await ethers.getContractFactory("AttestationReader");
-  const attestationReaderImplementation = await upgrades.deployImplementation(AttestationReader);
-  console.log(`AttestationReader implementation deployed at: ${attestationReaderImplementation}`);
-
-  await new Promise((resolve) => setTimeout(resolve, 5000));
-  await run("verify:verify", {
-    address: attestationReaderImplementation,
+    address: schemaRegistryAddress,
   });
 
   console.log(`\n----\n`);
 
   console.log(`** IMPLEMENTATION ADDRESSES SUMMARY **`);
-  console.log(`Router: ${routerImplementation}`);
-  console.log(`AttestationRegistry: ${attestationRegistryImplementation}`);
-  console.log(`ModuleRegistry: ${moduleRegistryImplementation}`);
-  console.log(`PortalRegistry: ${portalRegistryImplementation}`);
-  console.log(`SchemaRegistry: ${schemaRegistryImplementation}`);
-  console.log(`AttestationReader: ${attestationReaderImplementation}`);
+  console.log(`Router: ${routerAddress}`);
+  console.log(`AttestationRegistry: ${attestationRegistryAddress}`);
+  console.log(`ModuleRegistry: ${moduleRegistryAddress}`);
+  console.log(`PortalRegistry: ${portalRegistryAddress}`);
+  console.log(`SchemaRegistry: ${schemaRegistryAddress}`);
 
   console.log(`END IMPLEMENTATIONS DEPLOYMENT`);
 }

--- a/contracts/script/deploy/deployImplementationsEas.ts
+++ b/contracts/script/deploy/deployImplementationsEas.ts
@@ -1,0 +1,29 @@
+import { ethers, run } from "hardhat";
+
+async function main() {
+  console.log(`START EAS IMPLEMENTATIONS DEPLOYMENT`);
+
+  console.log("Deploying AttestationReader implementation...");
+  const AttestationReader = await ethers.getContractFactory("AttestationReader");
+  const attestationReader = await AttestationReader.deploy();
+  await attestationReader.waitForDeployment();
+  const attestationReaderAddress = await attestationReader.getAddress();
+  console.log(`AttestationReader implementation deployed at: ${attestationReaderAddress}`);
+
+  await new Promise((resolve) => setTimeout(resolve, 5000));
+  await run("verify:verify", {
+    address: attestationReaderAddress,
+  });
+
+  console.log(`\n----\n`);
+
+  console.log(`** EAS IMPLEMENTATION ADDRESSES SUMMARY **`);
+  console.log(`AttestationReader: ${attestationReaderAddress}`);
+
+  console.log(`END EAS IMPLEMENTATIONS DEPLOYMENT`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## What does this PR do?

- Adds a new script `deployImplementations.ts` to deploy only contract implementations without proxies
- Supports deployment of all main registry contracts:
  - Router
  - AttestationRegistry
  - ModuleRegistry
  - PortalRegistry
  - SchemaRegistry
  - AttestationReader
- Includes automatic contract verification on block explorer
- Provides a summary of all deployed implementation addresses

### Related ticket

Fixes #864
### Type of change

- [ ] Chore
- [ ] Bug fix
- [X] New feature
- [ ] Documentation update

## Check list

- [x] My contribution follows the [guidelines](https://github.com/Consensys/linea-attestation-registry/blob/dev/CONTRIBUTING.md) of this project
- [x] I have made corresponding changes to the documentation
- [ ] Unit tests for any smart contract change
- [ ] Contracts and functions are documented