### PR TITLE
feat(subgraph): As a user, I want the update Registry address on the Router to be indexed for the 4 registries

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linea-attestation-registry",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "Core smart contracts to read and write attestations on Linea",
   "keywords": [
     "linea-attestation-registry",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linea-attestation-registry",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "description": "Core smart contracts to read and write attestations on Linea",
   "keywords": [
     "linea-attestation-registry",

--- a/subgraph/abis/Router.json
+++ b/subgraph/abis/Router.json
@@ -1,0 +1,222 @@
+[
+  {
+    "inputs": [],
+    "name": "RegistryAlreadySet",
+    "type": "error"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "registryAddress",
+        "type": "address"
+      }
+    ],
+    "name": "AttestationRegistryUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "registryAddress",
+        "type": "address"
+      }
+    ],
+    "name": "ModuleRegistryUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "registryAddress",
+        "type": "address"
+      }
+    ],
+    "name": "PortalRegistryUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "registryAddress",
+        "type": "address"
+      }
+    ],
+    "name": "SchemaRegistryUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "getAttestationRegistry",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getModuleRegistry",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getPortalRegistry",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getSchemaRegistry",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "initialize",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "renounceOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "transferOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_attestationRegistry",
+        "type": "address"
+      }
+    ],
+    "name": "updateAttestationRegistry",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_moduleRegistry",
+        "type": "address"
+      }
+    ],
+    "name": "updateModuleRegistry",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_portalRegistry",
+        "type": "address"
+      }
+    ],
+    "name": "updatePortalRegistry",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_schemaRegistry",
+        "type": "address"
+      }
+    ],
+    "name": "updateSchemaRegistry",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/subgraph/package.json
+++ b/subgraph/package.json
@@ -54,8 +54,8 @@
     "test:docker": "graph test -d"
   },
   "devDependencies": {
-    "@graphprotocol/graph-cli": "0.49.0",
-    "@graphprotocol/graph-ts": "0.30.0",
+    "@graphprotocol/graph-cli": "0.49.0 ",
+    "@graphprotocol/graph-ts": "0.30.0 ",
     "assemblyscript": "0.19.10",
     "matchstick-as": "0.6.0"
   }

--- a/subgraph/package.json
+++ b/subgraph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linea-attestation-registry-subgraph",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "description": "Subgraph to index the main objects of Verax",
   "keywords": [
     "linea-attestation-registry",
@@ -53,7 +53,6 @@
     "test:coverage": "graph test -c",
     "test:docker": "graph test -d"
   },
-  "dependencies": {},
   "devDependencies": {
     "@graphprotocol/graph-cli": "0.49.0",
     "@graphprotocol/graph-ts": "0.30.0",

--- a/subgraph/package.json
+++ b/subgraph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linea-attestation-registry-subgraph",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "Subgraph to index the main objects of Verax",
   "keywords": [
     "linea-attestation-registry",
@@ -15,6 +15,9 @@
   "license": "MIT",
   "author": "Consensys",
   "scripts": {
+    "codegen": "graph codegen",
+    "build": "graph build",
+    "deploy": "graph deploy",
     "build:arbitrum-one:v1": "pnpm run codegen:v1 && graph build subgraph-v1.arbitrum-one.yaml",
     "build:arbitrum-one:v2": "pnpm run codegen:v2 && graph build subgraph.arbitrum-one.yaml",
     "build:arbitrum-sepolia:v1": "pnpm run codegen:v1 && graph build subgraph-v1.arbitrum-sepolia.yaml",
@@ -53,9 +56,11 @@
     "test:coverage": "graph test -c",
     "test:docker": "graph test -d"
   },
+  "dependencies": {
+    "@graphprotocol/graph-ts": "0.30.0"
+  },
   "devDependencies": {
-    "@graphprotocol/graph-cli": "0.73.0",
-    "@graphprotocol/graph-ts": "0.31.0",
+    "@graphprotocol/graph-cli": "0.49.0",
     "assemblyscript": "0.19.10",
     "matchstick-as": "0.6.0"
   }

--- a/subgraph/package.json
+++ b/subgraph/package.json
@@ -15,9 +15,6 @@
   "license": "MIT",
   "author": "Consensys",
   "scripts": {
-    "codegen": "graph codegen",
-    "build": "graph build",
-    "deploy": "graph deploy",
     "build:arbitrum-one:v1": "pnpm run codegen:v1 && graph build subgraph-v1.arbitrum-one.yaml",
     "build:arbitrum-one:v2": "pnpm run codegen:v2 && graph build subgraph.arbitrum-one.yaml",
     "build:arbitrum-sepolia:v1": "pnpm run codegen:v1 && graph build subgraph-v1.arbitrum-sepolia.yaml",
@@ -56,11 +53,10 @@
     "test:coverage": "graph test -c",
     "test:docker": "graph test -d"
   },
-  "dependencies": {
-    "@graphprotocol/graph-ts": "0.30.0"
-  },
+  "dependencies": {},
   "devDependencies": {
     "@graphprotocol/graph-cli": "0.49.0",
+    "@graphprotocol/graph-ts": "0.30.0",
     "assemblyscript": "0.19.10",
     "matchstick-as": "0.6.0"
   }

--- a/subgraph/package.json
+++ b/subgraph/package.json
@@ -54,8 +54,8 @@
     "test:docker": "graph test -d"
   },
   "devDependencies": {
-    "@graphprotocol/graph-cli": "0.73.0 ",
-    "@graphprotocol/graph-ts": "0.31.0 ",
+    "@graphprotocol/graph-cli": "0.73.0",
+    "@graphprotocol/graph-ts": "0.31.0",
     "assemblyscript": "0.19.10",
     "matchstick-as": "0.6.0"
   }

--- a/subgraph/package.json
+++ b/subgraph/package.json
@@ -54,8 +54,8 @@
     "test:docker": "graph test -d"
   },
   "devDependencies": {
-    "@graphprotocol/graph-cli": "0.49.0 ",
-    "@graphprotocol/graph-ts": "0.30.0 ",
+    "@graphprotocol/graph-cli": "0.73.0 ",
+    "@graphprotocol/graph-ts": "0.31.0 ",
     "assemblyscript": "0.19.10",
     "matchstick-as": "0.6.0"
   }

--- a/subgraph/schema-v1.graphql
+++ b/subgraph/schema-v1.graphql
@@ -60,3 +60,29 @@ type RegistryVersion @entity {
   versionNumber: Int
   timestamp: BigInt
 }
