### PR TITLE
chore(sdk): Regroup transaction options in a dedicated object

### DIFF
--- a/sdk/src/dataMapper/AttestationDataMapper.ts
+++ b/sdk/src/dataMapper/AttestationDataMapper.ts
@@ -1,6 +1,6 @@
 import BaseDataMapper from "./BaseDataMapper";
 import { abiAttestationRegistry } from "../abi/AttestationRegistry";
-import { Attestation, AttestationPayload, OffchainData, Schema } from "../types";
+import { Attestation, AttestationPayload, OffchainData, Schema, TransactionOptions } from "../types";
 import { ActionType, Constants } from "../utils/constants";
 import { Attestation_filter, Attestation_orderBy, OrderDirection } from "../../.graphclient";
 import { handleError } from "../utils/errorHandler";
@@ -125,9 +125,9 @@ export default class AttestationDataMapper extends BaseDataMapper<
     return this.simulateContract("updateRouter", [routerAddress]);
   }
 
-  async updateRouter(routerAddress: Address, waitForConfirmation: boolean = false) {
+  async updateRouter(routerAddress: Address, options?: TransactionOptions) {
     const request = await this.simulateUpdateRouter(routerAddress);
-    return executeTransaction(request, this.web3Client, this.walletClient, waitForConfirmation);
+    return executeTransaction(request, this.web3Client, this.walletClient, options?.waitForConfirmation || false);
   }
 
   async simulateMassImport(portalAddress: Address, attestationPayloads: AttestationPayload[]) {
@@ -154,19 +154,19 @@ export default class AttestationDataMapper extends BaseDataMapper<
   async massImport(
     portalAddress: Address,
     attestationPayloads: AttestationPayload[],
-    waitForConfirmation: boolean = false,
+    options?: TransactionOptions,
   ) {
     const request = await this.simulateMassImport(portalAddress, attestationPayloads);
-    return executeTransaction(request, this.web3Client, this.walletClient, waitForConfirmation);
+    return executeTransaction(request, this.web3Client, this.walletClient, options?.waitForConfirmation || false);
   }
 
   async simulateIncrementVersionNumber() {
     return this.simulateContract("incrementVersionNumber", []);
   }
 
-  async incrementVersionNumber(waitForConfirmation: boolean = false) {
+  async incrementVersionNumber(options?: TransactionOptions) {
     const request = await this.simulateIncrementVersionNumber();
-    return executeTransaction(request, this.web3Client, this.walletClient, waitForConfirmation);
+    return executeTransaction(request, this.web3Client, this.walletClient, options?.waitForConfirmation || false);
   }
 
   async isRegistered(attestationId: string) {

--- a/sdk/src/dataMapper/AttestationDataMapper.ts
+++ b/sdk/src/dataMapper/AttestationDataMapper.ts
@@ -127,7 +127,7 @@ export default class AttestationDataMapper extends BaseDataMapper<
 
   async updateRouter(routerAddress: Address, options?: TransactionOptions) {
     const request = await this.simulateUpdateRouter(routerAddress);
-    return executeTransaction(request, this.web3Client, this.walletClient, options?.waitForConfirmation || false);
+    return executeTransaction(request, this.web3Client, this.walletClient, options?.waitForConfirmation);
   }
 
   async simulateMassImport(portalAddress: Address, attestationPayloads: AttestationPayload[]) {
@@ -151,13 +151,9 @@ export default class AttestationDataMapper extends BaseDataMapper<
     return this.simulateContract("massImport", [attestationPayloadsArg, portalAddress]);
   }
 
-  async massImport(
-    portalAddress: Address,
-    attestationPayloads: AttestationPayload[],
-    options?: TransactionOptions,
-  ) {
+  async massImport(portalAddress: Address, attestationPayloads: AttestationPayload[], options?: TransactionOptions) {
     const request = await this.simulateMassImport(portalAddress, attestationPayloads);
-    return executeTransaction(request, this.web3Client, this.walletClient, options?.waitForConfirmation || false);
+    return executeTransaction(request, this.web3Client, this.walletClient, options?.waitForConfirmation);
   }
 
   async simulateIncrementVersionNumber() {
@@ -166,7 +162,7 @@ export default class AttestationDataMapper extends BaseDataMapper<
 
   async incrementVersionNumber(options?: TransactionOptions) {
     const request = await this.simulateIncrementVersionNumber();
-    return executeTransaction(request, this.web3Client, this.walletClient, options?.waitForConfirmation || false);
+    return executeTransaction(request, this.web3Client, this.walletClient, options?.waitForConfirmation);
   }
 
   async isRegistered(attestationId: string) {

--- a/sdk/src/dataMapper/ModuleDataMapper.ts
+++ b/sdk/src/dataMapper/ModuleDataMapper.ts
@@ -23,7 +23,7 @@ export default class ModuleDataMapper extends BaseDataMapper<Module, Module_filt
 
   async updateRouter(routerAddress: Address, options?: TransactionOptions) {
     const request = await this.simulateUpdateRouter(routerAddress);
-    return executeTransaction(request, this.web3Client, this.walletClient, options?.waitForConfirmation || false);
+    return executeTransaction(request, this.web3Client, this.walletClient, options?.waitForConfirmation);
   }
 
   async simulateRegister(name: string, description: string, moduleAddress: Address) {
@@ -32,13 +32,14 @@ export default class ModuleDataMapper extends BaseDataMapper<Module, Module_filt
 
   async register(name: string, description: string, moduleAddress: Address, options?: TransactionOptions) {
     const request = await this.simulateRegister(name, description, moduleAddress);
-    return executeTransaction(request, this.web3Client, this.walletClient, options?.waitForConfirmation || false);
+    return executeTransaction(request, this.web3Client, this.walletClient, options?.waitForConfirmation);
   }
 
   async simulateRunModules(
     modulesAddresses: Address[],
     attestationPayload: AttestationPayload,
     validationPayloads: string[],
+    value?: bigint,
   ) {
     const matchingSchema = await this.veraxSdk.schema.findOneById(attestationPayload.schemaId);
     if (!matchingSchema) {
@@ -49,6 +50,7 @@ export default class ModuleDataMapper extends BaseDataMapper<Module, Module_filt
       modulesAddresses,
       [attestationPayload.schemaId, attestationPayload.expirationDate, attestationPayload.subject, attestationData],
       validationPayloads,
+      value ? `0x${value}` : undefined,
     ]);
   }
 
@@ -58,8 +60,13 @@ export default class ModuleDataMapper extends BaseDataMapper<Module, Module_filt
     validationPayloads: string[],
     options?: TransactionOptions,
   ) {
-    const request = await this.simulateRunModules(modulesAddresses, attestationPayload, validationPayloads);
-    return executeTransaction(request, this.web3Client, this.walletClient, options?.waitForConfirmation || false);
+    const request = await this.simulateRunModules(
+      modulesAddresses,
+      attestationPayload,
+      validationPayloads,
+      options?.value,
+    );
+    return executeTransaction(request, this.web3Client, this.walletClient, options?.waitForConfirmation);
   }
 
   async simulateBulkRunModules(
@@ -92,7 +99,7 @@ export default class ModuleDataMapper extends BaseDataMapper<Module, Module_filt
     options?: TransactionOptions,
   ) {
     const request = await this.simulateBulkRunModules(modulesAddresses, attestationPayloads, validationPayloads);
-    return executeTransaction(request, this.web3Client, this.walletClient, options?.waitForConfirmation || false);
+    return executeTransaction(request, this.web3Client, this.walletClient, options?.waitForConfirmation);
   }
 
   async isContractAddress(contractAddress: Address) {

--- a/sdk/src/dataMapper/ModuleDataMapper.ts
+++ b/sdk/src/dataMapper/ModuleDataMapper.ts
@@ -1,6 +1,6 @@
 import { Address } from "viem";
 import { Module_filter, Module_orderBy } from "../../.graphclient";
-import { AttestationPayload, Module } from "../types";
+import { AttestationPayload, Module, TransactionOptions } from "../types";
 import { ActionType } from "../utils/constants";
 import BaseDataMapper from "./BaseDataMapper";
 import { abiModuleRegistry } from "../abi/ModuleRegistry";
@@ -21,25 +21,24 @@ export default class ModuleDataMapper extends BaseDataMapper<Module, Module_filt
     return this.simulateContract("updateRouter", [routerAddress]);
   }
 
-  async updateRouter(routerAddress: Address, waitForConfirmation: boolean = false) {
+  async updateRouter(routerAddress: Address, options?: TransactionOptions) {
     const request = await this.simulateUpdateRouter(routerAddress);
-    return executeTransaction(request, this.web3Client, this.walletClient, waitForConfirmation);
+    return executeTransaction(request, this.web3Client, this.walletClient, options?.waitForConfirmation || false);
   }
 
   async simulateRegister(name: string, description: string, moduleAddress: Address) {
     return this.simulateContract("register", [name, description, moduleAddress]);
   }
 
-  async register(name: string, description: string, moduleAddress: Address, waitForConfirmation: boolean = false) {
+  async register(name: string, description: string, moduleAddress: Address, options?: TransactionOptions) {
     const request = await this.simulateRegister(name, description, moduleAddress);
-    return executeTransaction(request, this.web3Client, this.walletClient, waitForConfirmation);
+    return executeTransaction(request, this.web3Client, this.walletClient, options?.waitForConfirmation || false);
   }
 
   async simulateRunModules(
     modulesAddresses: Address[],
     attestationPayload: AttestationPayload,
     validationPayloads: string[],
-    value: number,
   ) {
     const matchingSchema = await this.veraxSdk.schema.findOneById(attestationPayload.schemaId);
     if (!matchingSchema) {
@@ -50,7 +49,6 @@ export default class ModuleDataMapper extends BaseDataMapper<Module, Module_filt
       modulesAddresses,
       [attestationPayload.schemaId, attestationPayload.expirationDate, attestationPayload.subject, attestationData],
       validationPayloads,
-      `0x${value}`,
     ]);
   }
 
@@ -58,11 +56,10 @@ export default class ModuleDataMapper extends BaseDataMapper<Module, Module_filt
     modulesAddresses: Address[],
     attestationPayload: AttestationPayload,
     validationPayloads: string[],
-    value: number,
-    waitForConfirmation: boolean = false,
+    options?: TransactionOptions,
   ) {
-    const request = await this.simulateRunModules(modulesAddresses, attestationPayload, validationPayloads, value);
-    return executeTransaction(request, this.web3Client, this.walletClient, waitForConfirmation);
+    const request = await this.simulateRunModules(modulesAddresses, attestationPayload, validationPayloads);
+    return executeTransaction(request, this.web3Client, this.walletClient, options?.waitForConfirmation || false);
   }
 
   async simulateBulkRunModules(
@@ -92,10 +89,10 @@ export default class ModuleDataMapper extends BaseDataMapper<Module, Module_filt
     modulesAddresses: Address[],
     attestationPayloads: AttestationPayload[],
     validationPayloads: string[][],
-    waitForConfirmation: boolean = false,
+    options?: TransactionOptions,
   ) {
     const request = await this.simulateBulkRunModules(modulesAddresses, attestationPayloads, validationPayloads);
-    return executeTransaction(request, this.web3Client, this.walletClient, waitForConfirmation);
+    return executeTransaction(request, this.web3Client, this.walletClient, options?.waitForConfirmation || false);
   }
 
   async isContractAddress(contractAddress: Address) {

--- a/sdk/src/dataMapper/PortalDataMapper.ts
+++ b/sdk/src/dataMapper/PortalDataMapper.ts
@@ -40,7 +40,7 @@ export default class PortalDataMapper extends BaseDataMapper<Portal, Portal_filt
         [attestationPayload.schemaId, attestationPayload.expirationDate, attestationPayload.subject, attestationData],
         validationPayloads,
       ],
-      options?.value || 0n,
+      options?.value,
       options?.customAbi,
     );
   }
@@ -52,7 +52,7 @@ export default class PortalDataMapper extends BaseDataMapper<Portal, Portal_filt
     options?: TransactionOptions,
   ) {
     const request = await this.simulateAttest(portalAddress, attestationPayload, validationPayloads, options);
-    return executeTransaction(request, this.web3Client, this.walletClient, options?.waitForConfirmation || false);
+    return executeTransaction(request, this.web3Client, this.walletClient, options?.waitForConfirmation);
   }
 
   async simulateBulkAttest(
@@ -81,7 +81,7 @@ export default class PortalDataMapper extends BaseDataMapper<Portal, Portal_filt
       portalAddress,
       "bulkAttest",
       [attestationPayloadsArg, validationPayloads],
-      options?.value || 0n,
+      options?.value,
       options?.customAbi,
     );
   }
@@ -104,7 +104,7 @@ export default class PortalDataMapper extends BaseDataMapper<Portal, Portal_filt
         [attestationPayload.schemaId, attestationPayload.expirationDate, attestationPayload.subject, attestationData],
         validationPayloads,
       ],
-      options?.value || 0n,
+      options?.value,
       options?.customAbi,
     );
   }
