### PR TITLE
feat(sdk): override subgraphs URLs

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -124,8 +124,8 @@ importers:
         specifier: ^8.21.3
         version: 8.21.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@verax-attestation-registry/verax-sdk':
-        specifier: 3.0.0-beta-5
-        version: 3.0.0-beta-5(@graphql-mesh/types@0.104.13(graphql@16.10.0))(@graphql-tools/delegate@11.0.1(graphql@16.10.0))(@graphql-tools/utils@10.9.1(graphql@16.10.0))(@graphql-tools/wrap@11.0.1(graphql@16.10.0))(@types/node@22.18.12)(bufferutil@4.0.9)(encoding@0.1.13)(graphql-yoga@5.16.0(graphql@16.10.0))(typescript@5.2.2)(utf-8-validate@5.0.10)(zod@3.24.3)
+        specifier: 5.0.0
+        version: 5.0.0(@graphql-mesh/types@0.104.13(graphql@16.10.0))(@graphql-tools/delegate@11.0.1(graphql@16.10.0))(@graphql-tools/utils@10.9.1(graphql@16.10.0))(@graphql-tools/wrap@11.0.1(graphql@16.10.0))(@types/node@22.18.12)(bufferutil@4.0.9)(encoding@0.1.13)(graphql-yoga@5.16.0(graphql@16.10.0))(utf-8-validate@5.0.10)(viem@2.38.3(bufferutil@4.0.9)(typescript@5.2.2)(utf-8-validate@5.0.10)(zod@3.24.3))
       abitype:
         specifier: ^0.10.3
         version: 0.10.3(typescript@5.2.2)(zod@3.24.3)
@@ -4465,8 +4465,10 @@ packages:
   '@verax-attestation-registry/verax-contracts@10.0.0':
     resolution: {integrity: sha512-zpDSOabajbwUQIy8cQL/20WW3hotkyTmjUEKOgQo7/nTAvnF6/YPlN+4Fp1JixqHf5NTjpzeJjk/sbOfliX38Q==}
 
-  '@verax-attestation-registry/verax-sdk@3.0.0-beta-5':
-    resolution: {integrity: sha512-58lCILMdAgmZa+k/YQD13q9+NjMMYH+ILEQftIqQqzESf0mBk4ytFvSNbROAkdw/aVuz4hEhCvtL3wwJaEvajQ==}
+  '@verax-attestation-registry/verax-sdk@5.0.0':
+    resolution: {integrity: sha512-ORIQCiRV1p59BWfWoW0/jdl6dRSM3w7gSyunlOgFeZ6gVbduVNr9yT/7CLU9m4PxWe5Ay11it9UTJcwCVVlaiA==}
+    peerDependencies:
+      viem: ^2.0.0
 
   '@vitejs/plugin-react@4.7.0':
     resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
@@ -10077,9 +10079,9 @@ packages:
     resolution: {integrity: sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==}
     engines: {node: '>=8'}
 
