### PR TITLE
fix(explorer): Attestation ID column seems uselessly wide

### DIFF
--- a/explorer/src/components/DataTable/index.tsx
+++ b/explorer/src/components/DataTable/index.tsx
@@ -61,7 +61,7 @@ export function DataTable<TData, TValue>({ columns, data, link }: DataTableProps
                 className="table-row-transition hover:bg-jumbotronLight dark:hover:bg-jumbotronDark cursor-pointer"
               >
                 {row.getVisibleCells().map((cell) => (
-                  <TableCell key={cell.id} className="whitespace-nowrap text-text-secondary first:w-[45%]">
+                  <TableCell key={cell.id} className="whitespace-nowrap text-text-secondary">
                     {flexRender(cell.column.columnDef.cell, cell.getContext())}
                   </TableCell>
                 ))}


### PR DESCRIPTION
## What does this PR do?

Removes the specific width for the first column of any table

### Related ticket

Fixes #949 

### Type of change

- [ ] Chore
- [X] Bug fix
- [ ] New feature
- [ ] Documentation update

## Check list

- [X] My&nbsp;contribution&nbsp;follows&nbsp;the&nbsp;project's&nbsp;[guidelines](https://github.com/Consensys/linea-attestation-registry/blob/dev/CONTRIBUTING.md)
- [ ] I have made corresponding changes to the documentation
- [ ] Unit tests for any smart contract change
- [ ] Contracts and functions are documented
