### PR TITLE
chore(contracts): Add a passing test for balanceOf

### DIFF
--- a/contracts/test/AttestationRegistry.t.sol
+++ b/contracts/test/AttestationRegistry.t.sol
@@ -524,6 +524,22 @@ contract AttestationRegistryTest is Test {
     vm.stopPrank();
   }
 
+  function test_balanceOf(AttestationPayload memory attestationPayload) public {
+    vm.assume(attestationPayload.subject.length != 0);
+    vm.assume(attestationPayload.attestationData.length != 0);
+    vm.assume(attestationPayload.expirationDate > block.timestamp);
+    SchemaRegistryMock schemaRegistryMock = SchemaRegistryMock(router.getSchemaRegistry());
+    attestationPayload.schemaId = schemaRegistryMock.getIdFromSchemaString("schemaString");
+    schemaRegistryMock.createSchema("name", "description", "context", "schemaString");
+
+    vm.startPrank(portal);
+    attestationPayload.subject = abi.encode(address(1));
+    attestationRegistry.attest(attestationPayload, attester);
+
+    uint256 balance = attestationRegistry.balanceOf(address(1), 1);
+    assertEq(balance, 1);
+  }
+
   function test_balanceOf_attestationNotFound(AttestationPayload memory attestationPayload) public {
     vm.assume(attestationPayload.subject.length != 0);
     vm.assume(attestationPayload.attestationData.length != 0);


### PR DESCRIPTION
## What does this PR do?

Adds a passing test for the `balanceOf` function

### Related ticket

Fixes #943 

### Type of change

- [X] Chore
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update

## Check list

- [X] My&nbsp;contribution&nbsp;follows&nbsp;the&nbsp;project's&nbsp;[guidelines](https://github.com/Consensys/linea-attestation-registry/blob/dev/CONTRIBUTING.md)
- [ ] I have made corresponding changes to the documentation
- [X] Unit tests for any smart contract change
- [ ] Contracts and functions are documented
