### PR TITLE
fix(ci): lockfile regeneration on Dependabot PRs

### DIFF
--- a/.github/workflows/contracts-examples.yml
+++ b/.github/workflows/contracts-examples.yml
@@ -21,6 +21,8 @@ env:
 
 jobs:
   build-examples:
+    # Skip initial Dependabot PR run - will re-run after lockfile update
+    if: github.actor != 'dependabot[bot]' || github.event.action == 'synchronize'
     runs-on: ubuntu-latest
 
     defaults:

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -6,7 +6,6 @@ on:
       - main
       - dev
       - release/*
-      - feat/multichain
   push:
     branches:
       - main
@@ -22,6 +21,8 @@ env:
 
 jobs:
   build-contracts:
+    # Skip initial Dependabot PR run - will re-run after lockfile update
+    if: github.actor != 'dependabot[bot]' || github.event.action == 'synchronize'
     runs-on: ubuntu-latest
 
     defaults:

--- a/.github/workflows/dependabot-lockfile.yml
+++ b/.github/workflows/dependabot-lockfile.yml
@@ -29,6 +29,9 @@ jobs:
           node-version-file: "package.json"
           cache: "pnpm"
 
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+
       - name: Update lockfile
         run: pnpm install --no-frozen-lockfile
 

--- a/.github/workflows/explorer-build.yml
+++ b/.github/workflows/explorer-build.yml
@@ -6,7 +6,6 @@ on:
       - main
       - dev
       - release/*
-      - feat/multichain
   push:
     branches:
       - main
@@ -19,6 +18,8 @@ concurrency:
 
 jobs:
   build-explorer:
+    # Skip initial Dependabot PR run - will re-run after lockfile update
+    if: github.actor != 'dependabot[bot]' || github.event.action == 'synchronize'
     runs-on: ubuntu-latest
 
     defaults:

--- a/.github/workflows/explorer-deploy-preview.yml
+++ b/.github/workflows/explorer-deploy-preview.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branches:
       - dev
-      - feat/multichain
     paths:
       - explorer/**
 
@@ -14,6 +13,8 @@ concurrency:
 
 jobs:
   deploy-explorer-preview:
+    # Skip initial Dependabot PR run - will re-run after lockfile update
+    if: github.actor != 'dependabot[bot]' || github.event.action == 'synchronize'
     runs-on: ubuntu-latest
 
     defaults:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,7 +6,6 @@ on:
       - main
       - dev
       - release/*
-      - feat/multichain
   push:
     branches:
       - main
@@ -19,6 +18,8 @@ concurrency:
 
 jobs:
   lint:
+    # Skip initial Dependabot PR run - will re-run after lockfile update
+    if: github.actor != 'dependabot[bot]' || github.event.action == 'synchronize'
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -6,7 +6,6 @@ on:
       - main
       - dev
       - release/*
-      - feat/multichain
   push:
     branches:
       - main
@@ -19,6 +18,8 @@ concurrency:
 
 jobs:
   unit-test-sdk:
+    # Skip initial Dependabot PR run - will re-run after lockfile update
+    if: github.actor != 'dependabot[bot]' || github.event.action == 'synchronize'
     runs-on: ubuntu-latest
 
     defaults:
@@ -72,6 +73,8 @@ jobs:
           echo "✅ Coverage not uploaded to Codecov" >> $GITHUB_STEP_SUMMARY
 
   integration-test-sdk:
+    # Skip initial Dependabot PR run - will re-run after lockfile update
+    if: github.actor != 'dependabot[bot]' || github.event.action == 'synchronize'
     runs-on: ubuntu-latest
 
     defaults:

--- a/.github/workflows/subgraph.yml
+++ b/.github/workflows/subgraph.yml
@@ -6,7 +6,6 @@ on:
       - main
       - dev
       - release/*
-      - feat/multichain
   push:
     branches:
       - main
@@ -19,6 +18,8 @@ concurrency:
 
 jobs:
   test-subgraph:
+    # Skip initial Dependabot PR run - will re-run after lockfile update
+    if: github.actor != 'dependabot[bot]' || github.event.action == 'synchronize'
     runs-on: ubuntu-22.04
 
     defaults:


### PR DESCRIPTION
## What does this PR do?

Fixes the pnpm lockfile regeneration on PRs opened by Dependabot

### Type of change

- [ ] Chore
- [X] Bug fix
- [ ] New feature
- [ ] Documentation update

## Check list

- [ ] My&nbsp;contribution&nbsp;follows&nbsp;the&nbsp;project's&nbsp;[guidelines](https://github.com/Consensys/linea-attestation-registry/blob/dev/CONTRIBUTING.md)
- [ ] I have made corresponding changes to the documentation
- [ ] Unit tests for any smart contract change
- [ ] Contracts and functions are documented

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves CI behavior for Dependabot PRs and ensures reliable lockfile regeneration.
> 
> - Add conditional `if: github.actor != 'dependabot[bot]' || github.event.action == 'synchronize'` to `contracts`, `contracts-examples`, `explorer` (build + preview), `lint`, `sdk` (unit + integration), and `subgraph` jobs to skip the initial Dependabot run
> - Update `dependabot-lockfile.yml` to install `Foundry` before `pnpm install` for lockfile refresh and commit
> - Remove outdated `feat/multichain` branch filters from multiple workflows
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3523f5e36a1978661e88edb894dba0b11c1ca69a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->