@@ -115,13 +115,8 @@ export default class PortalDataMapper extends BaseDataMapper<Portal, Portal_filt
     validationPayloads: string[],
     options?: TransactionOptions,
   ) {
-    const request = await this.simulateAttestV2(
-      portalAddress,
-      attestationPayload,
-      validationPayloads,
-      options,
-    );
-    return executeTransaction(request, this.web3Client, this.walletClient, options?.waitForConfirmation || false);
+    const request = await this.simulateAttestV2(portalAddress, attestationPayload, validationPayloads, options);
+    return executeTransaction(request, this.web3Client, this.walletClient, options?.waitForConfirmation);
   }
 
   async bulkAttest(
@@ -131,29 +126,31 @@ export default class PortalDataMapper extends BaseDataMapper<Portal, Portal_filt
     options?: TransactionOptions,
   ) {
     const request = await this.simulateBulkAttest(portalAddress, attestationPayloads, validationPayloads, options);
-    return executeTransaction(request, this.web3Client, this.walletClient, options?.waitForConfirmation || false);
+    return executeTransaction(request, this.web3Client, this.walletClient, options?.waitForConfirmation);
   }
 
   async simulateRevoke(portalAddress: Address, attestationId: string, options?: TransactionOptions) {
-    return this.simulatePortalContract(portalAddress, "revoke", [attestationId], options?.value || 0n, options?.customAbi);
+    return this.simulatePortalContract(portalAddress, "revoke", [attestationId], options?.value, options?.customAbi);
   }
 
   async revoke(portalAddress: Address, attestationId: string, options?: TransactionOptions) {
     const request = await this.simulateRevoke(portalAddress, attestationId, options);
-    return executeTransaction(request, this.web3Client, this.walletClient, options?.waitForConfirmation || false);
+    return executeTransaction(request, this.web3Client, this.walletClient, options?.waitForConfirmation);
   }
 
   async simulateBulkRevoke(portalAddress: Address, attestationIds: string[], options?: TransactionOptions) {
-    return this.simulatePortalContract(portalAddress, "bulkRevoke", [attestationIds], options?.value || 0n, options?.customAbi);
+    return this.simulatePortalContract(
+      portalAddress,
+      "bulkRevoke",
+      [attestationIds],
+      options?.value,
+      options?.customAbi,
+    );
   }
 
