### PR TITLE
fix contract compilation failing due to updated Openzepplin

### DIFF
--- a/contracts/src/AttestationRegistry.sol
+++ b/contracts/src/AttestationRegistry.sol
@@ -83,7 +83,7 @@ contract AttestationRegistry is OwnableUpgradeable {
    *      and the last 60 characters must be 0
    */
   function initialize(address _router, uint256 _chainPrefix) public initializer {
-    __Ownable_init();
+    __Ownable_init(msg.sender);
 
     if (_router == address(0)) revert RouterAddressInvalid();
     router = IRouter(_router);

--- a/contracts/src/ModuleRegistry.sol
+++ b/contracts/src/ModuleRegistry.sol
@@ -63,7 +63,7 @@ contract ModuleRegistry is OwnableUpgradeable {
    * @param _router the address of the Router contract
    */
   function initialize(address _router) public initializer {
-    __Ownable_init();
+    __Ownable_init(msg.sender);
     if (_router == address(0)) revert RouterAddressInvalid();
     router = IRouter(_router);
     emit RouterSet(_router);

--- a/contracts/src/PortalRegistry.sol
+++ b/contracts/src/PortalRegistry.sol
@@ -84,7 +84,7 @@ contract PortalRegistry is OwnableUpgradeable {
    * @param _isTestnet Boolean indicating if the deployment is on a testnet
    */
   function initialize(address _router, bool _isTestnet) public initializer {
-    __Ownable_init();
+    __Ownable_init(msg.sender);
 
     if (_router == address(0)) revert RouterAddressInvalid();
     router = IRouter(_router);

--- a/contracts/src/SchemaRegistry.sol
+++ b/contracts/src/SchemaRegistry.sol
@@ -66,7 +66,7 @@ contract SchemaRegistry is OwnableUpgradeable {
    * @param _router the address of the Router contract
    */
   function initialize(address _router) public initializer {
-    __Ownable_init();
+    __Ownable_init(msg.sender);
     if (_router == address(0)) revert RouterAddressInvalid();
     router = IRouter(_router);
     emit RouterSet(_router);

--- a/contracts/src/abstracts/AbstractPortalV2.sol
+++ b/contracts/src/abstracts/AbstractPortalV2.sol
@@ -200,7 +200,7 @@ abstract contract AbstractPortalV2 is IPortal, ERC165 {
    * @param interfaceID the interface identifier checked in this call
    * @return True if the interface is supported, false otherwise
    */
-  function supportsInterface(bytes4 interfaceID) public view virtual override returns (bool) {
+  function supportsInterface(bytes4 interfaceID) public view virtual returns (bool) {
     return
       interfaceID == type(AbstractPortalV2).interfaceId ||
       interfaceID == type(IPortal).interfaceId ||


### PR DESCRIPTION
## What does this PR do?
Fixes Verax Contract compilation after the updated Openzepplin contracts
Was getting errors when trying to compile contract in remix - 

```
ypeError: Wrong argument count for function call: 0 arguments given but expected 1.
  --> contracts/verax/contracts/ModuleRegistry.sol:66:5:
   |
66 |     __Ownable_init();
   |     ^^^^^^^^^^^^^^^^
```

```
TypeError: Function has override specified but does not override anything.
   --> contracts/verax/contracts/abstracts/AbstractPortal.sol:257:70:
    |
257 |   function supportsInterface(bytes4 interfaceID) public pure virtual override returns (bool) {
    |      
```

Issue was due to latest openzeppelin contract changes from 4.x to 5.x

### Related ticket

Fixes #

### Type of change

- [ ] Chore
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update

## Check list

- [x] My&nbsp;contribution&nbsp;follows&nbsp;the&nbsp;project's&nbsp;[guidelines](https://github.com/Consensys/linea-attestation-registry/blob/dev/CONTRIBUTING.md)
- [ ] I have made corresponding changes to the documentation
- [ ] Unit tests for any smart contract change
- [ ] Contracts and functions are documented
