### PR TITLE
feat(explorer): multichain custom subgraphs URLs

### DIFF
--- a/explorer/package.json
+++ b/explorer/package.json
@@ -28,7 +28,7 @@
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@tanstack/react-query": "^5.90.5",
     "@tanstack/react-table": "^8.21.3",
-    "@verax-attestation-registry/verax-sdk": "3.0.0-beta-5",
+    "@verax-attestation-registry/verax-sdk": "5.0.0",
     "abitype": "^0.10.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/explorer/src/config/index.tsx
+++ b/explorer/src/config/index.tsx
@@ -28,6 +28,8 @@ import LineaSepoliaIcon from "@/assets/networks/linea-sepolia.svg?react";
 import LineaMainnetIcon from "@/assets/networks/linea.svg?react";
 import { INetwork, NetworkName } from "@/interfaces/config";
 
+import { getSubgraphUrlOverrides } from "./subgraphUrls";
+
 const infuraApiKey: string = import.meta.env.VITE_INFURA_API_KEY;
 
 const rpcUrls = {
@@ -50,14 +52,16 @@ const transports = Object.entries(rpcUrls).reduce(
   {},
 );
 
+// Get centralized subgraph URL overrides
+const subgraphUrlOverrides = getSubgraphUrlOverrides();
+
 const chains: INetwork[] = [
   {
     name: "Linea",
     chain: linea,
     veraxEnv: {
       ...VeraxSdk.DEFAULT_LINEA_MAINNET_FRONTEND,
-      subgraphUrl:
-        "https://gateway.thegraph.com/api/649414afdd14301c7a2f6d141f717ed1/subgraphs/id/ESRDQ5djmucKeqxNz7JGVHr621sjGEEsY6M6JibjJ9u3",
+      subgraphUrlOverrides,
       rpcUrl: rpcUrls[linea.id],
     },
     img: <LineaMainnetIcon />,
@@ -71,8 +75,7 @@ const chains: INetwork[] = [
     chain: lineaSepolia,
     veraxEnv: {
       ...VeraxSdk.DEFAULT_LINEA_SEPOLIA_FRONTEND,
-      subgraphUrl:
-        "https://gateway.thegraph.com/api/649414afdd14301c7a2f6d141f717ed1/subgraphs/id/2gfRmZ1e1uJKpCQsUrvxJmRivNa7dvvuULoc8SJabR8v",
+      subgraphUrlOverrides,
       rpcUrl: rpcUrls[lineaSepolia.id],
     },
     img: <LineaSepoliaIcon />,
@@ -85,8 +88,7 @@ const chains: INetwork[] = [
     chain: arbitrum,
     veraxEnv: {
       ...VeraxSdk.DEFAULT_ARBITRUM_FRONTEND,
-      subgraphUrl:
-        "https://gateway.thegraph.com/api/649414afdd14301c7a2f6d141f717ed1/subgraphs/id/ELQZyXzGu5MVA6kMCpMh5zNqdU8gqhtynM9yVRQ4bZoA",
+      subgraphUrlOverrides,
       rpcUrl: rpcUrls[arbitrum.id],
     },
     img: <ArbitrumIcon />,
@@ -100,8 +102,7 @@ const chains: INetwork[] = [
     chain: arbitrumSepolia,
     veraxEnv: {
       ...VeraxSdk.DEFAULT_ARBITRUM_SEPOLIA_FRONTEND,
-      subgraphUrl:
-        "https://gateway.thegraph.com/api/649414afdd14301c7a2f6d141f717ed1/subgraphs/id/5RBJNNUvaoekU2yJsbmEZ1R62Mo3imWy7nMgNj97ZG8u",
+      subgraphUrlOverrides,
       rpcUrl: rpcUrls[arbitrumSepolia.id],
     },
     img: <ArbitrumSepoliaIcon />,
@@ -114,8 +115,7 @@ const chains: INetwork[] = [
     chain: base,
     veraxEnv: {
       ...VeraxSdk.DEFAULT_BASE_FRONTEND,
-      subgraphUrl:
-        "https://gateway.thegraph.com/api/649414afdd14301c7a2f6d141f717ed1/subgraphs/id/fje2qXNP7KeRBZDPFv1VCERchv9PZyZokPRWNZkWtXk",
+      subgraphUrlOverrides,
       rpcUrl: rpcUrls[base.id],
     },
     img: <BaseMainnetIcon />,
@@ -129,8 +129,7 @@ const chains: INetwork[] = [
     chain: baseSepolia,
     veraxEnv: {
       ...VeraxSdk.DEFAULT_BASE_SEPOLIA_FRONTEND,
-      subgraphUrl:
-        "https://gateway.thegraph.com/api/649414afdd14301c7a2f6d141f717ed1/subgraphs/id/EbruygUvdowo7dmsumFmRq2hRu81K88mWsLo5r3jxY3S",
+      subgraphUrlOverrides,
       rpcUrl: rpcUrls[baseSepolia.id],
     },
     img: <BaseSepoliaIcon />,
@@ -143,8 +142,7 @@ const chains: INetwork[] = [
     chain: bsc,
     veraxEnv: {
       ...VeraxSdk.DEFAULT_BSC_FRONTEND,
-      subgraphUrl:
-        "https://gateway.thegraph.com/api/649414afdd14301c7a2f6d141f717ed1/subgraphs/id/8VfLNCBXCFKkcfmRSLDZ6J36NG5rRCUzEgByRJXCzSoW",
+      subgraphUrlOverrides,
       rpcUrl: rpcUrls[bsc.id],
     },
     img: <BscMainnetIcon />,
@@ -158,8 +156,7 @@ const chains: INetwork[] = [
     chain: bscTestnet,
     veraxEnv: {
       ...VeraxSdk.DEFAULT_BSC_TESTNET_FRONTEND,
-      subgraphUrl:
-        "https://gateway.thegraph.com/api/649414afdd14301c7a2f6d141f717ed1/subgraphs/id/6iFYkMd9xbQcEcddHs6vbTMarra7d2NUt9S1qtNmWtaV",
+      subgraphUrlOverrides,
       rpcUrl: rpcUrls[bscTestnet.id],
     },
     img: <BscTestnetIcon />,

--- a/explorer/src/config/subgraphUrls.ts
+++ b/explorer/src/config/subgraphUrls.ts
@@ -1,0 +1,72 @@
+import { ChainName } from "@verax-attestation-registry/verax-sdk";
+
+/**
+ * Centralized subgraph URL configuration for all supported chains.
+ *
+ * These URLs use The Graph Gateway with an API key for higher rate limits.
+ *
+ * TODO: Update each URL with the latest subgraph deployment IDs
+ * TODO: Verify API key is still valid (currently: 649414afdd14301c7a2f6d141f717ed1)
+ */
+
+const THE_GRAPH_API_KEY = import.meta.env.VITE_THE_GRAPH_API_KEY || "649414afdd14301c7a2f6d141f717ed1";
+
+export const SUBGRAPH_URL_OVERRIDES: Partial<Record<ChainName, string>> = {
+  // Linea Mainnet
+  // Current: ESRDQ5djmucKeqxNz7JGVHr621sjGEEsY6M6JibjJ9u3
+  // TODO: Verify this is the latest deployment ID for verax-v2-linea
+  [ChainName.LINEA_MAINNET]: `https://gateway.thegraph.com/api/${THE_GRAPH_API_KEY}/subgraphs/id/ESRDQ5djmucKeqxNz7JGVHr621sjGEEsY6M6JibjJ9u3`,
+
+  // Linea Sepolia
+  // Current: 2gfRmZ1e1uJKpCQsUrvxJmRivNa7dvvuULoc8SJabR8v
+  // TODO: Verify this is the latest deployment ID for verax-v2-linea-sepolia
+  [ChainName.LINEA_SEPOLIA]: `https://gateway.thegraph.com/api/${THE_GRAPH_API_KEY}/subgraphs/id/2gfRmZ1e1uJKpCQsUrvxJmRivNa7dvvuULoc8SJabR8v`,
+
+  // Arbitrum Mainnet
+  // Current: ELQZyXzGu5MVA6kMCpMh5zNqdU8gqhtynM9yVRQ4bZoA
+  // TODO: Verify this is the latest deployment ID for verax-v2-arbitrum
+  [ChainName.ARBITRUM_MAINNET]: `https://gateway.thegraph.com/api/${THE_GRAPH_API_KEY}/subgraphs/id/ELQZyXzGu5MVA6kMCpMh5zNqdU8gqhtynM9yVRQ4bZoA`,
+
+  // Arbitrum Sepolia
+  // Current: 5RBJNNUvaoekU2yJsbmEZ1R62Mo3imWy7nMgNj97ZG8u
+  // TODO: Verify this is the latest deployment ID for verax-v2-arbitrum-sepolia
+  [ChainName.ARBITRUM_SEPOLIA]: `https://gateway.thegraph.com/api/${THE_GRAPH_API_KEY}/subgraphs/id/5RBJNNUvaoekU2yJsbmEZ1R62Mo3imWy7nMgNj97ZG8u`,
+
+  // Base Mainnet
+  // Current: fje2qXNP7KeRBZDPFv1VCERchv9PZyZokPRWNZkWtXk
+  // TODO: Verify this is the latest deployment ID for verax-v2-base
+  [ChainName.BASE_MAINNET]: `https://gateway.thegraph.com/api/${THE_GRAPH_API_KEY}/subgraphs/id/fje2qXNP7KeRBZDPFv1VCERchv9PZyZokPRWNZkWtXk`,
+
+  // Base Sepolia
+  // Current: EbruygUvdowo7dmsumFmRq2hRu81K88mWsLo5r3jxY3S
+  // TODO: Verify this is the latest deployment ID for verax-v2-base-sepolia
+  [ChainName.BASE_SEPOLIA]: `https://gateway.thegraph.com/api/${THE_GRAPH_API_KEY}/subgraphs/id/EbruygUvdowo7dmsumFmRq2hRu81K88mWsLo5r3jxY3S`,
+
+  // BSC Mainnet
+  // Current: 8VfLNCBXCFKkcfmRSLDZ6J36NG5rRCUzEgByRJXCzSoW
+  // TODO: Verify this is the latest deployment ID for verax-v2-bsc
+  [ChainName.BSC_MAINNET]: `https://gateway.thegraph.com/api/${THE_GRAPH_API_KEY}/subgraphs/id/8VfLNCBXCFKkcfmRSLDZ6J36NG5rRCUzEgByRJXCzSoW`,
+
+  // BSC Testnet
+  // Current: 6iFYkMd9xbQcEcddHs6vbTMarra7d2NUt9S1qtNmWtaV
+  // TODO: Verify this is the latest deployment ID for verax-v2-bsc-testnet
+  [ChainName.BSC_TESTNET]: `https://gateway.thegraph.com/api/${THE_GRAPH_API_KEY}/subgraphs/id/6iFYkMd9xbQcEcddHs6vbTMarra7d2NUt9S1qtNmWtaV`,
+};
+
+/**
+ * Helper to check if we should use URL overrides.
+ * By default, always uses custom URLs (dev + prod) for better performance.
+ * Set VITE_USE_FREE_SUBGRAPH_URLS=true to disable and use free URLs.
+ */
+export const shouldUseCustomUrls = (): boolean => {
+  // Disable custom URLs only if explicitly requested
+  return import.meta.env.VITE_USE_FREE_SUBGRAPH_URLS !== "true";
+};
+
+/**
+ * Gets the subgraph URL overrides to use based on environment.
+ * Returns the custom URLs by default for better performance (higher rate limits).
+ */
+export const getSubgraphUrlOverrides = (): Partial<Record<ChainName, string>> | undefined => {
+  return shouldUseCustomUrls() ? SUBGRAPH_URL_OVERRIDES : undefined;
+};

--- a/explorer/src/pages/Attestations/index.tsx
+++ b/explorer/src/pages/Attestations/index.tsx
@@ -1,9 +1,10 @@
-import { Attestation, ChainName } from "@verax-attestation-registry/verax-sdk";
 import {
+  Attestation,
   Attestation_filter,
   Attestation_orderBy,
+  ChainName,
   OrderDirection,
-} from "@verax-attestation-registry/verax-sdk/lib/types/.graphclient";
+} from "@verax-attestation-registry/verax-sdk";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import { useTernaryDarkMode } from "usehooks-ts";

--- a/explorer/src/pages/MyAttestations/index.tsx
+++ b/explorer/src/pages/MyAttestations/index.tsx
@@ -1,4 +1,4 @@
-import { OrderDirection } from "@verax-attestation-registry/verax-sdk/lib/types/.graphclient";
+import { OrderDirection } from "@verax-attestation-registry/verax-sdk";
 import { ConnectKitButton } from "connectkit";
 import { t } from "i18next";
 import { ArchiveIcon, Check, Copy, Wallet } from "lucide-react";

--- a/explorer/src/pages/Search/components/SearchAttestationsReceived/loadAttestationReceivedList.ts
+++ b/explorer/src/pages/Search/components/SearchAttestationsReceived/loadAttestationReceivedList.ts
@@ -1,5 +1,4 @@
-import { OrderDirection } from "@verax-attestation-registry/verax-sdk/lib/types/.graphclient";
-import AttestationDataMapper from "@verax-attestation-registry/verax-sdk/lib/types/src/dataMapper/AttestationDataMapper";
+import { AttestationDataMapper, OrderDirection } from "@verax-attestation-registry/verax-sdk";
 
 import { ITEMS_SEARCHED_DEFAULT } from "@/constants";
 import { NetworkType } from "@/contexts/NetworkContext.ts";

--- a/explorer/src/pages/Search/components/SearchModules/loadModuleList.ts
+++ b/explorer/src/pages/Search/components/SearchModules/loadModuleList.ts
@@ -1,4 +1,4 @@
-import ModuleDataMapper from "@verax-attestation-registry/verax-sdk/lib/types/src/dataMapper/ModuleDataMapper";
+import { ModuleDataMapper } from "@verax-attestation-registry/verax-sdk";
 
 import { ITEMS_PER_PAGE_DEFAULT } from "@/constants";
 import { NetworkType } from "@/contexts/NetworkContext.ts";

--- a/explorer/src/pages/Search/components/SearchPortals/loadPortalList.ts
+++ b/explorer/src/pages/Search/components/SearchPortals/loadPortalList.ts
@@ -1,4 +1,4 @@
-import PortalDataMapper from "@verax-attestation-registry/verax-sdk/lib/types/src/dataMapper/PortalDataMapper";
+import { PortalDataMapper } from "@verax-attestation-registry/verax-sdk";
 
 import { ITEMS_PER_PAGE_DEFAULT } from "@/constants";
 import { NetworkType } from "@/contexts/NetworkContext.ts";

--- a/explorer/src/pages/Search/components/SearchSchemas/loadSchemaList.ts
+++ b/explorer/src/pages/Search/components/SearchSchemas/loadSchemaList.ts
@@ -1,4 +1,4 @@
-import SchemaDataMapper from "@verax-attestation-registry/verax-sdk/lib/types/src/dataMapper/SchemaDataMapper";
+import { SchemaDataMapper } from "@verax-attestation-registry/verax-sdk";
 
 import { ITEMS_PER_PAGE_DEFAULT } from "@/constants";
 import { NetworkType } from "@/contexts/NetworkContext.ts";

--- a/explorer/src/pages/Subject/index.tsx
+++ b/explorer/src/pages/Subject/index.tsx
@@ -1,4 +1,4 @@
-import { OrderDirection } from "@verax-attestation-registry/verax-sdk/lib/types/.graphclient";
+import { OrderDirection } from "@verax-attestation-registry/verax-sdk";
 import { Check, Copy } from "lucide-react";
 import { useMemo, useState } from "react";
 import { CopyToClipboard } from "react-copy-to-clipboard";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -124,8 +124,8 @@ importers:
         specifier: ^8.21.3
         version: 8.21.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@verax-attestation-registry/verax-sdk':
-        specifier: 3.0.0-beta-5
-        version: 3.0.0-beta-5(@graphql-mesh/types@0.104.13(graphql@16.10.0))(@graphql-tools/delegate@11.0.1(graphql@16.10.0))(@graphql-tools/utils@10.9.1(graphql@16.10.0))(@graphql-tools/wrap@11.0.1(graphql@16.10.0))(@types/node@22.18.12)(bufferutil@4.0.9)(encoding@0.1.13)(graphql-yoga@5.16.0(graphql@16.10.0))(typescript@5.2.2)(utf-8-validate@5.0.10)(zod@3.24.3)
+        specifier: 5.0.0
+        version: 5.0.0(@graphql-mesh/types@0.104.13(graphql@16.10.0))(@graphql-tools/delegate@11.0.1(graphql@16.10.0))(@graphql-tools/utils@10.9.1(graphql@16.10.0))(@graphql-tools/wrap@11.0.1(graphql@16.10.0))(@types/node@22.18.12)(bufferutil@4.0.9)(encoding@0.1.13)(graphql-yoga@5.16.0(graphql@16.10.0))(utf-8-validate@5.0.10)(viem@2.38.3(bufferutil@4.0.9)(typescript@5.2.2)(utf-8-validate@5.0.10)(zod@3.24.3))
       abitype:
         specifier: ^0.10.3
         version: 0.10.3(typescript@5.2.2)(zod@3.24.3)
@@ -4465,8 +4465,10 @@ packages:
   '@verax-attestation-registry/verax-contracts@10.0.0':
     resolution: {integrity: sha512-zpDSOabajbwUQIy8cQL/20WW3hotkyTmjUEKOgQo7/nTAvnF6/YPlN+4Fp1JixqHf5NTjpzeJjk/sbOfliX38Q==}
 
-  '@verax-attestation-registry/verax-sdk@3.0.0-beta-5':
-    resolution: {integrity: sha512-58lCILMdAgmZa+k/YQD13q9+NjMMYH+ILEQftIqQqzESf0mBk4ytFvSNbROAkdw/aVuz4hEhCvtL3wwJaEvajQ==}
+  '@verax-attestation-registry/verax-sdk@5.0.0':
+    resolution: {integrity: sha512-ORIQCiRV1p59BWfWoW0/jdl6dRSM3w7gSyunlOgFeZ6gVbduVNr9yT/7CLU9m4PxWe5Ay11it9UTJcwCVVlaiA==}
+    peerDependencies:
+      viem: ^2.0.0
 
   '@vitejs/plugin-react@4.7.0':
     resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
@@ -10077,9 +10079,9 @@ packages:
     resolution: {integrity: sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==}
     engines: {node: '>=8'}
 
-  uWebSockets.js@https://codeload.github.com/uNetworking/uWebSockets.js/tar.gz/af546e5c53c957df9c9f6ba6f76f8534fcb6a505:
-    resolution: {tarball: https://codeload.github.com/uNetworking/uWebSockets.js/tar.gz/af546e5c53c957df9c9f6ba6f76f8534fcb6a505}
-    version: 20.55.0
+  uWebSockets.js@https://codeload.github.com/uNetworking/uWebSockets.js/tar.gz/d04e707a1292928d50163ff7545e45c3e84c5ec3:
+    resolution: {tarball: https://codeload.github.com/uNetworking/uWebSockets.js/tar.gz/d04e707a1292928d50163ff7545e45c3e84c5ec3}
+    version: 20.56.0
 
   ua-parser-js@1.0.37:
     resolution: {integrity: sha512-bhTyI94tZofjo+Dn8SN6Zv8nBDvyXTymAdM3LDI/0IboIUwTu1rEhW7v2TfiVsoYWgkQ4kOVqnI8APUFbIQIFQ==}
@@ -13316,7 +13318,7 @@ snapshots:
       yargs: 17.7.2
     optionalDependencies:
       node-libcurl: 4.0.0(encoding@0.1.13)
-      uWebSockets.js: https://codeload.github.com/uNetworking/uWebSockets.js/tar.gz/af546e5c53c957df9c9f6ba6f76f8534fcb6a505
+      uWebSockets.js: https://codeload.github.com/uNetworking/uWebSockets.js/tar.gz/d04e707a1292928d50163ff7545e45c3e84c5ec3
     transitivePeerDependencies:
       - bufferutil
       - encoding
@@ -16872,7 +16874,7 @@ snapshots:
       '@openzeppelin/contracts': 4.9.6
       '@openzeppelin/contracts-upgradeable': 4.9.6
 
-  '@verax-attestation-registry/verax-sdk@3.0.0-beta-5(@graphql-mesh/types@0.104.13(graphql@16.10.0))(@graphql-tools/delegate@11.0.1(graphql@16.10.0))(@graphql-tools/utils@10.9.1(graphql@16.10.0))(@graphql-tools/wrap@11.0.1(graphql@16.10.0))(@types/node@22.18.12)(bufferutil@4.0.9)(encoding@0.1.13)(graphql-yoga@5.16.0(graphql@16.10.0))(typescript@5.2.2)(utf-8-validate@5.0.10)(zod@3.24.3)':
+  '@verax-attestation-registry/verax-sdk@5.0.0(@graphql-mesh/types@0.104.13(graphql@16.10.0))(@graphql-tools/delegate@11.0.1(graphql@16.10.0))(@graphql-tools/utils@10.9.1(graphql@16.10.0))(@graphql-tools/wrap@11.0.1(graphql@16.10.0))(@types/node@22.18.12)(bufferutil@4.0.9)(encoding@0.1.13)(graphql-yoga@5.16.0(graphql@16.10.0))(utf-8-validate@5.0.10)(viem@2.38.3(bufferutil@4.0.9)(typescript@5.2.2)(utf-8-validate@5.0.10)(zod@3.24.3))':
     dependencies:
       '@graphprotocol/client-add-source-name': 2.0.7(@graphql-mesh/types@0.104.13(graphql@16.10.0))(@graphql-tools/delegate@11.0.1(graphql@16.10.0))(@graphql-tools/utils@10.9.1(graphql@16.10.0))(@graphql-tools/wrap@11.0.1(graphql@16.10.0))(graphql@16.10.0)
       '@graphql-mesh/cache-localforage': 0.105.14(graphql@16.10.0)
@@ -16906,10 +16908,8 @@ snapshots:
       - graphql-yoga
       - ioredis
       - supports-color
-      - typescript
       - uWebSockets.js
       - utf-8-validate
-      - zod
 
   '@vitejs/plugin-react@4.7.0(vite@5.4.21(@types/node@22.18.12)(terser@5.31.0))':
     dependencies:
@@ -24305,7 +24305,7 @@ snapshots:
 
   typical@5.2.0: {}
 
-  uWebSockets.js@https://codeload.github.com/uNetworking/uWebSockets.js/tar.gz/af546e5c53c957df9c9f6ba6f76f8534fcb6a505:
+  uWebSockets.js@https://codeload.github.com/uNetworking/uWebSockets.js/tar.gz/d04e707a1292928d50163ff7545e45c3e84c5ec3:
     optional: true
 
   ua-parser-js@1.0.37: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,8 @@
+# 3 days
+minimumReleaseAge: 4320
+minimumReleaseAgeExclude:
+  - '@verax-attestation-registry/verax-sdk'
+
 packages:
   - contracts
   - examples


### PR DESCRIPTION
## What does this PR do?

Overrides the default subgraphs URLs on the Explorer to make sure it doesn't hit rate limits

### Type of change

- [ ] Chore
- [ ] Bug fix
- [X] New feature
- [ ] Documentation update

## Check list

- [ ] My&nbsp;contribution&nbsp;follows&nbsp;the&nbsp;project's&nbsp;[guidelines](https://github.com/Consensys/linea-attestation-registry/blob/dev/CONTRIBUTING.md)
- [ ] I have made corresponding changes to the documentation
- [ ] Unit tests for any smart contract change
- [ ] Contracts and functions are documented

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds centralized multichain subgraph URL overrides and updates explorer to verax-sdk v5 with refactored imports.
> 
> - **Explorer config**:
>   - Centralizes subgraph URLs via new `explorer/src/config/subgraphUrls.ts` with The Graph Gateway support and env-controlled overrides (`VITE_THE_GRAPH_API_KEY`, `VITE_USE_FREE_SUBGRAPH_URLS`).
>   - Wires `subgraphUrlOverrides` into all chains in `explorer/src/config/index.tsx` (`veraxEnv`), replacing per-chain `subgraphUrl` literals.
> - **SDK upgrade & API changes**:
>   - Bumps `@verax-attestation-registry/verax-sdk` to `5.0.0` in `explorer/package.json` and lockfile.
>   - Refactors imports across explorer pages to use root SDK exports (e.g., `AttestationDataMapper`, `ModuleDataMapper`, `PortalDataMapper`, `SchemaDataMapper`, `OrderDirection`, Graph types) instead of deep `.graphclient` paths.
> - **Workspace**:
>   - Adds release-age policy in `pnpm-workspace.yaml` with `minimumReleaseAge` and excludes `@verax-attestation-registry/verax-sdk`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7571bb87a07b43c40554bc90ee39eb1ea7b95ad9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->