-  async bulkRevoke(
-    portalAddress: Address,
-    attestationIds: string[],
-    options?: TransactionOptions,
-  ) {
+  async bulkRevoke(portalAddress: Address, attestationIds: string[], options?: TransactionOptions) {
     const request = await this.simulateBulkRevoke(portalAddress, attestationIds, options);
-    return executeTransaction(request, this.web3Client, this.walletClient, options?.waitForConfirmation || false);
+    return executeTransaction(request, this.web3Client, this.walletClient, options?.waitForConfirmation);
   }
 
   async simulateReplace(
@@ -176,7 +173,7 @@ export default class PortalDataMapper extends BaseDataMapper<Portal, Portal_filt
         [attestationPayload.schemaId, attestationPayload.expirationDate, attestationPayload.subject, attestationData],
         validationPayloads,
       ],
-      options?.value || 0n,
+      options?.value,
       options?.customAbi,
     );
   }
@@ -195,7 +192,7 @@ export default class PortalDataMapper extends BaseDataMapper<Portal, Portal_filt
       validationPayloads,
       options,
     );
-    return executeTransaction(request, this.web3Client, this.walletClient, options?.waitForConfirmation || false);
+    return executeTransaction(request, this.web3Client, this.walletClient, options?.waitForConfirmation);
   }
 
   async simulateBulkReplace(
@@ -224,7 +221,7 @@ export default class PortalDataMapper extends BaseDataMapper<Portal, Portal_filt
       portalAddress,
       "bulkReplace",
       [attestationIds, attestationPayloadsArg, validationPayloads],
-      options?.value || 0n,
+      options?.value,
       options?.customAbi,
     );
   }
