### PR TITLE
bug(explorer): Explorer doesn't show a decoded payload when it's done SDK-side only

### DIFF
--- a/explorer/package.json
+++ b/explorer/package.json
@@ -28,7 +28,7 @@
     "@radix-ui/react-dropdown-menu": "^2.0.6",
     "@tanstack/react-query": "^5.61.4",
     "@tanstack/react-table": "^8.10.7",
-    "@verax-attestation-registry/verax-sdk": "2.3.0",
+    "@verax-attestation-registry/verax-sdk": "2.3.1",
     "abitype": "^0.10.3",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.0.0",

--- a/explorer/src/pages/Attestation/components/AttestationData/index.tsx
+++ b/explorer/src/pages/Attestation/components/AttestationData/index.tsx
@@ -10,7 +10,7 @@ import { HelperIndicator } from "@/components/HelperIndicator";
 import { EMPTY_STRING, THOUSAND } from "@/constants";
 import useWindowDimensions from "@/hooks/useWindowDimensions";
 
-import { getAttestationData, isDecodedData } from "./utils";
+import { getAttestationData } from "./utils";
 
 export const AttestationData: React.FC<Attestation> = ({ ...attestation }) => {
   const screen = useWindowDimensions();
@@ -21,7 +21,7 @@ export const AttestationData: React.FC<Attestation> = ({ ...attestation }) => {
   const { isDarkMode } = useTernaryDarkMode();
 
   const { decodedData, decodedPayload } = attestation;
-  const data = isDecodedData(decodedPayload, decodedData) ? getAttestationData(decodedPayload ?? decodedData) : null;
+  const data = getAttestationData(decodedPayload ?? decodedData);
 
   const handleCopy = (text: string, result: boolean) => {
     if (!result || !text) return;

--- a/explorer/src/pages/Attestation/components/AttestationData/utils.ts
+++ b/explorer/src/pages/Attestation/components/AttestationData/utils.ts
@@ -1,11 +1,9 @@
-export const getAttestationData = (decodedPayload: unknown): string => {
-  decodedPayload = Array.isArray(decodedPayload) && decodedPayload.length === 1 ? decodedPayload[0] : decodedPayload;
-  return JSON.stringify(decodedPayload, (_key, value) => (typeof value === "bigint" ? value.toString() : value));
-};
+export const getAttestationData = (decodedPayload: unknown): string | null => {
+  if (!decodedPayload) return null;
 
-export const isDecodedData = (decodedPayload?: unknown, decodedData?: Array<string>): boolean => {
-  if (Array.isArray(decodedPayload) && !decodedPayload.length) return false;
-  if (!decodedData?.length) return false;
-  if (decodedData.length === 1 && decodedData[0] === "NOT DECODED") return false;
-  return Boolean(decodedPayload || decodedData);
+  const payload = Array.isArray(decodedPayload) && decodedPayload.length === 1 ? decodedPayload[0] : decodedPayload;
+
+  if (payload === "NOT DECODED") return null;
+
+  return JSON.stringify(payload, (_, value) => (typeof value === "bigint" ? value.toString() : value));
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,8 +107,8 @@ importers:
         specifier: ^8.10.7
         version: 8.17.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@verax-attestation-registry/verax-sdk':
-        specifier: 2.3.0
-        version: 2.3.0(@graphql-mesh/types@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(@types/node@20.12.12)(@types/react@18.3.2)(bufferutil@4.0.9)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1)(typescript@5.2.2)(utf-8-validate@5.0.10)
+        specifier: 2.3.1
+        version: 2.3.1(@graphql-mesh/types@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(@types/node@20.12.12)(@types/react@18.3.2)(bufferutil@4.0.9)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1)(typescript@5.2.2)(utf-8-validate@5.0.10)
       abitype:
         specifier: ^0.10.3
         version: 0.10.3(typescript@5.2.2)
@@ -5327,8 +5327,8 @@ packages:
   '@ungap/structured-clone@1.2.0':
     resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
 
-  '@verax-attestation-registry/verax-sdk@2.3.0':
-    resolution: {integrity: sha512-YsohKMZVs7NCOIzM1s5ji84Qhxzzat/76oZvX38qf1f3nuSnUCoO2NmDVjZ1UIzo/jL0EwSR7rWUyNGluBSGUA==}
+  '@verax-attestation-registry/verax-sdk@2.3.1':
+    resolution: {integrity: sha512-Q1K3Mb63edoFPhX1nEJP8NOwbv+M1Tj7hk1SFxgA36KaQ6uTX36g9KAgSBVUNrKorSp9F6bwVQvkiOwaxQP6CQ==}
 
   '@vercel/webpack-asset-relocator-loader@1.7.3':
     resolution: {integrity: sha512-vizrI18v8Lcb1PmNNUBz7yxPxxXoOeuaVEjTG9MjvDrphjiSxFZrRJ5tIghk+qdLFRCXI5HBCshgobftbmrC5g==}
@@ -16750,7 +16750,7 @@ snapshots:
     dependencies:
       '@graphql-tools/utils': 9.2.1(graphql@16.8.1)
       graphql: 16.8.1
-      tslib: 2.7.0
+      tslib: 2.8.1
 
   '@graphql-tools/merge@9.0.4(graphql@16.8.1)':
     dependencies:
@@ -20048,7 +20048,7 @@ snapshots:
   '@swc/helpers@0.4.36':
     dependencies:
       legacy-swc-helpers: '@swc/helpers@0.4.14'
-      tslib: 2.7.0
+      tslib: 2.8.1
 
   '@szmarczak/http-timer@4.0.6':
     dependencies:
@@ -20663,7 +20663,7 @@ snapshots:
 
   '@ungap/structured-clone@1.2.0': {}
 
-  '@verax-attestation-registry/verax-sdk@2.3.0(@graphql-mesh/types@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(@types/node@20.12.12)(@types/react@18.3.2)(bufferutil@4.0.9)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1)(typescript@5.2.2)(utf-8-validate@5.0.10)':
+  '@verax-attestation-registry/verax-sdk@2.3.1(@graphql-mesh/types@0.98.4)(@graphql-tools/utils@10.2.0(graphql@16.8.1))(@types/node@20.12.12)(@types/react@18.3.2)(bufferutil@4.0.9)(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1)(typescript@5.2.2)(utf-8-validate@5.0.10)':
     dependencies:
       '@graphql-mesh/cache-localforage': 0.95.8(@graphql-mesh/types@0.98.4)(@graphql-mesh/utils@0.95.8)(graphql@16.8.1)(tslib@2.8.1)
       '@graphql-mesh/cross-helpers': 0.4.2(@graphql-tools/utils@10.2.0(graphql@16.8.1))(graphql@16.8.1)
@@ -26331,7 +26331,7 @@ snapshots:
 
   is-lower-case@2.0.2:
     dependencies:
-      tslib: 2.7.0
+      tslib: 2.8.1
 
   is-map@2.0.3: {}
 
@@ -26415,7 +26415,7 @@ snapshots:
 
   is-upper-case@2.0.2:
     dependencies:
-      tslib: 2.7.0
+      tslib: 2.8.1
 
   is-valid-domain@0.1.6:
     dependencies:
@@ -27288,11 +27288,11 @@ snapshots:
 
   lower-case-first@2.0.2:
     dependencies:
-      tslib: 2.7.0
+      tslib: 2.8.1
 
   lower-case@2.0.2:
     dependencies:
-      tslib: 2.7.0
+      tslib: 2.8.1
 
   lowercase-keys@2.0.0: {}
 
@@ -27333,7 +27333,7 @@ snapshots:
 
   make-dir@4.0.0:
     dependencies:
-      semver: 7.6.2
+      semver: 7.7.1
 
   make-error@1.3.6: {}
 
@@ -29776,7 +29776,7 @@ snapshots:
 
   sponge-case@1.0.1:
     dependencies:
-      tslib: 2.7.0
+      tslib: 2.8.1
 
   sprintf-js@1.0.3: {}
 
@@ -30088,7 +30088,7 @@ snapshots:
 
   swap-case@2.0.2:
     dependencies:
-      tslib: 2.7.0
+      tslib: 2.8.1
 
   swc-loader@0.2.6(@swc/core@1.3.78)(webpack@5.97.1(@swc/core@1.3.78)):
     dependencies:
@@ -30354,7 +30354,7 @@ snapshots:
 
   title-case@3.0.3:
     dependencies:
-      tslib: 2.7.0
+      tslib: 2.8.1
 
   tmp-promise@3.0.3:
     dependencies:
@@ -30811,11 +30811,11 @@ snapshots:
 
   upper-case-first@2.0.2:
     dependencies:
-      tslib: 2.7.0
+      tslib: 2.8.1
 
   upper-case@2.0.2:
     dependencies:
-      tslib: 2.7.0
+      tslib: 2.8.1
 
   uqr@0.1.2: {}
 


### PR DESCRIPTION
## What does this PR do?

Refactor the display of the decoded Attestation payload

### Related ticket

Fixes #936 

### Type of change

- [ ] Chore
- [X] Bug fix
- [ ] New feature
- [ ] Documentation update

## Check list

- [X] My&nbsp;contribution&nbsp;follows&nbsp;the&nbsp;project's&nbsp;[guidelines](https://github.com/Consensys/linea-attestation-registry/blob/dev/CONTRIBUTING.md)
- [ ] I have made corresponding changes to the documentation
- [ ] Unit tests for any smart contract change
- [ ] Contracts and functions are documented
