### PR TITLE
ci: bump actions/checkout to v6

### DIFF
--- a/.github/workflows/contracts-examples.yml
+++ b/.github/workflows/contracts-examples.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -85,7 +85,7 @@ jobs:
 
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -86,7 +86,7 @@ jobs:
 
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -136,7 +136,7 @@ jobs:
 
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           submodules: recursive
           fetch-depth: 0
@@ -239,7 +239,7 @@ jobs:
 
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           submodules: recursive
           fetch-depth: 0
@@ -436,7 +436,7 @@ jobs:
 
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           submodules: recursive
           fetch-depth: 0

--- a/.github/workflows/explorer-build.yml
+++ b/.github/workflows/explorer-build.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Install Pnpm
         uses: pnpm/action-setup@v2

--- a/.github/workflows/explorer-deploy-preview.yml
+++ b/.github/workflows/explorer-deploy-preview.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/explorer-deploy-prod.yml
+++ b/.github/workflows/explorer-deploy-prod.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Install Pnpm
         uses: pnpm/action-setup@v2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Install Pnpm
         uses: pnpm/action-setup@v2

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: "Check out the repo"
-        uses: "actions/checkout@v5"
+        uses: "actions/checkout@v6"
         with:
           fetch-depth: 0
           token: ${{ secrets.PROD_RELEASER_GH_TOKEN }}

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Install Pnpm
         uses: pnpm/action-setup@v2
@@ -101,7 +101,7 @@ jobs:
 
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Install Pnpm
         uses: pnpm/action-setup@v2

--- a/.github/workflows/subgraph.yml
+++ b/.github/workflows/subgraph.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Install Pnpm
         uses: pnpm/action-setup@v2


### PR DESCRIPTION
Updates CI to use `actions/checkout@v6` for improved performance and security.

https://github.com/actions/checkout/releases/tag/v6.0.0

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update all GitHub Actions workflows to use `actions/checkout@v6`.
> 
> - **CI/Workflows**:
>   - Upgrade `actions/checkout` to `v6` across workflows:
>     - `contracts*.yml` (build, test, coverage, upgradeability, size) and `contracts-examples.yml`
>     - `explorer-*.yml` (build, deploy preview, deploy prod)
>     - `sdk.yml` (unit, integration)
>     - `subgraph.yml`
>     - `lint.yml`
>     - `releaser.yml`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4f2288539fadd780831e7b6c55618d836d770181. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->