@@ -243,7 +240,7 @@ export default class PortalDataMapper extends BaseDataMapper<Portal, Portal_filt
       validationPayloads,
       options,
     );
-    return executeTransaction(request, this.web3Client, this.walletClient, options?.waitForConfirmation || false);
+    return executeTransaction(request, this.web3Client, this.walletClient, options?.waitForConfirmation);
   }
 
   async simulateRegister(id: Address, name: string, description: string, isRevocable: boolean, ownerName: string) {
@@ -259,7 +256,7 @@ export default class PortalDataMapper extends BaseDataMapper<Portal, Portal_filt
     options?: TransactionOptions,
   ) {
     const request = await this.simulateRegister(id, name, description, isRevocable, ownerName);
-    return executeTransaction(request, this.web3Client, this.walletClient, options?.waitForConfirmation || false);
+    return executeTransaction(request, this.web3Client, this.walletClient, options?.waitForConfirmation);
   }
 
   async simulateDeployDefaultPortal(
@@ -287,7 +284,7 @@ export default class PortalDataMapper extends BaseDataMapper<Portal, Portal_filt
     options?: TransactionOptions,
   ) {
     const request = await this.simulateDeployDefaultPortal(modules, name, description, isRevocable, ownerName);
-    return executeTransaction(request, this.web3Client, this.walletClient, options?.waitForConfirmation || false);
+    return executeTransaction(request, this.web3Client, this.walletClient, options?.waitForConfirmation);
   }
 
   async getPortalByAddress(address: Address) {

--- a/sdk/src/dataMapper/PortalDataMapper.ts
+++ b/sdk/src/dataMapper/PortalDataMapper.ts
@@ -1,4 +1,4 @@
-import { AttestationPayload, Portal } from "../types";
+import { AttestationPayload, Portal, TransactionOptions } from "../types";
 import { ActionType } from "../utils/constants";
 import BaseDataMapper from "./BaseDataMapper";
 import { abiDefaultPortal } from "../abi/DefaultPortal";
@@ -26,8 +26,7 @@ export default class PortalDataMapper extends BaseDataMapper<Portal, Portal_filt
     portalAddress: Address,
     attestationPayload: AttestationPayload,
     validationPayloads: string[],
-    value: bigint = 0n,
-    customAbi?: Abi,
+    options?: TransactionOptions,
   ) {
     const matchingSchema = await this.veraxSdk.schema.findOneById(attestationPayload.schemaId);
     if (!matchingSchema) {
@@ -41,8 +40,8 @@ export default class PortalDataMapper extends BaseDataMapper<Portal, Portal_filt
         [attestationPayload.schemaId, attestationPayload.expirationDate, attestationPayload.subject, attestationData],
         validationPayloads,
       ],
-      value,
-      customAbi,
+      options?.value || 0n,
+      options?.customAbi,
     );
   }
 
