### PR TITLE
chore(global): bump Node.js and pnpm

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,9 +39,9 @@
     "typescript": "catalog:core",
     "typescript-eslint": "catalog:eslint"
   },
-  "packageManager": "pnpm@10.27.0",
+  "packageManager": "pnpm@10.28.0",
   "engines": {
-    "node": "22.21.1",
-    "pnpm": "10.27.0"
+    "node": "22.22.0",
+    "pnpm": "10.28.0"
   }
 }


### PR DESCRIPTION
## What does this PR do?

Bumps Node.js and pnpm

### Type of change

- [X] Chore
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update

## Check list

- [ ] My&nbsp;contribution&nbsp;follows&nbsp;the&nbsp;project's&nbsp;[guidelines](https://github.com/Consensys/linea-attestation-registry/blob/dev/CONTRIBUTING.md)
- [ ] I have made corresponding changes to the documentation
- [ ] Unit tests for any smart contract change
- [ ] Contracts and functions are documented

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates toolchain versions in `package.json`.
> 
> - Bump `engines.node` to `22.22.0`
> - Bump `engines.pnpm` and `packageManager` to `pnpm@10.28.0`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6ed834a0c7a2a8ea0b8a2a3f2e4b2aa9e90be81d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->