### PR TITLE
chore(explorer): redirect legacy linea subject page

### DIFF
--- a/explorer/src/routes/LineaRedirect.tsx
+++ b/explorer/src/routes/LineaRedirect.tsx
@@ -1,0 +1,21 @@
+import { useEffect } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+
+/**
+ * Redirects legacy /linea/* URLs to /* by stripping the /linea prefix
+ * Example: /linea/subject/0xabc... -> /subject/0xabc...
+ */
+export const LineaRedirect = () => {
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  useEffect(() => {
+    const currentPath = location.pathname;
+    const newPath = currentPath.replace(/^\/linea/, "");
+    const fullPath = `${newPath}${location.search}${location.hash}`;
+    navigate(fullPath, { replace: true });
+  }, [navigate, location]);
+
+  return null;
+};
+

--- a/explorer/src/routes/index.tsx
+++ b/explorer/src/routes/index.tsx
@@ -15,6 +15,7 @@ import { Subject } from "@/pages/Subject";
 import { Providers } from "@/providers";
 
 import { APP_ROUTES } from "./constants";
+import { LineaRedirect } from "./LineaRedirect";
 import { NotFoundPage } from "./NotFoundPage";
 
 export const router = createBrowserRouter(
@@ -32,6 +33,7 @@ export const router = createBrowserRouter(
       <Route path={APP_ROUTES.MODULE_BY_ID} element={<Module />} />
       <Route path={APP_ROUTES.SEARCH} element={<Search />} />
       <Route path={APP_ROUTES.PORTAL_BY_ID} element={<Portal />} />
+      <Route path="/linea/*" element={<LineaRedirect />} />
       <Route path={APP_ROUTES.DEFAULT} element={<NotFoundPage />} />
     </Route>,
   ),


### PR DESCRIPTION
## What does this PR do?

Redirects legacy `/linea/...` URLs to multichain URLs

### Type of change

- [X] Chore
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update

## Check list

- [ ] My&nbsp;contribution&nbsp;follows&nbsp;the&nbsp;project's&nbsp;[guidelines](https://github.com/Consensys/linea-attestation-registry/blob/dev/CONTRIBUTING.md)
- [ ] I have made corresponding changes to the documentation
- [ ] Unit tests for any smart contract change
- [ ] Contracts and functions are documented

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add client-side redirect for legacy `/linea/*` URLs to their non-prefixed equivalents.
> 
> - **Frontend routing**:
>   - Add `LineaRedirect` component to strip `/linea` prefix and preserve query/hash.
>   - Register route `"/linea/*"` in `routes/index.tsx` to invoke the redirect.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fdb72ba058cfd355060318085deb121eaa5612a1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->