@@ -50,19 +49,17 @@ export default class PortalDataMapper extends BaseDataMapper<Portal, Portal_filt
     portalAddress: Address,
     attestationPayload: AttestationPayload,
     validationPayloads: string[],
-    waitForConfirmation: boolean = false,
-    value: bigint = 0n,
-    customAbi?: Abi,
+    options?: TransactionOptions,
   ) {
-    const request = await this.simulateAttest(portalAddress, attestationPayload, validationPayloads, value, customAbi);
-    return executeTransaction(request, this.web3Client, this.walletClient, waitForConfirmation);
+    const request = await this.simulateAttest(portalAddress, attestationPayload, validationPayloads, options);
+    return executeTransaction(request, this.web3Client, this.walletClient, options?.waitForConfirmation || false);
   }
 
   async simulateBulkAttest(
     portalAddress: Address,
     attestationPayloads: AttestationPayload[],
     validationPayloads: string[][],
-    customAbi?: Abi,
+    options?: TransactionOptions,
   ) {
     const attestationPayloadsArg = [];
 
@@ -84,8 +81,8 @@ export default class PortalDataMapper extends BaseDataMapper<Portal, Portal_filt
       portalAddress,
       "bulkAttest",
       [attestationPayloadsArg, validationPayloads],
-      0n,
-      customAbi,
+      options?.value || 0n,
+      options?.customAbi,
     );
   }
 
@@ -93,8 +90,7 @@ export default class PortalDataMapper extends BaseDataMapper<Portal, Portal_filt
     portalAddress: Address,
     attestationPayload: AttestationPayload,
     validationPayloads: string[],
-    value: bigint = 0n,
-    customAbi?: Abi,
+    options?: TransactionOptions,
   ) {
     const matchingSchema = await this.veraxSdk.schema.findOneById(attestationPayload.schemaId);
     if (!matchingSchema) {
@@ -108,8 +104,8 @@ export default class PortalDataMapper extends BaseDataMapper<Portal, Portal_filt
         [attestationPayload.schemaId, attestationPayload.expirationDate, attestationPayload.subject, attestationData],
         validationPayloads,
       ],
-      value,
-      customAbi,
+      options?.value || 0n,
+      options?.customAbi,
     );
   }
 
@@ -117,52 +113,47 @@ export default class PortalDataMapper extends BaseDataMapper<Portal, Portal_filt
     portalAddress: Address,
     attestationPayload: AttestationPayload,
     validationPayloads: string[],
