### PR TITLE
chore(subgraph): cache tuple length for better decoder performance

### DIFF
--- a/subgraph/src/attestation-registry.ts
+++ b/subgraph/src/attestation-registry.ts
@@ -131,8 +131,9 @@ export function handleVersionUpdated(event: VersionUpdated): void {
 
 function tupleToStringArray(tuple: ethereum.Tuple): string[] {
   const tempStringArray: string[] = [];
+  const length = tuple.length;
 
-  for (let i = 0; i < tuple.length; i++) {
+  for (let i = 0; i < length; i++) {
     tempStringArray.push(valueToString(tuple[i]));
   }
 


### PR DESCRIPTION
## What does this PR do?

This PR optimizes the performance of the subgraph decoder by caching the array length before iteration in the tupleToStringArray function.


### Type of change

- [x] Chore
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update

## Check list

- [x] My&nbsp;contribution&nbsp;follows&nbsp;the&nbsp;project's&nbsp;[guidelines](https://github.com/Consensys/linea-attestation-registry/blob/dev/CONTRIBUTING.md)
- [ ] I have made corresponding changes to the documentation
- [ ] Unit tests for any smart contract change
- [ ] Contracts and functions are documented