-  uWebSockets.js@https://codeload.github.com/uNetworking/uWebSockets.js/tar.gz/af546e5c53c957df9c9f6ba6f76f8534fcb6a505:
-    resolution: {tarball: https://codeload.github.com/uNetworking/uWebSockets.js/tar.gz/af546e5c53c957df9c9f6ba6f76f8534fcb6a505}
-    version: 20.55.0
+  uWebSockets.js@https://codeload.github.com/uNetworking/uWebSockets.js/tar.gz/d04e707a1292928d50163ff7545e45c3e84c5ec3:
+    resolution: {tarball: https://codeload.github.com/uNetworking/uWebSockets.js/tar.gz/d04e707a1292928d50163ff7545e45c3e84c5ec3}
+    version: 20.56.0
 
   ua-parser-js@1.0.37:
     resolution: {integrity: sha512-bhTyI94tZofjo+Dn8SN6Zv8nBDvyXTymAdM3LDI/0IboIUwTu1rEhW7v2TfiVsoYWgkQ4kOVqnI8APUFbIQIFQ==}
@@ -13316,7 +13318,7 @@ snapshots:
       yargs: 17.7.2
     optionalDependencies:
       node-libcurl: 4.0.0(encoding@0.1.13)
-      uWebSockets.js: https://codeload.github.com/uNetworking/uWebSockets.js/tar.gz/af546e5c53c957df9c9f6ba6f76f8534fcb6a505
+      uWebSockets.js: https://codeload.github.com/uNetworking/uWebSockets.js/tar.gz/d04e707a1292928d50163ff7545e45c3e84c5ec3
     transitivePeerDependencies:
       - bufferutil
       - encoding
@@ -16872,7 +16874,7 @@ snapshots:
       '@openzeppelin/contracts': 4.9.6
       '@openzeppelin/contracts-upgradeable': 4.9.6
 
-  '@verax-attestation-registry/verax-sdk@3.0.0-beta-5(@graphql-mesh/types@0.104.13(graphql@16.10.0))(@graphql-tools/delegate@11.0.1(graphql@16.10.0))(@graphql-tools/utils@10.9.1(graphql@16.10.0))(@graphql-tools/wrap@11.0.1(graphql@16.10.0))(@types/node@22.18.12)(bufferutil@4.0.9)(encoding@0.1.13)(graphql-yoga@5.16.0(graphql@16.10.0))(typescript@5.2.2)(utf-8-validate@5.0.10)(zod@3.24.3)':
+  '@verax-attestation-registry/verax-sdk@5.0.0(@graphql-mesh/types@0.104.13(graphql@16.10.0))(@graphql-tools/delegate@11.0.1(graphql@16.10.0))(@graphql-tools/utils@10.9.1(graphql@16.10.0))(@graphql-tools/wrap@11.0.1(graphql@16.10.0))(@types/node@22.18.12)(bufferutil@4.0.9)(encoding@0.1.13)(graphql-yoga@5.16.0(graphql@16.10.0))(utf-8-validate@5.0.10)(viem@2.38.3(bufferutil@4.0.9)(typescript@5.2.2)(utf-8-validate@5.0.10)(zod@3.24.3))':
     dependencies:
       '@graphprotocol/client-add-source-name': 2.0.7(@graphql-mesh/types@0.104.13(graphql@16.10.0))(@graphql-tools/delegate@11.0.1(graphql@16.10.0))(@graphql-tools/utils@10.9.1(graphql@16.10.0))(@graphql-tools/wrap@11.0.1(graphql@16.10.0))(graphql@16.10.0)
       '@graphql-mesh/cache-localforage': 0.105.14(graphql@16.10.0)
@@ -16906,10 +16908,8 @@ snapshots:
       - graphql-yoga
       - ioredis
       - supports-color
-      - typescript
       - uWebSockets.js
       - utf-8-validate
-      - zod
 
   '@vitejs/plugin-react@4.7.0(vite@5.4.21(@types/node@22.18.12)(terser@5.31.0))':
     dependencies:
@@ -24305,7 +24305,7 @@ snapshots:
 
   typical@5.2.0: {}
 
-  uWebSockets.js@https://codeload.github.com/uNetworking/uWebSockets.js/tar.gz/af546e5c53c957df9c9f6ba6f76f8534fcb6a505:
+  uWebSockets.js@https://codeload.github.com/uNetworking/uWebSockets.js/tar.gz/d04e707a1292928d50163ff7545e45c3e84c5ec3:
     optional: true
 
   ua-parser-js@1.0.37: {}

--- a/sdk/.graphclient/schema.graphql
+++ b/sdk/.graphclient/schema.graphql
@@ -1300,7 +1300,6 @@ type _Meta_ {
   will be null if the _meta field has a block constraint that asks for
   a block number. It will be filled if the _meta field has no block constraint
   and therefore asks for the latest  block
-  
   """
   block: _Block_!
   """The deployment ID"""

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -22,6 +22,43 @@ pnpm add @verax-attestation-registry/verax-sdk
 Check the
 [SDK documentation](https://docs.ver.ax/verax-documentation/developer-guides/using-the-sdk#user-content-getting-started)
 
+## Using Custom Subgraph URLs
+
+By default, the SDK uses free-tier subgraph URLs from The Graph Studio, which have rate limits. For production
+applications, you can override these URLs with your own endpoints that use The Graph API keys for higher rate limits.
+
+### Basic Usage
+
+```typescript
+import { VeraxSdk, ChainName } from "@verax-attestation-registry/verax-sdk";
+
+const sdk = new VeraxSdk({
+  ...VeraxSdk.DEFAULT_LINEA_MAINNET,
+  subgraphUrlOverrides: {
+    [ChainName.LINEA_MAINNET]: "https://gateway.thegraph.com/api/YOUR_API_KEY/subgraphs/id/...",
+    [ChainName.ARBITRUM_MAINNET]: "https://gateway.thegraph.com/api/YOUR_API_KEY/subgraphs/id/...",
+  },
+});
+```
+
+### How It Works
+
+The SDK uses **cascading fallback logic** to resolve subgraph URLs for any chain:
+
+1. **First**: Check `subgraphUrlOverrides[chainName]` (your custom URL)
+2. **Then**: Check `subgraphUrl` (if querying the configured chain)
+3. **Finally**: Use default free-tier URL
+
+This unified approach works for **both single-chain and multi-chain queries**, providing consistent behavior throughout
+the SDK.
+
+### Benefits
+
+- **Higher rate limits** - Use paid API keys to avoid throttling
+- **Production-ready** - Suitable for high-traffic applications
+- **Flexible** - Override only the chains you need
+- **Consistent** - Same logic for all query types
+
 ## CLI examples
 
 cf. [CLI examples](./doc/cli-examples.md)

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verax-attestation-registry/verax-sdk",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "description": "Verax Attestation Registry SDK to interact with the subgraph and the contracts",
   "keywords": [
     "linea-attestation-registry",

--- a/sdk/src/dataMapper/AttestationDataMapper.ts
+++ b/sdk/src/dataMapper/AttestationDataMapper.ts
@@ -86,7 +86,8 @@ export default class AttestationDataMapper extends BaseDataMapper<
     orderBy?: Attestation_orderBy,
     orderDirection?: OrderDirection,
   ) {
-    const attestationsResult = await this.crossChainClient.MultichainAttestationsQuery({
+    const crossChainClient = await this.getCrossChainClient();
+    const attestationsResult = await crossChainClient.MultichainAttestationsQuery({
       chainNames: chainNames,
       first: first,
       skip: skip,

--- a/sdk/src/dataMapper/BaseDataMapper.test.ts
+++ b/sdk/src/dataMapper/BaseDataMapper.test.ts
@@ -2,11 +2,17 @@ import BaseDataMapper from "./BaseDataMapper";
 import { PublicClient, WalletClient } from "viem";
 import { lineaSepolia } from "viem/chains";
 
-import { Conf } from "../types";
+import { ChainName, Conf } from "../types";
 import { SDKMode, VeraxSdk } from "../VeraxSdk";
 import { subgraphCall, stringifyWhereClause } from "../utils/graphClientHelper";
+import { getCustomGraphSDK } from "../utils/graphClientBuilder";
+import { getBuiltGraphSDK } from "../../.graphclient";
+import { getConfiguredSubgraphUrl } from "../utils/urlResolver";
 
 jest.mock("../utils/graphClientHelper");
+jest.mock("../utils/graphClientBuilder");
+jest.mock("../../.graphclient");
+jest.mock("../utils/urlResolver");
 
 type TestType = {
   id: string;
@@ -42,6 +48,7 @@ describe("BaseDataMapper", () => {
   beforeEach(() => {
     mockDataMapper = new MockDataMapper(mockConf, mockWeb3Client, mockVeraxSdk, mockWalletClient);
     jest.clearAllMocks();
+    (getConfiguredSubgraphUrl as jest.Mock).mockReturnValue(mockConf.subgraphUrl);
   });
 
   describe("findOneById", () => {
@@ -170,6 +177,78 @@ describe("BaseDataMapper", () => {
       const result = await mockDataMapper.findTotalCount();
 
       expect(result).toEqual(0);
+    });
+  });
+
+  describe("getCrossChainClient", () => {
+    const mockCrossChainClient = {
+      MultichainAttestationsQuery: jest.fn(),
+      MultichainPortalsQuery: jest.fn(),
+      MultichainSchemasQuery: jest.fn(),
+      MultichainModulesQuery: jest.fn(),
+    };
+
+    beforeEach(() => {
+      (getBuiltGraphSDK as jest.Mock).mockReturnValue(mockCrossChainClient);
+      (getCustomGraphSDK as jest.Mock).mockResolvedValue(mockCrossChainClient);
+    });
+
+    it("should use default SDK when no URL overrides are provided", async () => {
+      const mapper = new MockDataMapper(mockConf, mockWeb3Client, mockVeraxSdk, mockWalletClient);
+
+      const client = await mapper["getCrossChainClient"]();
+
+      expect(getBuiltGraphSDK).toHaveBeenCalled();
+      expect(getCustomGraphSDK).not.toHaveBeenCalled();
+      expect(client).toBe(mockCrossChainClient);
+    });
+
+    it("should use custom SDK when URL overrides are provided", async () => {
+      const confWithOverrides: Conf = {
+        ...mockConf,
+        subgraphUrlOverrides: {
+          [ChainName.LINEA_MAINNET]: "https://custom-url.com/graphql",
+        },
+      };
+
+      const mapper = new MockDataMapper(confWithOverrides, mockWeb3Client, mockVeraxSdk, mockWalletClient);
+
+      const client = await mapper["getCrossChainClient"]();
+
+      expect(getCustomGraphSDK).toHaveBeenCalledWith(confWithOverrides.subgraphUrlOverrides);
+      expect(getBuiltGraphSDK).not.toHaveBeenCalled();
+      expect(client).toBe(mockCrossChainClient);
+    });
+
+    it("should cache the client instance on subsequent calls", async () => {
+      const mapper = new MockDataMapper(mockConf, mockWeb3Client, mockVeraxSdk, mockWalletClient);
+
+      // Call twice
+      const client1 = await mapper["getCrossChainClient"]();
+      const client2 = await mapper["getCrossChainClient"]();
+
+      // Should only call getBuiltGraphSDK once (lazy initialization)
+      expect(getBuiltGraphSDK).toHaveBeenCalledTimes(1);
+      expect(client1).toBe(client2);
+    });
+
+    it("should cache the client instance even with URL overrides", async () => {
+      const confWithOverrides: Conf = {
+        ...mockConf,
+        subgraphUrlOverrides: {
+          [ChainName.LINEA_MAINNET]: "https://custom-url.com/graphql",
+        },
+      };
+
+      const mapper = new MockDataMapper(confWithOverrides, mockWeb3Client, mockVeraxSdk, mockWalletClient);
+
+      // Call twice
+      const client1 = await mapper["getCrossChainClient"]();
+      const client2 = await mapper["getCrossChainClient"]();
+
+      // Should only call getCustomGraphSDK once (lazy initialization)
+      expect(getCustomGraphSDK).toHaveBeenCalledTimes(1);
+      expect(client1).toBe(client2);
     });
   });
 });

--- a/sdk/src/dataMapper/BaseDataMapper.ts
+++ b/sdk/src/dataMapper/BaseDataMapper.ts
@@ -3,12 +3,14 @@ import { Conf, CrossChainClient } from "../types";
 import { getBuiltGraphSDK, OrderDirection } from "../../.graphclient";
 import { VeraxSdk } from "../VeraxSdk";
 import { stringifyWhereClause, subgraphCall } from "../utils/graphClientHelper";
+import { getCustomGraphSDK } from "../utils/graphClientBuilder";
+import { getConfiguredSubgraphUrl } from "../utils/urlResolver";
 
 export default abstract class BaseDataMapper<T, TFilter, TOrder> {
   protected readonly conf: Conf;
   protected readonly web3Client: PublicClient;
   protected readonly walletClient: WalletClient | undefined;
-  protected readonly crossChainClient: CrossChainClient;
+  private crossChainClientPromise: Promise<CrossChainClient> | null = null;
   protected readonly veraxSdk: VeraxSdk;
   protected abstract typeName: string;
   protected abstract gqlInterface: string;
@@ -18,13 +20,27 @@ export default abstract class BaseDataMapper<T, TFilter, TOrder> {
     this.web3Client = _web3Client;
     this.veraxSdk = _veraxSdk;
     this.walletClient = _walletClient;
-    this.crossChainClient = getBuiltGraphSDK();
+  }
+
+  protected async getCrossChainClient(): Promise<CrossChainClient> {
+    if (!this.crossChainClientPromise) {
+      // Initialize the client lazily on first use
+      if (this.conf.subgraphUrlOverrides) {
+        // Use custom SDK builder with URL overrides
+        this.crossChainClientPromise = getCustomGraphSDK(this.conf.subgraphUrlOverrides);
+      } else {
+        // Use default SDK without overrides
+        this.crossChainClientPromise = Promise.resolve(getBuiltGraphSDK());
+      }
+    }
+    return this.crossChainClientPromise;
   }
 
   async findOneById(id: string) {
     const query = `query get_${this.typeName} { ${this.typeName}(id: "${id}") ${this.gqlInterface} }`;
 
-    const { data, status } = await subgraphCall(query, this.conf.subgraphUrl);
+    const subgraphUrl = getConfiguredSubgraphUrl(this.conf);
+    const { data, status } = await subgraphCall(query, subgraphUrl);
 
     if (status != 200) {
       throw new Error(`Error(s) while fetching ${this.typeName}`);
@@ -47,7 +63,8 @@ export default abstract class BaseDataMapper<T, TFilter, TOrder> {
         }
     `;
 
-    const { data, status } = await subgraphCall(query, this.conf.subgraphUrl);
+    const subgraphUrl = getConfiguredSubgraphUrl(this.conf);
+    const { data, status } = await subgraphCall(query, subgraphUrl);
 
     if (status != 200) {
       throw new Error(`Error(s) while fetching ${this.typeName}s`);
@@ -59,7 +76,8 @@ export default abstract class BaseDataMapper<T, TFilter, TOrder> {
   async findTotalCount() {
     const query = `query get_${this.typeName}_Counter { counters { ${this.typeName}s } }`;
 
-    const { data, status } = await subgraphCall(query, this.conf.subgraphUrl);
+    const subgraphUrl = getConfiguredSubgraphUrl(this.conf);
+    const { data, status } = await subgraphCall(query, subgraphUrl);
 
     if (status != 200) {
       throw new Error(`Error(s) while fetching total count of ${this.typeName}s`);

--- a/sdk/src/dataMapper/ModuleDataMapper.ts
+++ b/sdk/src/dataMapper/ModuleDataMapper.ts
@@ -25,7 +25,8 @@ export default class ModuleDataMapper extends BaseDataMapper<Module, Module_filt
     orderBy?: Module_orderBy,
     orderDirection?: OrderDirection,
   ) {
-    const modulesResult = await this.crossChainClient.MultichainModulesQuery({
+    const crossChainClient = await this.getCrossChainClient();
+    const modulesResult = await crossChainClient.MultichainModulesQuery({
       chainNames: chainNames,
       first: first,
       skip: skip,

--- a/sdk/src/dataMapper/PortalDataMapper.ts
+++ b/sdk/src/dataMapper/PortalDataMapper.ts
@@ -31,7 +31,8 @@ export default class PortalDataMapper extends BaseDataMapper<Portal, Portal_filt
     orderBy?: Portal_orderBy,
     orderDirection?: OrderDirection,
   ) {
-    const portalsResult = await this.crossChainClient.MultichainPortalsQuery({
+    const crossChainClient = await this.getCrossChainClient();
+    const portalsResult = await crossChainClient.MultichainPortalsQuery({
       chainNames: chainNames,
       first: first,
       skip: skip,

--- a/sdk/src/dataMapper/SchemaDataMapper.ts
+++ b/sdk/src/dataMapper/SchemaDataMapper.ts
@@ -26,7 +26,8 @@ export default class SchemaDataMapper extends BaseDataMapper<Schema, Schema_filt
     orderBy?: Schema_orderBy,
     orderDirection?: OrderDirection,
   ) {
-    const schemasResult = await this.crossChainClient.MultichainSchemasQuery({
+    const crossChainClient = await this.getCrossChainClient();
+    const schemasResult = await crossChainClient.MultichainSchemasQuery({
       chainNames: chainNames,
       first: first,
       skip: skip,

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -18,10 +18,25 @@ export { default as UtilsDataMapper } from "./dataMapper/UtilsDataMapper";
 // Types
 export * from "./types";
 
+// GraphQL types from generated code (for filters, ordering, etc.)
+export type {
+  Attestation_filter,
+  Attestation_orderBy,
+  Schema_filter,
+  Schema_orderBy,
+  Portal_filter,
+  Portal_orderBy,
+  Module_filter,
+  Module_orderBy,
+  OrderDirection,
+} from "../.graphclient";
+
 // Constants
 export * from "./utils/constants";
 
 // Utilities (for advanced usage)
 export { encode, decodeWithRetry } from "./utils/abiCoder";
 export { handleError } from "./utils/errorHandler";
+export { getCustomGraphSDK } from "./utils/graphClientBuilder";
+export { getSubgraphUrlForChain, getConfiguredSubgraphUrl } from "./utils/urlResolver";
 export type { IPFSConfig } from "./types";

--- a/sdk/src/types/index.ts
+++ b/sdk/src/types/index.ts
@@ -21,6 +21,7 @@ export interface Conf {
   attestationRegistryAddress: Address;
   rpcUrl?: string;
   offchainConfig?: OffChainAttestationConfig;
+  subgraphUrlOverrides?: Partial<Record<ChainName, string>>;
 }
 
 export type AttestationPayload = {

--- a/sdk/src/utils/graphClientBuilder.test.ts
+++ b/sdk/src/utils/graphClientBuilder.test.ts
@@ -1,0 +1,194 @@
+import { getCustomGraphSDK } from "./graphClientBuilder";
+import { getMeshOptions, getSdk } from "../../.graphclient";
+import { getMesh } from "@graphql-mesh/runtime";
+import { ChainName } from "../types";
+
+// Mock the GraphQL Mesh functions
+jest.mock("../../.graphclient", () => ({
+  getMeshOptions: jest.fn(),
+  getBuiltGraphSDK: jest.fn(),
+  getSdk: jest.fn(),
+}));
+
+jest.mock("@graphql-mesh/runtime", () => ({
+  getMesh: jest.fn(),
+}));
+
+describe("graphClientBuilder", () => {
+  describe("getCustomGraphSDK", () => {
+    let mockFetch: jest.Mock;
+    let mockMeshOptions: Awaited<ReturnType<typeof getMeshOptions>>;
+    let mockMesh: Awaited<ReturnType<typeof getMesh>>;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+
+      // Create mock fetch function
+      mockFetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ data: {} }),
+      });
+
+      // Create mock mesh options
+      mockMeshOptions = {
+        fetchFn: mockFetch,
+        sources: [],
+        transforms: [],
+      } as unknown as Awaited<ReturnType<typeof getMeshOptions>>;
+
+      // Create mock SDK methods
+      const mockSDK = {
+        MultichainAttestationsQuery: jest.fn(),
+        MultichainPortalsQuery: jest.fn(),
+        MultichainSchemasQuery: jest.fn(),
+        MultichainModulesQuery: jest.fn(),
+      };
+
+      // Create mock mesh instance
+      mockMesh = {
+        sdkRequesterFactory: jest.fn().mockReturnValue(jest.fn()),
+      } as unknown as Awaited<ReturnType<typeof getMesh>>;
+
+      (getMeshOptions as jest.Mock).mockResolvedValue(mockMeshOptions);
+      (getMesh as jest.Mock).mockResolvedValue(mockMesh);
+      (getSdk as jest.Mock).mockReturnValue(mockSDK);
+    });
+
+    it("should create SDK without URL overrides", async () => {
+      const sdk = await getCustomGraphSDK();
+
+      expect(getMeshOptions).toHaveBeenCalled();
+      expect(getMesh).toHaveBeenCalledWith(mockMeshOptions);
+      expect(mockMesh.sdkRequesterFactory).toHaveBeenCalled();
+      expect(sdk).toBeDefined();
+      expect(sdk.MultichainAttestationsQuery).toBeDefined();
+    });
+
+    it("should create SDK with URL overrides", async () => {
+      const urlOverrides = {
+        [ChainName.LINEA_MAINNET]: "https://custom-linea-url.com/graphql",
+        [ChainName.ARBITRUM_MAINNET]: "https://custom-arbitrum-url.com/graphql",
+      };
+
+      const sdk = await getCustomGraphSDK(urlOverrides);
+
+      expect(getMeshOptions).toHaveBeenCalled();
+      expect(getMesh).toHaveBeenCalled();
+      expect(sdk).toBeDefined();
+
+      // Verify that the fetch function was wrapped
+      const modifiedOptions = (getMesh as jest.Mock).mock.calls[0][0];
+      expect(modifiedOptions.fetchFn).toBeDefined();
+      expect(modifiedOptions.fetchFn).not.toBe(mockFetch);
+    });
+
+    it("should redirect requests to custom URLs when override matches", async () => {
+      const customUrl = "https://custom-linea-url.com/graphql";
+      const urlOverrides = {
+        [ChainName.LINEA_MAINNET]: customUrl,
+      };
+
+      await getCustomGraphSDK(urlOverrides);
+
+      // Get the wrapped fetch function
+      const modifiedOptions = (getMesh as jest.Mock).mock.calls[0][0];
+      const wrappedFetch = modifiedOptions.fetchFn;
+
+      // Simulate a request that contains the chain name
+      const requestUrl = `https://api.studio.thegraph.com/query/67521/${ChainName.LINEA_MAINNET}/version/latest`;
+      await wrappedFetch(requestUrl, {}, {});
+
+      // Verify that the original fetch was called with the custom URL
+      expect(mockFetch).toHaveBeenCalledWith(customUrl, {}, {});
+    });
+
+    it("should use default URL when no override matches", async () => {
+      const urlOverrides = {
+        [ChainName.LINEA_MAINNET]: "https://custom-linea-url.com/graphql",
+      };
+
+      await getCustomGraphSDK(urlOverrides);
+
+      // Get the wrapped fetch function
+      const modifiedOptions = (getMesh as jest.Mock).mock.calls[0][0];
+      const wrappedFetch = modifiedOptions.fetchFn;
+
+      // Simulate a request for a different chain (no override)
+      const requestUrl = `https://api.studio.thegraph.com/query/67521/${ChainName.ARBITRUM_MAINNET}/version/latest`;
+      await wrappedFetch(requestUrl, {}, {});
+
+      // Verify that the original fetch was called with the original URL
+      expect(mockFetch).toHaveBeenCalledWith(requestUrl, {}, {});
+    });
+
+    it("should handle multiple chain overrides", async () => {
+      const customLineaUrl = "https://custom-linea-url.com/graphql";
+      const customArbitrumUrl = "https://custom-arbitrum-url.com/graphql";
+      const urlOverrides = {
+        [ChainName.LINEA_MAINNET]: customLineaUrl,
+        [ChainName.ARBITRUM_MAINNET]: customArbitrumUrl,
+      };
+
+      await getCustomGraphSDK(urlOverrides);
+
+      // Get the wrapped fetch function
+      const modifiedOptions = (getMesh as jest.Mock).mock.calls[0][0];
+      const wrappedFetch = modifiedOptions.fetchFn;
+
+      // Test Linea override
+      const lineaUrl = `https://api.studio.thegraph.com/query/67521/${ChainName.LINEA_MAINNET}/version/latest`;
+      await wrappedFetch(lineaUrl, {}, {});
+      expect(mockFetch).toHaveBeenCalledWith(customLineaUrl, {}, {});
+
+      // Test Arbitrum override
+      mockFetch.mockClear();
+      const arbitrumUrl = `https://api.studio.thegraph.com/query/67521/${ChainName.ARBITRUM_MAINNET}/version/latest`;
+      await wrappedFetch(arbitrumUrl, {}, {});
+      expect(mockFetch).toHaveBeenCalledWith(customArbitrumUrl, {}, {});
+    });
+
+    it("should handle URL as URL object", async () => {
+      const customUrl = "https://custom-linea-url.com/graphql";
+      const urlOverrides = {
+        [ChainName.LINEA_MAINNET]: customUrl,
+      };
+
+      await getCustomGraphSDK(urlOverrides);
+
+      // Get the wrapped fetch function
+      const modifiedOptions = (getMesh as jest.Mock).mock.calls[0][0];
+      const wrappedFetch = modifiedOptions.fetchFn;
+
+      // Simulate a request with URL as string (GraphQL Mesh always passes strings to fetchFn)
+      const requestUrl = `https://api.studio.thegraph.com/query/67521/${ChainName.LINEA_MAINNET}/version/latest`;
+      await wrappedFetch(requestUrl, {}, {});
+
+      // Verify that the original fetch was called with the custom URL
+      expect(mockFetch).toHaveBeenCalledWith(customUrl, {}, {});
+    });
+
+    it("should not wrap fetchFn when URL overrides are empty", async () => {
+      const urlOverrides = {};
+
+      await getCustomGraphSDK(urlOverrides);
+
+      expect(getMeshOptions).toHaveBeenCalled();
+      expect(getMesh).toHaveBeenCalled();
+
+      // Verify that fetchFn was NOT wrapped when overrides are empty
+      const modifiedOptions = (getMesh as jest.Mock).mock.calls[0][0];
+      expect(modifiedOptions.fetchFn).toBe(mockFetch);
+    });
+
+    it("should work without any URL overrides parameter", async () => {
+      await getCustomGraphSDK();
+
+      expect(getMeshOptions).toHaveBeenCalled();
+      expect(getMesh).toHaveBeenCalled();
+
+      // Verify that fetchFn was NOT wrapped when no overrides provided
+      const modifiedOptions = (getMesh as jest.Mock).mock.calls[0][0];
+      expect(modifiedOptions.fetchFn).toBe(mockFetch);
+    });
+  });
+});

--- a/sdk/src/utils/graphClientBuilder.ts
+++ b/sdk/src/utils/graphClientBuilder.ts
@@ -1,0 +1,36 @@
+import { getMeshOptions, getSdk } from "../../.graphclient";
+import { getMesh } from "@graphql-mesh/runtime";
+import { ChainName, CrossChainClient } from "../types";
+
+type FetchFn = (url: string, options?: RequestInit, context?: Record<string, unknown>) => Promise<Response>;
+
+/**
+ * Creates a custom GraphQL Mesh SDK with URL overrides for multi-chain queries.
+ * Falls back to default URLs if no override is provided for a specific chain.
+ */
+export async function getCustomGraphSDK(urlOverrides?: Partial<Record<ChainName, string>>): Promise<CrossChainClient> {
+  const meshOptions = await getMeshOptions();
+
+  if (urlOverrides && Object.keys(urlOverrides).length > 0) {
+    const originalFetch = meshOptions.fetchFn as FetchFn;
+
+    meshOptions.fetchFn = async (url: string, options?: RequestInit, context?: Record<string, unknown>) => {
+      // Check if we should override the URL based on chain name in the URL
+      for (const [chainName, customUrl] of Object.entries(urlOverrides)) {
+        if (url.includes(chainName)) {
+          return originalFetch(customUrl, options, context);
+        }
+      }
+
+      // No override found, use the original URL
+      return originalFetch(url, options, context);
+    };
+  }
+
+  const mesh = await getMesh(meshOptions);
+  const globalContext = {};
+  const sdkRequester = mesh.sdkRequesterFactory(globalContext);
+
+  // Wrap the requester with getSdk to get the typed methods
+  return getSdk((...args) => sdkRequester(...args)) as unknown as CrossChainClient;
+}

--- a/sdk/src/utils/urlResolver.test.ts
+++ b/sdk/src/utils/urlResolver.test.ts
@@ -1,0 +1,147 @@
+import { linea, lineaSepolia, arbitrum, base } from "viem/chains";
+import { getSubgraphUrlForChain, getConfiguredSubgraphUrl } from "./urlResolver";
+import { ChainName, Conf } from "../types";
+import { SDKMode } from "./constants";
+
+describe("urlResolver", () => {
+  const mockBaseConf: Conf = {
+    chain: linea,
+    mode: SDKMode.BACKEND,
+    subgraphUrl: "https://custom-linea-url.com/graphql",
+    portalRegistryAddress: "0x1",
+    moduleRegistryAddress: "0x2",
+    schemaRegistryAddress: "0x3",
+    attestationRegistryAddress: "0x4",
+  };
+
+  describe("getSubgraphUrlForChain", () => {
+    it("should return override URL when provided", () => {
+      const conf: Conf = {
+        ...mockBaseConf,
+        subgraphUrlOverrides: {
+          [ChainName.LINEA_MAINNET]: "https://override-linea.com/graphql",
+        },
+      };
+
+      const url = getSubgraphUrlForChain(ChainName.LINEA_MAINNET, conf);
+      expect(url).toBe("https://override-linea.com/graphql");
+    });
+
+    it("should fallback to subgraphUrl for the configured chain", () => {
+      const conf: Conf = {
+        ...mockBaseConf,
+        chain: linea,
+        subgraphUrl: "https://custom-linea-url.com/graphql",
+      };
+
+      const url = getSubgraphUrlForChain(ChainName.LINEA_MAINNET, conf);
+      expect(url).toBe("https://custom-linea-url.com/graphql");
+    });
+
+    it("should fallback to default URL when no override or subgraphUrl matches", () => {
+      const conf: Conf = {
+        ...mockBaseConf,
+        chain: linea, // Configured for Linea
+        subgraphUrl: "https://custom-linea-url.com/graphql",
+      };
+
+      // Request for a different chain - should use default
+      const url = getSubgraphUrlForChain(ChainName.ARBITRUM_MAINNET, conf);
+      expect(url).toBe("https://api.studio.thegraph.com/query/67521/verax-v2-arbitrum/v0.0.2");
+    });
+
+    it("should prioritize override over subgraphUrl", () => {
+      const conf: Conf = {
+        ...mockBaseConf,
+        chain: linea,
+        subgraphUrl: "https://fallback-url.com/graphql",
+        subgraphUrlOverrides: {
+          [ChainName.LINEA_MAINNET]: "https://override-url.com/graphql",
+        },
+      };
+
+      const url = getSubgraphUrlForChain(ChainName.LINEA_MAINNET, conf);
+      expect(url).toBe("https://override-url.com/graphql");
+    });
+
+    it("should handle partial overrides", () => {
+      const conf: Conf = {
+        ...mockBaseConf,
+        chain: linea,
+        subgraphUrl: "https://custom-linea.com/graphql",
+        subgraphUrlOverrides: {
+          [ChainName.ARBITRUM_MAINNET]: "https://custom-arbitrum.com/graphql",
+        },
+      };
+
+      // Linea: uses subgraphUrl (configured chain)
+      expect(getSubgraphUrlForChain(ChainName.LINEA_MAINNET, conf)).toBe("https://custom-linea.com/graphql");
+
+      // Arbitrum: uses override
+      expect(getSubgraphUrlForChain(ChainName.ARBITRUM_MAINNET, conf)).toBe("https://custom-arbitrum.com/graphql");
+
+      // Base: uses default (no override, different chain)
+      expect(getSubgraphUrlForChain(ChainName.BASE_MAINNET, conf)).toBe(
+        "https://api.studio.thegraph.com/query/67521/verax-v2-base/v0.0.1",
+      );
+    });
+  });
+
+  describe("getConfiguredSubgraphUrl", () => {
+    it("should return URL for the configured chain", () => {
+      const conf: Conf = {
+        ...mockBaseConf,
+        chain: linea,
+        subgraphUrl: "https://custom-linea.com/graphql",
+      };
+
+      const url = getConfiguredSubgraphUrl(conf);
+      expect(url).toBe("https://custom-linea.com/graphql");
+    });
+
+    it("should use override for the configured chain", () => {
+      const conf: Conf = {
+        ...mockBaseConf,
+        chain: linea,
+        subgraphUrl: "https://fallback.com/graphql",
+        subgraphUrlOverrides: {
+          [ChainName.LINEA_MAINNET]: "https://override.com/graphql",
+        },
+      };
+
+      const url = getConfiguredSubgraphUrl(conf);
+      expect(url).toBe("https://override.com/graphql");
+    });
+
+    it("should fallback to default if no subgraphUrl or override", () => {
+      const conf: Conf = {
+        ...mockBaseConf,
+        chain: lineaSepolia,
+        subgraphUrl: "", // Empty subgraphUrl
+      };
+
+      const url = getConfiguredSubgraphUrl(conf);
+      expect(url).toBe("https://api.studio.thegraph.com/query/67521/verax-v2-linea-sepolia/v0.0.2");
+    });
+
+    it("should work for different chains", () => {
+      const confArbitrum: Conf = {
+        ...mockBaseConf,
+        chain: arbitrum,
+        subgraphUrl: "https://custom-arbitrum.com/graphql",
+      };
+
+      const urlArbitrum = getConfiguredSubgraphUrl(confArbitrum);
+      expect(urlArbitrum).toBe("https://custom-arbitrum.com/graphql");
+
+      const confBase: Conf = {
+        ...mockBaseConf,
+        chain: base,
+        subgraphUrl: "https://custom-base.com/graphql",
+      };
+
+      const urlBase = getConfiguredSubgraphUrl(confBase);
+      expect(urlBase).toBe("https://custom-base.com/graphql");
+    });
+  });
+});

--- a/sdk/src/utils/urlResolver.ts
+++ b/sdk/src/utils/urlResolver.ts
@@ -1,0 +1,56 @@
+import { Chain } from "viem";
+import { arbitrum, arbitrumSepolia, base, baseSepolia, bsc, bscTestnet, linea, lineaSepolia } from "viem/chains";
+import { ChainName, Conf } from "../types";
+
+const DEFAULT_SUBGRAPH_URLS: Record<ChainName, string> = {
+  [ChainName.LINEA_MAINNET]: "https://api.studio.thegraph.com/query/67521/verax-v2-linea/v0.0.1",
+  [ChainName.LINEA_SEPOLIA]: "https://api.studio.thegraph.com/query/67521/verax-v2-linea-sepolia/v0.0.2",
+  [ChainName.ARBITRUM_MAINNET]: "https://api.studio.thegraph.com/query/67521/verax-v2-arbitrum/v0.0.2",
+  [ChainName.ARBITRUM_SEPOLIA]: "https://api.studio.thegraph.com/query/67521/verax-v2-arbitrum-sepolia/v0.0.2",
+  [ChainName.BASE_MAINNET]: "https://api.studio.thegraph.com/query/67521/verax-v2-base/v0.0.1",
+  [ChainName.BASE_SEPOLIA]: "https://api.studio.thegraph.com/query/67521/verax-v2-base-sepolia/v0.0.2",
+  [ChainName.BSC_MAINNET]: "https://api.studio.thegraph.com/query/67521/verax-v2-bsc/v0.0.1",
+  [ChainName.BSC_TESTNET]: "https://api.studio.thegraph.com/query/67521/verax-v2-bsc-testnet/v0.0.1",
+};
+
+function chainToChainName(chain: Chain): ChainName {
+  const chainIdToName: Record<number, ChainName> = {
+    [linea.id]: ChainName.LINEA_MAINNET,
+    [lineaSepolia.id]: ChainName.LINEA_SEPOLIA,
+    [arbitrum.id]: ChainName.ARBITRUM_MAINNET,
+    [arbitrumSepolia.id]: ChainName.ARBITRUM_SEPOLIA,
+    [base.id]: ChainName.BASE_MAINNET,
+    [baseSepolia.id]: ChainName.BASE_SEPOLIA,
+    [bsc.id]: ChainName.BSC_MAINNET,
+    [bscTestnet.id]: ChainName.BSC_TESTNET,
+  };
+
+  const chainName = chainIdToName[chain.id];
+  if (!chainName) {
+    throw new Error(`Unsupported chain ID: ${chain.id} (${chain.name})`);
+  }
+
+  return chainName;
+}
+
+export function getSubgraphUrlForChain(chainName: ChainName, conf: Conf): string {
+  // Priority 1: Check for chain-specific override
+  if (conf.subgraphUrlOverrides?.[chainName]) {
+    return conf.subgraphUrlOverrides[chainName]!;
+  }
+
+  // Priority 2: Use subgraphUrl if it's for the configured chain
+  // This maintains backward compatibility
+  const configuredChainName = chainToChainName(conf.chain);
+  if (chainName === configuredChainName && conf.subgraphUrl) {
+    return conf.subgraphUrl;
+  }
+
+  // Priority 3: Fallback to default URL
+  return DEFAULT_SUBGRAPH_URLS[chainName];
+}
+
+export function getConfiguredSubgraphUrl(conf: Conf): string {
+  const chainName = chainToChainName(conf.chain);
+  return getSubgraphUrlForChain(chainName, conf);
+}


### PR DESCRIPTION
## What does this PR do?

SDK exposes a way to override the default subgraphs URLs

### Type of change

- [ ] Chore
- [ ] Bug fix
- [X] New feature
- [ ] Documentation update

## Check list

- [ ] My&nbsp;contribution&nbsp;follows&nbsp;the&nbsp;project's&nbsp;[guidelines](https://github.com/Consensys/linea-attestation-registry/blob/dev/CONTRIBUTING.md)
- [ ] I have made corresponding changes to the documentation
- [ ] Unit tests for any smart contract change
- [ ] Contracts and functions are documented

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds cascading subgraph URL overrides, lazy/cached cross-chain GraphQL client, updates data mappers to use it, and documents/exports utilities; bumps SDK to 5.0.0.
> 
> - **SDK/Core**:
>   - Add `subgraphUrlOverrides` to `Conf` with cascading resolution via `getSubgraphUrlForChain`/`getConfiguredSubgraphUrl`.
>   - Introduce `getCustomGraphSDK` to override GraphQL Mesh fetch URLs; BaseDataMapper now lazily caches a cross-chain client (default or custom).
>   - Update `BaseDataMapper` queries to use `getConfiguredSubgraphUrl`.
>   - Update multi-chain methods in `AttestationDataMapper`, `ModuleDataMapper`, `PortalDataMapper`, `SchemaDataMapper` to use `getCrossChainClient`.
>   - Export GraphQL filter/order types and new utilities from `src/index.ts`.
> - **Docs**: README adds "Using Custom Subgraph URLs" with example and behavior.
> - **Tests**: New unit tests for `graphClientBuilder`, `urlResolver`, and `BaseDataMapper` cross-chain client behavior.
> - **Version**: Bump `@verax-attestation-registry/verax-sdk` to `5.0.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e8d00444bc38ade5fc00306a6ae63e764b13f7ce. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->