-    waitForConfirmation: boolean = false,
-    value: bigint = 0n,
-    customAbi?: Abi,
+    options?: TransactionOptions,
   ) {
     const request = await this.simulateAttestV2(
       portalAddress,
       attestationPayload,
       validationPayloads,
-      value,
-      customAbi,
+      options,
     );
-    return executeTransaction(request, this.web3Client, this.walletClient, waitForConfirmation);
+    return executeTransaction(request, this.web3Client, this.walletClient, options?.waitForConfirmation || false);
   }
 
   async bulkAttest(
     portalAddress: Address,
     attestationPayloads: AttestationPayload[],
     validationPayloads: string[][],
-    waitForConfirmation: boolean = false,
-    customAbi?: Abi,
+    options?: TransactionOptions,
   ) {
-    const request = await this.simulateBulkAttest(portalAddress, attestationPayloads, validationPayloads, customAbi);
-    return executeTransaction(request, this.web3Client, this.walletClient, waitForConfirmation);
+    const request = await this.simulateBulkAttest(portalAddress, attestationPayloads, validationPayloads, options);
+    return executeTransaction(request, this.web3Client, this.walletClient, options?.waitForConfirmation || false);
   }
 
-  async simulateRevoke(portalAddress: Address, attestationId: string, customAbi?: Abi) {
-    return this.simulatePortalContract(portalAddress, "revoke", [attestationId], 0n, customAbi);
+  async simulateRevoke(portalAddress: Address, attestationId: string, options?: TransactionOptions) {
+    return this.simulatePortalContract(portalAddress, "revoke", [attestationId], options?.value || 0n, options?.customAbi);
   }
 
-  async revoke(portalAddress: Address, attestationId: string, waitForConfirmation: boolean = false, customAbi?: Abi) {
-    const request = await this.simulateRevoke(portalAddress, attestationId, customAbi);
-    return executeTransaction(request, this.web3Client, this.walletClient, waitForConfirmation);
+  async revoke(portalAddress: Address, attestationId: string, options?: TransactionOptions) {
+    const request = await this.simulateRevoke(portalAddress, attestationId, options);
+    return executeTransaction(request, this.web3Client, this.walletClient, options?.waitForConfirmation || false);
   }
 
-  async simulateBulkRevoke(portalAddress: Address, attestationIds: string[], customAbi?: Abi) {
-    return this.simulatePortalContract(portalAddress, "bulkRevoke", [attestationIds], 0n, customAbi);
+  async simulateBulkRevoke(portalAddress: Address, attestationIds: string[], options?: TransactionOptions) {
+    return this.simulatePortalContract(portalAddress, "bulkRevoke", [attestationIds], options?.value || 0n, options?.customAbi);
   }
 
   async bulkRevoke(
     portalAddress: Address,
     attestationIds: string[],
-    waitForConfirmation: boolean = false,
-    customAbi?: Abi,
+    options?: TransactionOptions,
   ) {
-    const request = await this.simulateBulkRevoke(portalAddress, attestationIds, customAbi);
-    return executeTransaction(request, this.web3Client, this.walletClient, waitForConfirmation);
+    const request = await this.simulateBulkRevoke(portalAddress, attestationIds, options);
+    return executeTransaction(request, this.web3Client, this.walletClient, options?.waitForConfirmation || false);
   }
 
   async simulateReplace(
@@ -170,7 +161,7 @@ export default class PortalDataMapper extends BaseDataMapper<Portal, Portal_filt
     attestationId: string,
     attestationPayload: AttestationPayload,
     validationPayloads: string[],
-    customAbi?: Abi,
+    options?: TransactionOptions,
   ) {
     const matchingSchema = await this.veraxSdk.schema.findOneById(attestationPayload.schemaId);
     if (!matchingSchema) {
@@ -185,8 +176,8 @@ export default class PortalDataMapper extends BaseDataMapper<Portal, Portal_filt
         [attestationPayload.schemaId, attestationPayload.expirationDate, attestationPayload.subject, attestationData],
         validationPayloads,
       ],
-      0n,
-      customAbi,
+      options?.value || 0n,
+      options?.customAbi,
     );
   }
 
@@ -195,17 +186,16 @@ export default class PortalDataMapper extends BaseDataMapper<Portal, Portal_filt
     attestationId: string,
     attestationPayload: AttestationPayload,
     validationPayloads: string[],
-    waitForConfirmation: boolean = false,
-    customAbi?: Abi,
+    options?: TransactionOptions,
   ) {
     const request = await this.simulateReplace(
       portalAddress,
       attestationId,
       attestationPayload,
       validationPayloads,
-      customAbi,
+      options,
     );
-    return executeTransaction(request, this.web3Client, this.walletClient, waitForConfirmation);
+    return executeTransaction(request, this.web3Client, this.walletClient, options?.waitForConfirmation || false);
   }
 
   async simulateBulkReplace(
@@ -213,7 +203,7 @@ export default class PortalDataMapper extends BaseDataMapper<Portal, Portal_filt
     attestationIds: string[],
     attestationPayloads: AttestationPayload[],
     validationPayloads: string[][],
-    customAbi?: Abi,
+    options?: TransactionOptions,
   ) {
     const attestationPayloadsArg = [];
 
@@ -234,8 +224,8 @@ export default class PortalDataMapper extends BaseDataMapper<Portal, Portal_filt
       portalAddress,
       "bulkReplace",
       [attestationIds, attestationPayloadsArg, validationPayloads],
-      0n,
-      customAbi,
+      options?.value || 0n,
+      options?.customAbi,
     );
   }
 