+
+type RegistryUpdate @entity {
+  id: ID!
+  registryType: String!
+  registryName: String!
+  registryAddress: Bytes!
+  auditInformation: String!
+}
+
+type Audit @entity {
+  id: ID!
+  blockNumber: BigInt!
+  transactionHash: Bytes!
+  transactionTimestamp: BigInt!
+  fromAddress: Bytes!
+  toAddress: Bytes!
+  valueTransferred: BigInt!
+  gasPrice: BigInt!
+}
+
+type AuditInformation @entity {
+  id: ID!
+  creation: String!
+  lastModification: String!
+  modifications: [String!]!
+}

--- a/subgraph/schema-v2.graphql
+++ b/subgraph/schema-v2.graphql
@@ -87,6 +87,7 @@ type Audit @entity {
 type RegistryUpdate @entity {
   id: ID!
   registryType: String!
+  registryName: String!
   registryAddress: Bytes!
   auditInformation: AuditInformation!
 }

--- a/subgraph/schema-v2.graphql
+++ b/subgraph/schema-v2.graphql
@@ -83,3 +83,10 @@ type Audit @entity {
   valueTransferred: BigInt
   gasPrice: BigInt
 }
+
+type RegistryUpdate @entity {
+  id: ID!
+  registryType: String!
+  registryAddress: Bytes!
+  auditInformation: AuditInformation!
+}

--- a/subgraph/src/module-registry.ts
+++ b/subgraph/src/module-registry.ts
@@ -1,29 +1,12 @@
 import { ModuleRegistered as ModuleRegisteredEvent } from "../generated/ModuleRegistry/ModuleRegistry";
-import { Audit, AuditInformation, Counter, Module } from "../generated/schema";
+import { Counter, Module } from "../generated/schema";
+import { createAuditInformation } from "../src/utils";
 
 export function handleModuleRegistered(event: ModuleRegisteredEvent): void {
   const module = new Module(event.params.moduleAddress.toHexString().toLowerCase());
-
-  const audit = new Audit(event.transaction.hash.toHexString().toLowerCase());
-  audit.blockNumber = event.block.number;
-  audit.transactionHash = event.transaction.hash;
-  audit.transactionTimestamp = event.block.timestamp;
-  audit.fromAddress = event.transaction.from;
-  audit.toAddress = event.transaction.to;
-  audit.valueTransferred = event.transaction.value;
-  audit.gasPrice = event.transaction.gasPrice;
-
-  audit.save();
-
-  const auditInformation = new AuditInformation(module.id);
-  auditInformation.creation = audit.id.toLowerCase();
-  auditInformation.lastModification = audit.id.toLowerCase();
-  auditInformation.modifications = [audit.id.toLowerCase()];
-
-  auditInformation.save();
-
-  module.auditInformation = auditInformation.id.toLowerCase();
-
+  
+  module.auditInformation = createAuditInformation(module.id, event);
+  
   incrementModulesCount();
 
   module.moduleAddress = event.params.moduleAddress;

--- a/subgraph/src/module-registry.ts
+++ b/subgraph/src/module-registry.ts
@@ -4,9 +4,9 @@ import { createAuditInformation } from "../src/utils";
 
 export function handleModuleRegistered(event: ModuleRegisteredEvent): void {
   const module = new Module(event.params.moduleAddress.toHexString().toLowerCase());
-  
+
   module.auditInformation = createAuditInformation(module.id, event);
-  
+
   incrementModulesCount();
 
   module.moduleAddress = event.params.moduleAddress;

--- a/subgraph/src/portal-registry.ts
+++ b/subgraph/src/portal-registry.ts
@@ -6,32 +6,15 @@ import {
   PortalRegistry,
   PortalRevoked as PortalRevokedEvent,
 } from "../generated/PortalRegistry/PortalRegistry";
-import { Audit, AuditInformation, Counter, Issuer, Portal } from "../generated/schema";
+import { AuditInformation, Counter, Issuer, Portal } from "../generated/schema";
+import { createAuditInformation } from "../src/utils";
 
 export function handlePortalRegistered(event: PortalRegisteredEvent): void {
   const contract = PortalRegistry.bind(event.address);
   const portalData = contract.getPortalByAddress(event.params.portalAddress);
   const portal = new Portal(event.params.portalAddress.toHexString().toLowerCase());
 
-  const audit = new Audit(event.transaction.hash.toHexString().toLowerCase());
-  audit.blockNumber = event.block.number;
-  audit.transactionHash = event.transaction.hash;
-  audit.transactionTimestamp = event.block.timestamp;
-  audit.fromAddress = event.transaction.from;
-  audit.toAddress = event.transaction.to;
-  audit.valueTransferred = event.transaction.value;
-  audit.gasPrice = event.transaction.gasPrice;
-
-  audit.save();
-
-  const auditInformation = new AuditInformation(portal.id);
-  auditInformation.creation = audit.id.toLowerCase();
-  auditInformation.lastModification = audit.id.toLowerCase();
-  auditInformation.modifications = [audit.id.toLowerCase()];
-
-  auditInformation.save();
-
-  portal.auditInformation = auditInformation.id.toLowerCase();
+  portal.auditInformation = createAuditInformation(portal.id, event);
 
   incrementPortalsCount();
 
@@ -65,27 +48,7 @@ export function handlePortalRevoked(event: PortalRevokedEvent): void {
 
 export function handleIssuerAdded(event: IssuerAdded): void {
   const issuer = new Issuer(event.params.issuerAddress.toHexString());
-
-  const audit = new Audit(event.transaction.hash.toHexString().toLowerCase());
-  audit.blockNumber = event.block.number;
-  audit.transactionHash = event.transaction.hash;
-  audit.transactionTimestamp = event.block.timestamp;
-  audit.fromAddress = event.transaction.from;
-  audit.toAddress = event.transaction.to;
-  audit.valueTransferred = event.transaction.value;
-  audit.gasPrice = event.transaction.gasPrice;
-
-  audit.save();
-
-  const auditInformation = new AuditInformation(issuer.id);
-  auditInformation.creation = audit.id.toLowerCase();
-  auditInformation.lastModification = audit.id.toLowerCase();
-  auditInformation.modifications = [audit.id.toLowerCase()];
-
-  auditInformation.save();
-
-  issuer.auditInformation = auditInformation.id.toLowerCase();
-
+  issuer.auditInformation = createAuditInformation(issuer.id, event);
   issuer.save();
 }
 

--- a/subgraph/src/router-v1.ts
+++ b/subgraph/src/router-v1.ts
@@ -1,0 +1,35 @@
+import { Address, ethereum } from "@graphprotocol/graph-ts";
+import {
+  AttestationRegistryUpdated,
+  ModuleRegistryUpdated,
+  PortalRegistryUpdated,
+  SchemaRegistryUpdated,
+} from "../generated/Router/Router";
+import { RegistryUpdate } from "../generated/schema";
+import { createAuditInformation, getRegistryName } from "../src/utils";
+
+function handleRegistryUpdate(registryAddress: Address, registryType: string, event: ethereum.Event): void {
+  const eventId = event.transaction.hash.toHexString();
+  const update = new RegistryUpdate(eventId);
+  update.registryType = registryType;
+  update.registryName = getRegistryName(registryType);
+  update.registryAddress = registryAddress;
+  update.auditInformation = createAuditInformation(eventId, event);
+  update.save();
+}
+
+export function handleAttestationRegistryUpdated(event: AttestationRegistryUpdated): void {
+  handleRegistryUpdate(event.params.registryAddress, "ATTESTATION", event as unknown as ethereum.Event);
+}
+
+export function handleModuleRegistryUpdated(event: ModuleRegistryUpdated): void {
+  handleRegistryUpdate(event.params.registryAddress, "MODULE", event as unknown as ethereum.Event);
+}
+
+export function handlePortalRegistryUpdated(event: PortalRegistryUpdated): void {
+  handleRegistryUpdate(event.params.registryAddress, "PORTAL", event as unknown as ethereum.Event);
+}
+
+export function handleSchemaRegistryUpdated(event: SchemaRegistryUpdated): void {
+  handleRegistryUpdate(event.params.registryAddress, "SCHEMA", event as unknown as ethereum.Event);
+}

--- a/subgraph/src/router.ts
+++ b/subgraph/src/router.ts
@@ -12,6 +12,7 @@ function handleRegistryUpdate(registryAddress: Address, registryType: string, ev
   const eventId = event.transaction.hash.toHexString();
   const update = new RegistryUpdate(eventId);
   update.registryType = registryType;
+  update.registryName = `${registryType} Registry`;
   update.registryAddress = registryAddress;
   update.auditInformation = createAuditInformation(eventId, event);
   update.save();

--- a/subgraph/src/router.ts
+++ b/subgraph/src/router.ts
@@ -1,0 +1,34 @@
+import { Address, ethereum } from "@graphprotocol/graph-ts";
+import {
+  AttestationRegistryUpdated,
+  ModuleRegistryUpdated,
+  PortalRegistryUpdated,
+  SchemaRegistryUpdated,
+} from "../generated/Router/Router";
+import { RegistryUpdate } from "../generated/schema";
+import { createAuditInformation } from "../src/utils";
+
+function handleRegistryUpdate(registryAddress: Address, registryType: string, event: ethereum.Event): void {
+  const eventId = event.transaction.hash.toHexString();
+  const update = new RegistryUpdate(eventId);
+  update.registryType = registryType;
+  update.registryAddress = registryAddress;
+  update.auditInformation = createAuditInformation(eventId, event);
+  update.save();
+}
+
+export function handleAttestationRegistryUpdated(event: AttestationRegistryUpdated): void {
+  handleRegistryUpdate(event.params.registryAddress, "ATTESTATION", event as unknown as ethereum.Event);
+}
+
+export function handleModuleRegistryUpdated(event: ModuleRegistryUpdated): void {
+  handleRegistryUpdate(event.params.registryAddress, "MODULE", event as unknown as ethereum.Event);
+}
+
+export function handlePortalRegistryUpdated(event: PortalRegistryUpdated): void {
+  handleRegistryUpdate(event.params.registryAddress, "PORTAL", event as unknown as ethereum.Event);
+}
+
+export function handleSchemaRegistryUpdated(event: SchemaRegistryUpdated): void {
+  handleRegistryUpdate(event.params.registryAddress, "SCHEMA", event as unknown as ethereum.Event);
+}

--- a/subgraph/src/router.ts
+++ b/subgraph/src/router.ts
@@ -6,13 +6,13 @@ import {
   SchemaRegistryUpdated,
 } from "../generated/Router/Router";
 import { RegistryUpdate } from "../generated/schema";
-import { createAuditInformation } from "../src/utils";
+import { createAuditInformation, getRegistryName } from "../src/utils";
 
 function handleRegistryUpdate(registryAddress: Address, registryType: string, event: ethereum.Event): void {
   const eventId = event.transaction.hash.toHexString();
   const update = new RegistryUpdate(eventId);
   update.registryType = registryType;
-  update.registryName = `${registryType} Registry`;
+  update.registryName = getRegistryName(registryType);
   update.registryAddress = registryAddress;
   update.auditInformation = createAuditInformation(eventId, event);
   update.save();

--- a/subgraph/src/schema-registry.ts
+++ b/subgraph/src/schema-registry.ts
@@ -1,12 +1,16 @@
-import { SchemaContextUpdated, SchemaCreated as SchemaCreatedEvent, SchemaRegistry } from "../generated/SchemaRegistry/SchemaRegistry";
+import {
+  SchemaContextUpdated,
+  SchemaCreated as SchemaCreatedEvent,
+  SchemaRegistry,
+} from "../generated/SchemaRegistry/SchemaRegistry";
 import { Counter, Schema } from "../generated/schema";
 import { createAuditInformation } from "../src/utils";
 
 export function handleSchemaCreated(event: SchemaCreatedEvent): void {
   const schema = new Schema(event.params.id.toHexString());
-  
+
   schema.auditInformation = createAuditInformation(schema.id, event);
-  
+
   incrementSchemasCount();
 
   schema.name = event.params.name;

--- a/subgraph/src/schema-registry.ts
+++ b/subgraph/src/schema-registry.ts
@@ -1,33 +1,12 @@
-import {
-  SchemaContextUpdated,
-  SchemaCreated as SchemaCreatedEvent,
-  SchemaRegistry,
-} from "../generated/SchemaRegistry/SchemaRegistry";
-import { Audit, AuditInformation, Counter, Schema } from "../generated/schema";
+import { SchemaContextUpdated, SchemaCreated as SchemaCreatedEvent, SchemaRegistry } from "../generated/SchemaRegistry/SchemaRegistry";
+import { Counter, Schema } from "../generated/schema";
+import { createAuditInformation } from "../src/utils";
 
 export function handleSchemaCreated(event: SchemaCreatedEvent): void {
   const schema = new Schema(event.params.id.toHexString());
-
-  const audit = new Audit(event.transaction.hash.toHexString().toLowerCase());
-  audit.blockNumber = event.block.number;
-  audit.transactionHash = event.transaction.hash;
-  audit.transactionTimestamp = event.block.timestamp;
-  audit.fromAddress = event.transaction.from;
-  audit.toAddress = event.transaction.to;
-  audit.valueTransferred = event.transaction.value;
-  audit.gasPrice = event.transaction.gasPrice;
-
-  audit.save();
-
-  const auditInformation = new AuditInformation(schema.id);
-  auditInformation.creation = audit.id.toLowerCase();
-  auditInformation.lastModification = audit.id.toLowerCase();
-  auditInformation.modifications = [audit.id.toLowerCase()];
-
-  auditInformation.save();
-
-  schema.auditInformation = auditInformation.id.toLowerCase();
-
+  
+  schema.auditInformation = createAuditInformation(schema.id, event);
+  
   incrementSchemasCount();
 
   schema.name = event.params.name;
@@ -42,32 +21,11 @@ export function handleSchemaCreated(event: SchemaCreatedEvent): void {
 export function handleSchemaContextUpdated(event: SchemaContextUpdated): void {
   const schemaRegistryContract = SchemaRegistry.bind(event.address);
   const newContext = schemaRegistryContract.getSchema(event.params.id).context;
-  // Get matching Schema
   const schema = Schema.load(event.params.id.toHexString());
 
   if (schema !== null) {
-    const audit = new Audit(event.transaction.hash.toHexString().toLowerCase());
-    audit.blockNumber = event.block.number;
-    audit.transactionHash = event.transaction.hash;
-    audit.transactionTimestamp = event.block.timestamp;
-    audit.fromAddress = event.transaction.from;
-    audit.toAddress = event.transaction.to;
-    audit.valueTransferred = event.transaction.value;
-    audit.gasPrice = event.transaction.gasPrice;
-
-    audit.save();
-
-    const auditInformation = AuditInformation.load(schema.id);
-    if (auditInformation !== null) {
-      auditInformation.lastModification = audit.id.toLowerCase();
-      auditInformation.modifications.push(audit.id.toLowerCase());
-
-      auditInformation.save();
-
-      schema.auditInformation = auditInformation.id.toLowerCase();
-    }
-
     schema.context = newContext;
+    schema.auditInformation = createAuditInformation(schema.id, event);
     schema.save();
   }
 }

--- a/subgraph/src/utils.ts
+++ b/subgraph/src/utils.ts
@@ -1,0 +1,28 @@
+import { ethereum } from "@graphprotocol/graph-ts";
+import { Audit, AuditInformation } from "../generated/schema";
+
+export function createAuditInformation(eventId: string, event: ethereum.Event): string {
+  const auditId = eventId + "-audit";
+  const audit = new Audit(auditId);
+  if (!event) return auditId;
+
+  const txn = event.transaction;
+  const block = event.block;
+
+  audit.blockNumber = block.number;
+  audit.transactionHash = txn.hash;
+  audit.transactionTimestamp = block.timestamp;
+  audit.fromAddress = txn.from;
+  audit.toAddress = txn.to || txn.from;
+  audit.valueTransferred = txn.value;
+  audit.gasPrice = txn.gasPrice;
+  audit.save();
+
+  const auditInfo = new AuditInformation(eventId);
+  auditInfo.creation = auditId;
+  auditInfo.lastModification = auditId;
+  auditInfo.modifications = [auditId];
+  auditInfo.save();
+
+  return eventId;
+}

--- a/subgraph/src/utils.ts
+++ b/subgraph/src/utils.ts
@@ -13,7 +13,10 @@ export function createAuditInformation(eventId: string, event: ethereum.Event): 
   audit.transactionHash = txn.hash;
   audit.transactionTimestamp = block.timestamp;
   audit.fromAddress = txn.from;
-  audit.toAddress = txn.to || txn.from;
+  // Only set toAddress for regular transactions (not contract creations)
+  if (txn.to) {
+    audit.toAddress = txn.to;
+  }
   audit.valueTransferred = txn.value;
   audit.gasPrice = txn.gasPrice;
   audit.save();

--- a/subgraph/src/utils.ts
+++ b/subgraph/src/utils.ts
@@ -1,9 +1,9 @@
 import { ethereum } from "@graphprotocol/graph-ts";
-import { Audit, AuditInformation } from "../generated/schema";
+import { Audit as AuditEntity, AuditInformation as AuditInfoEntity } from "../generated/schema";
 
 export function createAuditInformation(eventId: string, event: ethereum.Event): string {
   const auditId = eventId + "-audit";
-  const audit = new Audit(auditId);
+  const audit = new AuditEntity(auditId);
   if (!event) return auditId;
 
   const txn = event.transaction;
@@ -18,11 +18,15 @@ export function createAuditInformation(eventId: string, event: ethereum.Event): 
   audit.gasPrice = txn.gasPrice;
   audit.save();
 
-  const auditInfo = new AuditInformation(eventId);
+  const auditInfo = new AuditInfoEntity(eventId);
   auditInfo.creation = auditId;
   auditInfo.lastModification = auditId;
   auditInfo.modifications = [auditId];
   auditInfo.save();
 
   return eventId;
+}
+
+export function getRegistryName(registryType: string): string {
+  return `${registryType} Registry`;
 }

--- a/subgraph/subgraph-v1.arbitrum-one.yaml
+++ b/subgraph/subgraph-v1.arbitrum-one.yaml
@@ -94,3 +94,31 @@ dataSources:
         - event: SchemaContextUpdated(indexed bytes32)
           handler: handleSchemaContextUpdated
       file: ./src/schema-registry-v1.ts
+  - kind: ethereum
+    name: Router
+    network: arbitrum-one
+    source:
+      abi: Router
+      address: "0xa77196867bB03D04786EF636cDdD82f37A1248a9"
+      startBlock: 149970435
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - RegistryUpdate
+        - Audit
+        - AuditInformation
+      abis:
+        - name: Router
+          file: ./abis/Router.json
+      eventHandlers:
+        - event: AttestationRegistryUpdated(indexed address)
+          handler: handleAttestationRegistryUpdated
+        - event: ModuleRegistryUpdated(indexed address)
+          handler: handleModuleRegistryUpdated
+        - event: PortalRegistryUpdated(indexed address)
+          handler: handlePortalRegistryUpdated
+        - event: SchemaRegistryUpdated(indexed address)
+          handler: handleSchemaRegistryUpdated
+      file: ./src/router-v1.ts

--- a/subgraph/subgraph-v1.arbitrum-sepolia.yaml
+++ b/subgraph/subgraph-v1.arbitrum-sepolia.yaml
@@ -94,3 +94,29 @@ dataSources:
         - event: SchemaContextUpdated(indexed bytes32)
           handler: handleSchemaContextUpdated
       file: ./src/schema-registry-v1.ts
+  - kind: ethereum
+    name: Router
+    network: arbitrum-sepolia
+    source:
+      abi: Router
+      address: "0x374B686137eC0DB442a8d833451f8C12cD4B5De4"
+      startBlock: 22789964
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - RegistryUpdate
+        - Audit
+        - AuditInformation
+      abis:
+        - name: Router
+          file: ./abis/Router.json
+      eventHandlers:
+        - event: AttestationRegistryUpdated(indexed address)
+          handler: handleAttestationRegistryUpdated
+        - event: ModuleRegistryUpdated(indexed address)
+          handler: handleModuleRegistryUpdated
+        - event: PortalRegistryUpdated(indexed address)
+          handler: handlePortalRegistryUpdated
+      file: ./src/router.ts

--- a/subgraph/subgraph-v1.arbitrum-sepolia.yaml
+++ b/subgraph/subgraph-v1.arbitrum-sepolia.yaml
@@ -119,4 +119,6 @@ dataSources:
           handler: handleModuleRegistryUpdated
         - event: PortalRegistryUpdated(indexed address)
           handler: handlePortalRegistryUpdated
-      file: ./src/router.ts
+        - event: SchemaRegistryUpdated(indexed address)
+          handler: handleSchemaRegistryUpdated
+      file: ./src/router-v1.ts

--- a/subgraph/subgraph-v1.base-mainnet.yaml
+++ b/subgraph/subgraph-v1.base-mainnet.yaml
@@ -94,3 +94,31 @@ dataSources:
         - event: SchemaContextUpdated(indexed bytes32)
           handler: handleSchemaContextUpdated
       file: ./src/schema-registry-v1.ts
+  - kind: ethereum
+    name: Router
+    network: base
+    source:
+      abi: Router
+      address: "0x5A5A30aB3d6A6DD3463512793C7c36E9B47615e8"
+      startBlock: 13666866
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - RegistryUpdate
+        - Audit
+        - AuditInformation
+      abis:
+        - name: Router
+          file: ./abis/Router.json
+      eventHandlers:
+        - event: AttestationRegistryUpdated(indexed address)
+          handler: handleAttestationRegistryUpdated
+        - event: ModuleRegistryUpdated(indexed address)
+          handler: handleModuleRegistryUpdated
+        - event: PortalRegistryUpdated(indexed address)
+          handler: handlePortalRegistryUpdated
+        - event: SchemaRegistryUpdated(indexed address)
+          handler: handleSchemaRegistryUpdated
+      file: ./src/router-v1.ts

--- a/subgraph/subgraph-v1.base-sepolia.yaml
+++ b/subgraph/subgraph-v1.base-sepolia.yaml
@@ -94,3 +94,31 @@ dataSources:
         - event: SchemaContextUpdated(indexed bytes32)
           handler: handleSchemaContextUpdated
       file: ./src/schema-registry-v1.ts
+  - kind: ethereum
+    name: Router
+    network: base-sepolia
+    source:
+      abi: Router
+      address: "0xE235826514945186227918325D3E5b5f873861A6"
+      startBlock: 9174253
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - RegistryUpdate
+        - Audit
+        - AuditInformation
+      abis:
+        - name: Router
+          file: ./abis/Router.json
+      eventHandlers:
+        - event: AttestationRegistryUpdated(indexed address)
+          handler: handleAttestationRegistryUpdated
+        - event: ModuleRegistryUpdated(indexed address)
+          handler: handleModuleRegistryUpdated
+        - event: PortalRegistryUpdated(indexed address)
+          handler: handlePortalRegistryUpdated
+        - event: SchemaRegistryUpdated(indexed address)
+          handler: handleSchemaRegistryUpdated
+      file: ./src/router-v1.ts

--- a/subgraph/subgraph-v1.bsc-mainnet.yaml
+++ b/subgraph/subgraph-v1.bsc-mainnet.yaml
@@ -94,3 +94,31 @@ dataSources:
         - event: SchemaContextUpdated(indexed bytes32)
           handler: handleSchemaContextUpdated
       file: ./src/schema-registry-v1.ts
+  - kind: ethereum
+    name: Router
+    network: bsc
+    source:
+      abi: Router
+      address: "0x7a5C1fAC7fF9908a8b2ED479e060619213116A47"
+      startBlock: 39759713
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - RegistryUpdate
+        - Audit
+        - AuditInformation
+      abis:
+        - name: Router
+          file: ./abis/Router.json
+      eventHandlers:
+        - event: AttestationRegistryUpdated(indexed address)
+          handler: handleAttestationRegistryUpdated
+        - event: ModuleRegistryUpdated(indexed address)
+          handler: handleModuleRegistryUpdated
+        - event: PortalRegistryUpdated(indexed address)
+          handler: handlePortalRegistryUpdated
+        - event: SchemaRegistryUpdated(indexed address)
+          handler: handleSchemaRegistryUpdated
+      file: ./src/router-v1.ts

--- a/subgraph/subgraph-v1.bsc-testnet.yaml
+++ b/subgraph/subgraph-v1.bsc-testnet.yaml
@@ -94,3 +94,31 @@ dataSources:
         - event: SchemaContextUpdated(indexed bytes32)
           handler: handleSchemaContextUpdated
       file: ./src/schema-registry-v1.ts
+  - kind: ethereum
+    name: Router
+    network: bsc-testnet
+    source:
+      abi: Router
+      address: "0x90b8542d7288a83EC887229A7C727989C3b56209"
+      startBlock: 41312659
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - RegistryUpdate
+        - Audit
+        - AuditInformation
+      abis:
+        - name: Router
+          file: ./abis/Router.json
+      eventHandlers:
+        - event: AttestationRegistryUpdated(indexed address)
+          handler: handleAttestationRegistryUpdated
+        - event: ModuleRegistryUpdated(indexed address)
+          handler: handleModuleRegistryUpdated
+        - event: PortalRegistryUpdated(indexed address)
+          handler: handlePortalRegistryUpdated
+        - event: SchemaRegistryUpdated(indexed address)
+          handler: handleSchemaRegistryUpdated
+      file: ./src/router-v1.ts

--- a/subgraph/subgraph-v1.linea-mainnet.yaml
+++ b/subgraph/subgraph-v1.linea-mainnet.yaml
@@ -94,3 +94,31 @@ dataSources:
         - event: SchemaContextUpdated(indexed bytes32)
           handler: handleSchemaContextUpdated
       file: ./src/schema-registry-v1.ts
+  - kind: ethereum
+    name: Router
+    network: linea
+    source:
+      abi: Router
+      address: "0x4d3a380A03f3a18A5dC44b01119839D8674a552E"
+      startBlock: 346691
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - RegistryUpdate
+        - Audit
+        - AuditInformation
+      abis:
+        - name: Router
+          file: ./abis/Router.json
+      eventHandlers:
+        - event: AttestationRegistryUpdated(indexed address)
+          handler: handleAttestationRegistryUpdated
+        - event: ModuleRegistryUpdated(indexed address)
+          handler: handleModuleRegistryUpdated
+        - event: PortalRegistryUpdated(indexed address)
+          handler: handlePortalRegistryUpdated
+        - event: SchemaRegistryUpdated(indexed address)
+          handler: handleSchemaRegistryUpdated
+      file: ./src/router-v1.ts

--- a/subgraph/subgraph-v1.linea-sepolia.yaml
+++ b/subgraph/subgraph-v1.linea-sepolia.yaml
@@ -94,3 +94,31 @@ dataSources:
         - event: SchemaContextUpdated(indexed bytes32)
           handler: handleSchemaContextUpdated
       file: ./src/schema-registry-v1.ts
+  - kind: ethereum
+    name: Router
+    network: linea-sepolia
+    source:
+      abi: Router
+      address: "0x5A5A30aB3d6A6DD3463512793C7c36E9B47615e8"
+      startBlock: 487966
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - RegistryUpdate
+        - Audit
+        - AuditInformation
+      abis:
+        - name: Router
+          file: ./abis/Router.json
+      eventHandlers:
+        - event: AttestationRegistryUpdated(indexed address)
+          handler: handleAttestationRegistryUpdated
+        - event: ModuleRegistryUpdated(indexed address)
+          handler: handleModuleRegistryUpdated
+        - event: PortalRegistryUpdated(indexed address)
+          handler: handlePortalRegistryUpdated
+        - event: SchemaRegistryUpdated(indexed address)
+          handler: handleSchemaRegistryUpdated
+      file: ./src/router.ts

--- a/subgraph/subgraph-v1.linea-sepolia.yaml
+++ b/subgraph/subgraph-v1.linea-sepolia.yaml
@@ -121,4 +121,4 @@ dataSources:
           handler: handlePortalRegistryUpdated
         - event: SchemaRegistryUpdated(indexed address)
           handler: handleSchemaRegistryUpdated
-      file: ./src/router.ts
+      file: ./src/router-v1.ts

--- a/subgraph/subgraph-v1.linea-sepolia.yaml
+++ b/subgraph/subgraph-v1.linea-sepolia.yaml
@@ -99,7 +99,7 @@ dataSources:
     network: linea-sepolia
     source:
       abi: Router
-      address: "0x5A5A30aB3d6A6DD3463512793C7c36E9B47615e8"
+      address: "0xAfA952790492DDeB474012cEA12ba34B788ab39F"
       startBlock: 487966
     mapping:
       kind: ethereum/events

--- a/subgraph/subgraph.arbitrum-one.yaml
+++ b/subgraph/subgraph.arbitrum-one.yaml
@@ -94,3 +94,29 @@ dataSources:
         - event: SchemaContextUpdated(indexed bytes32)
           handler: handleSchemaContextUpdated
       file: ./src/schema-registry.ts
+  - kind: ethereum
+    name: Router
+    network: arbitrum-one
+    source:
+      abi: Router
+      address: "0x4E797aD91EE5d467D878E71C65D564D5b2026bE9"
+      startBlock: 160697387
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - RegistryUpdate
+      abis:
+        - name: Router
+          file: ./abis/Router.json
+      eventHandlers:
+        - event: AttestationRegistryUpdated(indexed address)
+          handler: handleAttestationRegistryUpdated
+        - event: ModuleRegistryUpdated(indexed address)
+          handler: handleModuleRegistryUpdated
+        - event: PortalRegistryUpdated(indexed address)
+          handler: handlePortalRegistryUpdated
+        - event: SchemaRegistryUpdated(indexed address)
+          handler: handleSchemaRegistryUpdated
+      file: ./src/router.ts

--- a/subgraph/subgraph.arbitrum-one.yaml
+++ b/subgraph/subgraph.arbitrum-one.yaml
@@ -99,7 +99,7 @@ dataSources:
     network: arbitrum-one
     source:
       abi: Router
-      address: "0x5A5A30aB3d6A6DD3463512793C7c36E9B47615e8"
+      address: "0xa77196867bB03D04786EF636cDdD82f37A1248a9"
       startBlock: 149970435
     mapping:
       kind: ethereum/events

--- a/subgraph/subgraph.arbitrum-one.yaml
+++ b/subgraph/subgraph.arbitrum-one.yaml
@@ -99,14 +99,16 @@ dataSources:
     network: arbitrum-one
     source:
       abi: Router
-      address: "0x4E797aD91EE5d467D878E71C65D564D5b2026bE9"
-      startBlock: 160697387
+      address: "0x5A5A30aB3d6A6DD3463512793C7c36E9B47615e8"
+      startBlock: 149970435
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
       language: wasm/assemblyscript
       entities:
         - RegistryUpdate
+        - Audit
+        - AuditInformation
       abis:
         - name: Router
           file: ./abis/Router.json

--- a/subgraph/subgraph.arbitrum-sepolia.yaml
+++ b/subgraph/subgraph.arbitrum-sepolia.yaml
@@ -102,4 +102,21 @@ dataSources:
       address: "0x4E797aD91EE5d467D878E71C65D564D5b2026bE9"
       startBlock: 1279337
     mapping:
-      # ...same mapping configuration as arbitrum-one...
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - RegistryUpdate
+      abis:
+        - name: Router
+          file: ./abis/Router.json
+      eventHandlers:
+        - event: AttestationRegistryUpdated(indexed address)
+          handler: handleAttestationRegistryUpdated
+        - event: ModuleRegistryUpdated(indexed address)
+          handler: handleModuleRegistryUpdated
+        - event: PortalRegistryUpdated(indexed address)
+          handler: handlePortalRegistryUpdated
+        - event: SchemaRegistryUpdated(indexed address)
+          handler: handleSchemaRegistryUpdated
+      file: ./src/router.ts

--- a/subgraph/subgraph.arbitrum-sepolia.yaml
+++ b/subgraph/subgraph.arbitrum-sepolia.yaml
@@ -94,3 +94,12 @@ dataSources:
         - event: SchemaContextUpdated(indexed bytes32)
           handler: handleSchemaContextUpdated
       file: ./src/schema-registry.ts
+  - kind: ethereum
+    name: Router
+    network: arbitrum-sepolia
+    source:
+      abi: Router
+      address: "0x4E797aD91EE5d467D878E71C65D564D5b2026bE9"
+      startBlock: 1279337
+    mapping:
+      # ...same mapping configuration as arbitrum-one...

--- a/subgraph/subgraph.arbitrum-sepolia.yaml
+++ b/subgraph/subgraph.arbitrum-sepolia.yaml
@@ -99,14 +99,16 @@ dataSources:
     network: arbitrum-sepolia
     source:
       abi: Router
-      address: "0x4E797aD91EE5d467D878E71C65D564D5b2026bE9"
-      startBlock: 1279337
+      address: "0x374B686137eC0DB442a8d833451f8C12cD4B5De4"
+      startBlock: 22789964
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
       language: wasm/assemblyscript
       entities:
         - RegistryUpdate
+        - Audit
+        - AuditInformation
       abis:
         - name: Router
           file: ./abis/Router.json

--- a/subgraph/subgraph.base-mainnet.yaml
+++ b/subgraph/subgraph.base-mainnet.yaml
@@ -94,3 +94,12 @@ dataSources:
         - event: SchemaContextUpdated(indexed bytes32)
           handler: handleSchemaContextUpdated
       file: ./src/schema-registry.ts
+  - kind: ethereum
+    name: Router
+    network: base
+    source:
+      abi: Router
+      address: "0x4E797aD91EE5d467D878E71C65D564D5b2026bE9"
+      startBlock: 7731130
+    mapping:
+      # ...same mapping configuration as arbitrum-one...

--- a/subgraph/subgraph.base-mainnet.yaml
+++ b/subgraph/subgraph.base-mainnet.yaml
@@ -102,4 +102,21 @@ dataSources:
       address: "0x4E797aD91EE5d467D878E71C65D564D5b2026bE9"
       startBlock: 7731130
     mapping:
-      # ...same mapping configuration as arbitrum-one...
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - RegistryUpdate
+      abis:
+        - name: Router
+          file: ./abis/Router.json
+      eventHandlers:
+        - event: AttestationRegistryUpdated(indexed address)
+          handler: handleAttestationRegistryUpdated
+        - event: ModuleRegistryUpdated(indexed address)
+          handler: handleModuleRegistryUpdated
+        - event: PortalRegistryUpdated(indexed address)
+          handler: handlePortalRegistryUpdated
+        - event: SchemaRegistryUpdated(indexed address)
+          handler: handleSchemaRegistryUpdated
+      file: ./src/router.ts

--- a/subgraph/subgraph.base-mainnet.yaml
+++ b/subgraph/subgraph.base-mainnet.yaml
@@ -99,14 +99,16 @@ dataSources:
     network: base
     source:
       abi: Router
-      address: "0x4E797aD91EE5d467D878E71C65D564D5b2026bE9"
-      startBlock: 7731130
+      address: "0x5A5A30aB3d6A6DD3463512793C7c36E9B47615e8"
+      startBlock: 13666866
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
       language: wasm/assemblyscript
       entities:
         - RegistryUpdate
+        - Audit
+        - AuditInformation
       abis:
         - name: Router
           file: ./abis/Router.json

--- a/subgraph/subgraph.base-sepolia.yaml
+++ b/subgraph/subgraph.base-sepolia.yaml
@@ -102,4 +102,21 @@ dataSources:
       address: "0x4E797aD91EE5d467D878E71C65D564D5b2026bE9"
       startBlock: 4716831
     mapping:
-      # ...same mapping configuration as arbitrum-one...
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - RegistryUpdate
+      abis:
+        - name: Router
+          file: ./abis/Router.json
+      eventHandlers:
+        - event: AttestationRegistryUpdated(indexed address)
+          handler: handleAttestationRegistryUpdated
+        - event: ModuleRegistryUpdated(indexed address)
+          handler: handleModuleRegistryUpdated
+        - event: PortalRegistryUpdated(indexed address)
+          handler: handlePortalRegistryUpdated
+        - event: SchemaRegistryUpdated(indexed address)
+          handler: handleSchemaRegistryUpdated
+      file: ./src/router.ts

--- a/subgraph/subgraph.base-sepolia.yaml
+++ b/subgraph/subgraph.base-sepolia.yaml
@@ -94,3 +94,12 @@ dataSources:
         - event: SchemaContextUpdated(indexed bytes32)
           handler: handleSchemaContextUpdated
       file: ./src/schema-registry.ts
+  - kind: ethereum
+    name: Router
+    network: base-sepolia
+    source:
+      abi: Router
+      address: "0x4E797aD91EE5d467D878E71C65D564D5b2026bE9"
+      startBlock: 4716831
+    mapping:
+      # ...same mapping configuration as arbitrum-one...

--- a/subgraph/subgraph.base-sepolia.yaml
+++ b/subgraph/subgraph.base-sepolia.yaml
@@ -99,14 +99,16 @@ dataSources:
     network: base-sepolia
     source:
       abi: Router
-      address: "0x4E797aD91EE5d467D878E71C65D564D5b2026bE9"
-      startBlock: 4716831
+      address: "0xE235826514945186227918325D3E5b5f873861A6"
+      startBlock: 9174253
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
       language: wasm/assemblyscript
       entities:
         - RegistryUpdate
+        - Audit
+        - AuditInformation
       abis:
         - name: Router
           file: ./abis/Router.json

--- a/subgraph/subgraph.bsc-mainnet.yaml
+++ b/subgraph/subgraph.bsc-mainnet.yaml
@@ -94,3 +94,29 @@ dataSources:
         - event: SchemaContextUpdated(indexed bytes32)
           handler: handleSchemaContextUpdated
       file: ./src/schema-registry.ts
+  - kind: ethereum
+    name: Router
+    network: bsc
+    source:
+      abi: Router
+      address: "0x4E797aD91EE5d467D878E71C65D564D5b2026bE9"
+      startBlock: 32972749
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - RegistryUpdate
+      abis:
+        - name: Router
+          file: ./abis/Router.json
+      eventHandlers:
+        - event: AttestationRegistryUpdated(indexed address)
+          handler: handleAttestationRegistryUpdated
+        - event: ModuleRegistryUpdated(indexed address)
+          handler: handleModuleRegistryUpdated
+        - event: PortalRegistryUpdated(indexed address)
+          handler: handlePortalRegistryUpdated
+        - event: SchemaRegistryUpdated(indexed address)
+          handler: handleSchemaRegistryUpdated
+      file: ./src/router.ts

--- a/subgraph/subgraph.bsc-mainnet.yaml
+++ b/subgraph/subgraph.bsc-mainnet.yaml
@@ -99,14 +99,16 @@ dataSources:
     network: bsc
     source:
       abi: Router
-      address: "0x4E797aD91EE5d467D878E71C65D564D5b2026bE9"
-      startBlock: 32972749
+      address: "0x7a5C1fAC7fF9908a8b2ED479e060619213116A47"
+      startBlock: 39759713
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
       language: wasm/assemblyscript
       entities:
         - RegistryUpdate
+        - Audit
+        - AuditInformation
       abis:
         - name: Router
           file: ./abis/Router.json

--- a/subgraph/subgraph.bsc-testnet.yaml
+++ b/subgraph/subgraph.bsc-testnet.yaml
@@ -94,3 +94,29 @@ dataSources:
         - event: SchemaContextUpdated(indexed bytes32)
           handler: handleSchemaContextUpdated
       file: ./src/schema-registry.ts
+  - kind: ethereum
+    name: Router
+    network: bsc-testnet
+    source:
+      abi: Router
+      address: "0x4E797aD91EE5d467D878E71C65D564D5b2026bE9"
+      startBlock: 34645879
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - RegistryUpdate
+      abis:
+        - name: Router
+          file: ./abis/Router.json
+      eventHandlers:
+        - event: AttestationRegistryUpdated(indexed address)
+          handler: handleAttestationRegistryUpdated
+        - event: ModuleRegistryUpdated(indexed address)
+          handler: handleModuleRegistryUpdated
+        - event: PortalRegistryUpdated(indexed address)
+          handler: handlePortalRegistryUpdated
+        - event: SchemaRegistryUpdated(indexed address)
+          handler: handleSchemaRegistryUpdated
+      file: ./src/router.ts

--- a/subgraph/subgraph.bsc-testnet.yaml
+++ b/subgraph/subgraph.bsc-testnet.yaml
@@ -96,17 +96,19 @@ dataSources:
       file: ./src/schema-registry.ts
   - kind: ethereum
     name: Router
-    network: bsc-testnet
+    network: chapel
     source:
       abi: Router
-      address: "0x4E797aD91EE5d467D878E71C65D564D5b2026bE9"
-      startBlock: 34645879
+      address: "0x90b8542d7288a83EC887229A7C727989C3b56209"
+      startBlock: 41312659
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.7
       language: wasm/assemblyscript
       entities:
         - RegistryUpdate
+        - Audit
+        - AuditInformation
       abis:
         - name: Router
           file: ./abis/Router.json

--- a/subgraph/subgraph.linea-mainnet.yaml
+++ b/subgraph/subgraph.linea-mainnet.yaml
@@ -94,3 +94,29 @@ dataSources:
         - event: SchemaContextUpdated(indexed bytes32)
           handler: handleSchemaContextUpdated
       file: ./src/schema-registry.ts
+  - kind: ethereum
+    name: Router
+    network: linea
+    source:
+      abi: Router
+      address: "0x5A5A30aB3d6A6DD3463512793C7c36E9B47615e8"
+      startBlock: 346691
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - RegistryUpdate
+      abis:
+        - name: Router
+          file: ./abis/Router.json
+      eventHandlers:
+        - event: AttestationRegistryUpdated(indexed address)
+          handler: handleAttestationRegistryUpdated
+        - event: ModuleRegistryUpdated(indexed address)
+          handler: handleModuleRegistryUpdated
+        - event: PortalRegistryUpdated(indexed address)
+          handler: handlePortalRegistryUpdated
+        - event: SchemaRegistryUpdated(indexed address)
+          handler: handleSchemaRegistryUpdated
+      file: ./src/router.ts

--- a/subgraph/subgraph.linea-mainnet.yaml
+++ b/subgraph/subgraph.linea-mainnet.yaml
@@ -94,3 +94,31 @@ dataSources:
         - event: SchemaContextUpdated(indexed bytes32)
           handler: handleSchemaContextUpdated
       file: ./src/schema-registry.ts
+  - kind: ethereum
+    name: Router
+    network: linea
+    source:
+      abi: Router
+      address: "0x4d3a380A03f3a18A5dC44b01119839D8674a552E"
+      startBlock: 346691
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - RegistryUpdate
+        - Audit
+        - AuditInformation
+      abis:
+        - name: Router
+          file: ./abis/Router.json
+      eventHandlers:
+        - event: AttestationRegistryUpdated(indexed address)
+          handler: handleAttestationRegistryUpdated
+        - event: ModuleRegistryUpdated(indexed address)
+          handler: handleModuleRegistryUpdated
+        - event: PortalRegistryUpdated(indexed address)
+          handler: handlePortalRegistryUpdated
+        - event: SchemaRegistryUpdated(indexed address)
+          handler: handleSchemaRegistryUpdated
+      file: ./src/router.ts

--- a/subgraph/subgraph.linea-mainnet.yaml
+++ b/subgraph/subgraph.linea-mainnet.yaml
@@ -94,29 +94,3 @@ dataSources:
         - event: SchemaContextUpdated(indexed bytes32)
           handler: handleSchemaContextUpdated
       file: ./src/schema-registry.ts
-  - kind: ethereum
-    name: Router
-    network: linea
-    source:
-      abi: Router
-      address: "0x5A5A30aB3d6A6DD3463512793C7c36E9B47615e8"
-      startBlock: 346691
-    mapping:
-      kind: ethereum/events
-      apiVersion: 0.0.7
-      language: wasm/assemblyscript
-      entities:
-        - RegistryUpdate
-      abis:
-        - name: Router
-          file: ./abis/Router.json
-      eventHandlers:
-        - event: AttestationRegistryUpdated(indexed address)
-          handler: handleAttestationRegistryUpdated
-        - event: ModuleRegistryUpdated(indexed address)
-          handler: handleModuleRegistryUpdated
-        - event: PortalRegistryUpdated(indexed address)
-          handler: handlePortalRegistryUpdated
-        - event: SchemaRegistryUpdated(indexed address)
-          handler: handleSchemaRegistryUpdated
-      file: ./src/router.ts

--- a/subgraph/subgraph.linea-sepolia.yaml
+++ b/subgraph/subgraph.linea-sepolia.yaml
@@ -94,3 +94,31 @@ dataSources:
         - event: SchemaContextUpdated(indexed bytes32)
           handler: handleSchemaContextUpdated
       file: ./src/schema-registry.ts
+  - kind: ethereum
+    name: Router
+    network: linea-sepolia
+    source:
+      abi: Router
+      address: "0xAfA952790492DDeB474012cEA12ba34B788ab39F"
+      startBlock: 487966
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - RegistryUpdate
+        - Audit
+        - AuditInformation
+      abis:
+        - name: Router
+          file: ./abis/Router.json
+      eventHandlers:
+        - event: AttestationRegistryUpdated(indexed address)
+          handler: handleAttestationRegistryUpdated
+        - event: ModuleRegistryUpdated(indexed address)
+          handler: handleModuleRegistryUpdated
+        - event: PortalRegistryUpdated(indexed address)
+          handler: handlePortalRegistryUpdated
+        - event: SchemaRegistryUpdated(indexed address)
+          handler: handleSchemaRegistryUpdated
+      file: ./src/router.ts


### PR DESCRIPTION
## What does this PR do?

This PR indexes the event emitted by the `Router` contract when it changes a Registry address.

### Related ticket

Fixes #290

### Type of change

- [ ] Chore
- [ ] Bug fix
- [X] New feature
- [ ] Documentation update

## Check list

- [X] My&nbsp;contribution&nbsp;follows&nbsp;the&nbsp;project's&nbsp;[guidelines](https://github.com/Consensys/linea-attestation-registry/blob/dev/CONTRIBUTING.md)
- [X] I have made corresponding changes to the documentation
- [X] Unit tests for any smart contract change
- [X] Contracts and functions are documented