@@ -244,17 +234,16 @@ export default class PortalDataMapper extends BaseDataMapper<Portal, Portal_filt
     attestationIds: string[],
     attestationPayloads: AttestationPayload[],
     validationPayloads: string[][],
-    waitForConfirmation: boolean = false,
-    customAbi?: Abi,
+    options?: TransactionOptions,
   ) {
     const request = await this.simulateBulkReplace(
       portalAddress,
       attestationIds,
       attestationPayloads,
       validationPayloads,
-      customAbi,
+      options,
     );
-    return executeTransaction(request, this.web3Client, this.walletClient, waitForConfirmation);
+    return executeTransaction(request, this.web3Client, this.walletClient, options?.waitForConfirmation || false);
   }
 
   async simulateRegister(id: Address, name: string, description: string, isRevocable: boolean, ownerName: string) {
@@ -267,10 +256,10 @@ export default class PortalDataMapper extends BaseDataMapper<Portal, Portal_filt
     description: string,
     isRevocable: boolean,
     ownerName: string,
-    waitForConfirmation: boolean = false,
+    options?: TransactionOptions,
   ) {
     const request = await this.simulateRegister(id, name, description, isRevocable, ownerName);
-    return executeTransaction(request, this.web3Client, this.walletClient, waitForConfirmation);
+    return executeTransaction(request, this.web3Client, this.walletClient, options?.waitForConfirmation || false);
   }
 
   async simulateDeployDefaultPortal(
@@ -295,10 +284,10 @@ export default class PortalDataMapper extends BaseDataMapper<Portal, Portal_filt
     description: string,
     isRevocable: boolean,
     ownerName: string,
-    waitForConfirmation: boolean = false,
+    options?: TransactionOptions,
   ) {
     const request = await this.simulateDeployDefaultPortal(modules, name, description, isRevocable, ownerName);
-    return executeTransaction(request, this.web3Client, this.walletClient, waitForConfirmation);
+    return executeTransaction(request, this.web3Client, this.walletClient, options?.waitForConfirmation || false);
   }
 
   async getPortalByAddress(address: Address) {

--- a/sdk/src/dataMapper/SchemaDataMapper.ts
+++ b/sdk/src/dataMapper/SchemaDataMapper.ts
@@ -22,27 +22,18 @@ export default class SchemaDataMapper extends BaseDataMapper<Schema, Schema_filt
     return this.simulateContract("updateRouter", [routerAddress]);
   }
 
-  async updateRouter(
-    routerAddress: Address,
-    options?: TransactionOptions,
-  ): Promise<Partial<TransactionReceipt>> {
+  async updateRouter(routerAddress: Address, options?: TransactionOptions): Promise<Partial<TransactionReceipt>> {
     const request = await this.simulateUpdateRouter(routerAddress);
-    return executeTransaction(request, this.web3Client, this.walletClient, options?.waitForConfirmation || false);
+    return executeTransaction(request, this.web3Client, this.walletClient, options?.waitForConfirmation);
   }
 
   async simulateCreate(name: string, description: string, context: string, schemaString: string) {
     return this.simulateContract("createSchema", [name, description, context, schemaString]);
   }
 
-  async create(
-    name: string,
-    description: string,
-    context: string,
-    schemaString: string,
-    options?: TransactionOptions,
-  ) {
+  async create(name: string, description: string, context: string, schemaString: string, options?: TransactionOptions) {
     const request = await this.simulateCreate(name, description, context, schemaString);
-    return executeTransaction(request, this.web3Client, this.walletClient, options?.waitForConfirmation || false);
+    return executeTransaction(request, this.web3Client, this.walletClient, options?.waitForConfirmation);
   }
 
   async simulateUpdateContext(schemaId: string, context: string) {
@@ -51,7 +42,7 @@ export default class SchemaDataMapper extends BaseDataMapper<Schema, Schema_filt
 
   async updateContext(schemaId: string, context: string, options?: TransactionOptions) {
     const request = await this.simulateUpdateContext(schemaId, context);
-    return executeTransaction(request, this.web3Client, this.walletClient, options?.waitForConfirmation || false);
+    return executeTransaction(request, this.web3Client, this.walletClient, options?.waitForConfirmation);
   }
 
   async getIdFromSchemaString(schema: string) {

--- a/sdk/src/dataMapper/SchemaDataMapper.ts
+++ b/sdk/src/dataMapper/SchemaDataMapper.ts
@@ -1,6 +1,6 @@
 import { Address, TransactionReceipt } from "viem";
 import { Schema_filter, Schema_orderBy } from "../../.graphclient";
-import { Schema } from "../types";
+import { Schema, TransactionOptions } from "../types";
 import { ActionType } from "../utils/constants";
 import BaseDataMapper from "./BaseDataMapper";
 import { abiSchemaRegistry } from "../abi/SchemaRegistry";
@@ -24,10 +24,10 @@ export default class SchemaDataMapper extends BaseDataMapper<Schema, Schema_filt
 
   async updateRouter(
     routerAddress: Address,
-    waitForConfirmation: boolean = false,
+    options?: TransactionOptions,
   ): Promise<Partial<TransactionReceipt>> {
     const request = await this.simulateUpdateRouter(routerAddress);
-    return executeTransaction(request, this.web3Client, this.walletClient, waitForConfirmation);
+    return executeTransaction(request, this.web3Client, this.walletClient, options?.waitForConfirmation || false);
   }
 
   async simulateCreate(name: string, description: string, context: string, schemaString: string) {
@@ -39,19 +39,19 @@ export default class SchemaDataMapper extends BaseDataMapper<Schema, Schema_filt
     description: string,
     context: string,
     schemaString: string,
-    waitForConfirmation: boolean = false,
+    options?: TransactionOptions,
   ) {
     const request = await this.simulateCreate(name, description, context, schemaString);
-    return executeTransaction(request, this.web3Client, this.walletClient, waitForConfirmation);
+    return executeTransaction(request, this.web3Client, this.walletClient, options?.waitForConfirmation || false);
   }
 
   async simulateUpdateContext(schemaId: string, context: string) {
     return this.simulateContract("updateContext", [schemaId, context]);
   }
 
-  async updateContext(schemaId: string, context: string, waitForConfirmation: boolean = false) {
+  async updateContext(schemaId: string, context: string, options?: TransactionOptions) {
     const request = await this.simulateUpdateContext(schemaId, context);
-    return executeTransaction(request, this.web3Client, this.walletClient, waitForConfirmation);
+    return executeTransaction(request, this.web3Client, this.walletClient, options?.waitForConfirmation || false);
   }
 
   async getIdFromSchemaString(schema: string) {

--- a/sdk/src/types/index.ts
+++ b/sdk/src/types/index.ts
@@ -1,4 +1,4 @@
-import { Address, Chain, EIP1193Provider } from "viem";
+import { Address, Abi, Chain, EIP1193Provider } from "viem";
 import { SDKMode } from "../utils/constants";
 
 export interface Conf {
@@ -70,6 +70,12 @@ export type OnChainModule = {
   moduleAddress: Address; // The address of the module.
   name: string; // The name of the module.
   description: string; // A description of the module.
+};
+
+export type TransactionOptions = {
+  waitForConfirmation?: boolean;
+  value?: bigint;
+  customAbi?: Abi;
 };
 
 declare global {


### PR DESCRIPTION
## What does this PR do?
This PR implements the TransactionOptions object to standardize the technical parameters for functions generating on-chain transactions. It refactors several data mapper files to use this new type, improving code maintainability and consistency across the codebase.

Created a new `TransactionOptions` type in `types/index.ts` with the following properties:
- `waitForConfirmation?: boolean` - Indicates whether to wait for transaction confirmation
- `value?: bigint` - Represents the value to send with the transaction
- `customAbi?: Abi` - Allows for a custom ABI to be used for the transaction

Refactored the following files to utilize the new TransactionOptions type:
- PortalDataMapper.ts
- AttestationDataMapper.ts
- SchemaDataMapper.ts
- ModuleDataMapper.ts

Updated all methods generating on-chain transactions to accept the TransactionOptions object instead of individual parameters.

### Related ticket

Fixes #858

### Type of change

- [x] Chore
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update

## Check list

- [x] My&nbsp;contribution&nbsp;follows&nbsp;the&nbsp;project's&nbsp;[guidelines](https://github.com/Consensys/linea-attestation-registry/blob/dev/CONTRIBUTING.md)
- [x] I have made corresponding changes to the documentation
- [x] Unit tests for any smart contract change
- [x] Contracts and functions are documented