### PR TITLE
fix(explorer): Explorer always showing mainnet data when toggling between testnet/mainnet

### DIFF
--- a/explorer/package.json
+++ b/explorer/package.json
@@ -28,7 +28,7 @@
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@tanstack/react-query": "^5.90.16",
     "@tanstack/react-table": "^8.21.3",
-    "@verax-attestation-registry/verax-sdk": "5.1.0",
+    "@verax-attestation-registry/verax-sdk": "5.2.0",
     "abitype": "^0.10.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/explorer/src/pages/Attestation/index.tsx
+++ b/explorer/src/pages/Attestation/index.tsx
@@ -1,6 +1,5 @@
 import { memo, useCallback, useMemo } from "react";
 import { useParams } from "react-router-dom";
-import useSWR from "swr";
 
 import { AttestationData } from "./components/AttestationData";
 import { AttestationInfo } from "./components/AttestationInfo";
@@ -10,6 +9,7 @@ import { AttestationSchemaCard } from "./components/AttestationSchemaCard";
 import { Back } from "@/components/Back";
 import { NotFoundPage } from "@/components/NotFoundPage";
 import { useNetwork } from "@/contexts/NetworkContext.ts";
+import { useNetworkTypeSWR } from "@/hooks/useNetworkTypeSWR";
 import { SWRKeys } from "@/interfaces/swr/enum";
 import { useNetworkContext } from "@/providers/network-provider/context";
 
@@ -41,7 +41,7 @@ function AttestationComponent() {
     data: attestation,
     isLoading,
     isValidating,
-  } = useSWR(`${SWRKeys.GET_ATTESTATION_BY_ID}/${id}`, fetchAttestation, {
+  } = useNetworkTypeSWR(`${SWRKeys.GET_ATTESTATION_BY_ID}/${id}`, fetchAttestation, {
     shouldRetryOnError: false,
     revalidateOnFocus: false,
   });

--- a/explorer/src/pages/Issuer/components/Attestations/index.tsx
+++ b/explorer/src/pages/Issuer/components/Attestations/index.tsx
@@ -1,22 +1,29 @@
 import { Loader } from "lucide-react";
 import { useLocation, useNavigate } from "react-router-dom";
-import useSWR from "swr";
 
 import { IAttestationProps } from "./interface";
 
+import { useNetwork } from "@/contexts/NetworkContext";
+import { useNetworkTypeSWR } from "@/hooks/useNetworkTypeSWR";
 import { SWRKeys } from "@/interfaces/swr/enum";
 import { useNetworkContext } from "@/providers/network-provider/context";
 import { APP_ROUTES } from "@/routes/constants";
+import { mainnets, testnets } from "@/utils";
 import { formatNumber } from "@/utils/amountUtils";
 
 import "./styles.css";
 
 export const Attestations: React.FC<IAttestationProps> = ({ address }) => {
   const { sdk } = useNetworkContext();
+  const { networkType } = useNetwork();
   const navigate = useNavigate();
   const location = useLocation();
-  const { data: portals, isLoading } = useSWR(`${SWRKeys.GET_PORTALS_BY_ISSUER}/${address}`, () =>
-    sdk.portal.findBy(undefined, undefined, { ownerAddress: address }),
+
+  const chainsForQuery = networkType === "mainnet" ? mainnets : testnets;
+
+  const { data: portals, isLoading } = useNetworkTypeSWR(
+    `${SWRKeys.GET_PORTALS_BY_ISSUER}/${address}/${chainsForQuery.join(",")}`,
+    () => sdk.portal.findByMultiChain(chainsForQuery, undefined, undefined, { ownerAddress: address }),
   );
 
   const attestationCounter = portals ? portals.reduce((total, portal) => total + portal.attestationCounter, 0) : 0;

--- a/explorer/src/pages/Modules/index.tsx
+++ b/explorer/src/pages/Modules/index.tsx
@@ -1,6 +1,5 @@
 import { t } from "i18next";
-import { useMemo, useRef, useState } from "react";
-import useSWR from "swr";
+import { useRef, useState } from "react";
 import { useTernaryDarkMode } from "usehooks-ts";
 
 import { DataTable } from "@/components/DataTable";
@@ -10,6 +9,7 @@ import { columns, moduleColumnsOption, skeletonModules } from "@/constants/colum
 import { columnsSkeleton } from "@/constants/columns/skeleton";
 import { useNetwork } from "@/contexts/NetworkContext.ts";
 import { EQueryParams } from "@/enums/queryParams";
+import { useNetworkTypeSWR } from "@/hooks/useNetworkTypeSWR";
 import { SWRKeys } from "@/interfaces/swr/enum";
 import { useNetworkContext } from "@/providers/network-provider/context";
 import { APP_ROUTES } from "@/routes/constants";
@@ -21,9 +21,9 @@ export const Modules: React.FC = () => {
   const { networkType } = useNetwork();
   const { isDarkMode } = useTernaryDarkMode();
 
-  const chainsForQuery = useMemo(() => (networkType === "mainnet" ? mainnets : testnets), [networkType]);
+  const chainsForQuery = networkType === "mainnet" ? mainnets : testnets;
 
-  const { data: modulesCount } = useSWR(
+  const { data: modulesCount } = useNetworkTypeSWR(
     `${SWRKeys.GET_MODULE_COUNT}`,
     () => sdk.module.getModulesNumber() as Promise<bigint>,
   );
@@ -35,8 +35,9 @@ export const Modules: React.FC = () => {
 
   const [skip, setSkip] = useState<number>(getItemsByPage(page, itemsPerPage));
 
-  const { data: modulesList, isLoading } = useSWR(`${SWRKeys.GET_MODULE_LIST}/${itemsPerPage}/${skip}`, () =>
-    sdk.module.findByMultiChain(chainsForQuery, itemsPerPage, skip),
+  const { data: modulesList, isLoading } = useNetworkTypeSWR(
+    `${SWRKeys.GET_MODULE_LIST}/${chainsForQuery.join(",")}/${itemsPerPage}/${skip}`,
+    () => sdk.module.findByMultiChain(chainsForQuery, itemsPerPage, skip),
   );
 
   const handlePage = (retrievedPage: number) => {

--- a/explorer/src/pages/MyAttestations/index.tsx
+++ b/explorer/src/pages/MyAttestations/index.tsx
@@ -2,9 +2,8 @@ import { OrderDirection } from "@verax-attestation-registry/verax-sdk";
 import { ConnectKitButton } from "connectkit";
 import { t } from "i18next";
 import { ArchiveIcon, Check, Copy, Wallet } from "lucide-react";
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import { CopyToClipboard } from "react-copy-to-clipboard";
-import useSWR from "swr";
 import { useAccount } from "wagmi";
 
 import { CardView } from "../Attestations/components/CardView";
@@ -16,6 +15,7 @@ import { InfoBlock } from "@/components/InfoBlock";
 import { THOUSAND } from "@/constants";
 import { useNetwork } from "@/contexts/NetworkContext.ts";
 import { EQueryParams } from "@/enums/queryParams";
+import { useNetworkTypeSWR } from "@/hooks/useNetworkTypeSWR";
 import useWindowDimensions from "@/hooks/useWindowDimensions";
 import { SWRKeys } from "@/interfaces/swr/enum";
 import { useNetworkContext } from "@/providers/network-provider/context";
@@ -31,7 +31,7 @@ export const MyAttestations: React.FC = () => {
 
   const [copied, setCopied] = useState<boolean>(false);
 
-  const chainsForQuery = useMemo(() => (networkType === "mainnet" ? mainnets : testnets), [networkType]);
+  const chainsForQuery = networkType === "mainnet" ? mainnets : testnets;
 
   const handleCopy = (text: string, result: boolean) => {
     if (!result || !text) return;
@@ -46,8 +46,8 @@ export const MyAttestations: React.FC = () => {
   const searchParams = new URLSearchParams(window.location.search);
   const sortByDateDirection = searchParams.get(EQueryParams.SORT_BY_DATE);
 
-  const { data: attestationsList, isLoading } = useSWR(
-    `${SWRKeys.GET_ATTESTATION_LIST}/${address}/${sortByDateDirection}`,
+  const { data: attestationsList, isLoading } = useNetworkTypeSWR(
+    `${SWRKeys.GET_ATTESTATION_LIST}/${chainsForQuery.join(",")}/${address}/${sortByDateDirection}`,
     async () => {
       const rawAttestations = await sdk.attestation.findByMultiChain(
         chainsForQuery,

--- a/explorer/src/pages/Schema/components/RecentAttestations/index.tsx
+++ b/explorer/src/pages/Schema/components/RecentAttestations/index.tsx
@@ -1,12 +1,12 @@
 import { t } from "i18next";
-import { useMemo, useRef } from "react";
-import useSWR from "swr";
+import { useRef } from "react";
 import { useTernaryDarkMode } from "usehooks-ts";
 
 import { DataTable } from "@/components/DataTable";
 import { attestationColumnsOption, columns, skeletonAttestations } from "@/constants/columns/attestation";
 import { columnsSkeleton } from "@/constants/columns/skeleton";
 import { useNetwork } from "@/contexts/NetworkContext.ts";
+import { useNetworkTypeSWR } from "@/hooks/useNetworkTypeSWR";
 import { SWRKeys } from "@/interfaces/swr/enum";
 import { useNetworkContext } from "@/providers/network-provider/context";
 import { APP_ROUTES } from "@/routes/constants";
@@ -17,13 +17,13 @@ export const RecentAttestations: React.FC<{ schemaId?: string; portalId?: string
   const { networkType } = useNetwork();
   const { isDarkMode } = useTernaryDarkMode();
 
-  const chainsForQuery = useMemo(() => (networkType === "mainnet" ? mainnets : testnets), [networkType]);
+  const chainsForQuery = networkType === "mainnet" ? mainnets : testnets;
 
   const fetchKey = schemaId
-    ? `${SWRKeys.GET_RECENT_ATTESTATION_SCHEMA}/${schemaId}`
+    ? `${SWRKeys.GET_RECENT_ATTESTATION_SCHEMA}/${chainsForQuery.join(",")}/${schemaId}`
     : portalId
-      ? `${SWRKeys.GET_RECENT_ATTESTATION_PORTAL}/${portalId}`
-      : `${SWRKeys.GET_RECENT_ATTESTATION_GLOBAL}`;
+      ? `${SWRKeys.GET_RECENT_ATTESTATION_PORTAL}/${chainsForQuery.join(",")}/${portalId}`
+      : `${SWRKeys.GET_RECENT_ATTESTATION_GLOBAL}/${chainsForQuery.join(",")}`;
 
   const fetchFunction = schemaId
     ? () => sdk.attestation.findByMultiChain(chainsForQuery, 5, 0, { schema: schemaId }, "attestedDate", "desc")
@@ -31,7 +31,7 @@ export const RecentAttestations: React.FC<{ schemaId?: string; portalId?: string
       ? () => sdk.attestation.findByMultiChain(chainsForQuery, 5, 0, { portal: portalId }, "attestedDate", "desc")
       : () => sdk.attestation.findByMultiChain(chainsForQuery, 5, 0, {}, "attestedDate", "desc");
 
-  const { data: attestations, isLoading } = useSWR(fetchKey, fetchFunction, {
+  const { data: attestations, isLoading } = useNetworkTypeSWR(fetchKey, fetchFunction, {
     shouldRetryOnError: false,
   });
 

--- a/explorer/src/pages/Schema/index.tsx
+++ b/explorer/src/pages/Schema/index.tsx
@@ -1,7 +1,6 @@
 import { ChainName } from "@verax-attestation-registry/verax-sdk";
 import { t } from "i18next";
 import { useParams } from "react-router-dom";
-import useSWR from "swr";
 import { useTernaryDarkMode } from "usehooks-ts";
 
 import { RecentAttestations } from "./components/RecentAttestations";
@@ -12,6 +11,7 @@ import { NotFoundPage } from "@/components/NotFoundPage";
 import { Tooltip } from "@/components/Tooltip";
 import { regexEthAddress, urlRegex } from "@/constants/regex";
 import { useNetwork } from "@/contexts/NetworkContext.ts";
+import { useNetworkTypeSWR } from "@/hooks/useNetworkTypeSWR";
 import { SWRKeys } from "@/interfaces/swr/enum";
 import { useNetworkContext } from "@/providers/network-provider/context";
 import { mainnets, testnets } from "@/utils";
@@ -23,20 +23,17 @@ export const Schema: React.FC = () => {
   const { networkType } = useNetwork();
   const { isDarkMode } = useTernaryDarkMode();
 
+  const chainsForQuery = networkType === "mainnet" ? mainnets : testnets;
+
   const {
     data: schemaData,
     isLoading,
     isValidating,
-  } = useSWR(
-    `${SWRKeys.GET_SCHEMA_BY_ID}/${id}`,
+  } = useNetworkTypeSWR(
+    `${SWRKeys.GET_SCHEMA_BY_ID}/${chainsForQuery.join(",")}/${id}`,
     async () => {
       if (id && regexEthAddress.byNumberOfChar[64].test(id)) {
-        const schemas = await sdk.schema.findByMultiChain(
-          networkType === "mainnet" ? mainnets : testnets,
-          undefined,
-          undefined,
-          { id },
-        );
+        const schemas = await sdk.schema.findByMultiChain(chainsForQuery, undefined, undefined, { id });
 
         if (schemas && schemas.length > 0) {
           const schema = schemas[0];

--- a/explorer/src/pages/Schemas/index.tsx
+++ b/explorer/src/pages/Schemas/index.tsx
@@ -1,7 +1,6 @@
 import { Schema } from "@verax-attestation-registry/verax-sdk";
 import { t } from "i18next";
 import { useMemo, useRef, useState } from "react";
-import useSWR from "swr";
 import { useTernaryDarkMode } from "usehooks-ts";
 
 import { DataTable } from "@/components/DataTable";
@@ -11,6 +10,7 @@ import { columns, schemaColumnsOption, skeletonSchemas } from "@/constants/colum
 import { columnsSkeleton } from "@/constants/columns/skeleton";
 import { useNetwork } from "@/contexts/NetworkContext.ts";
 import { EQueryParams } from "@/enums/queryParams";
+import { useNetworkTypeSWR } from "@/hooks/useNetworkTypeSWR";
 import { SWRKeys } from "@/interfaces/swr/enum";
 import { useNetworkContext } from "@/providers/network-provider/context";
 import { APP_ROUTES } from "@/routes/constants";
@@ -27,10 +27,11 @@ export const Schemas: React.FC = () => {
   const { networkType } = useNetwork();
   const { isDarkMode } = useTernaryDarkMode();
 
-  const chainsForQuery = useMemo(() => (networkType === "mainnet" ? mainnets : testnets), [networkType]);
+  const chainsForQuery = networkType === "mainnet" ? mainnets : testnets;
 
-  const { data: allSchemas, isLoading: isLoadingSchemas } = useSWR(`${SWRKeys.GET_ALL_SCHEMAS}`, () =>
-    sdk.schema.findByMultiChain(chainsForQuery),
+  const { data: allSchemas, isLoading: isLoadingSchemas } = useNetworkTypeSWR(
+    `${SWRKeys.GET_ALL_SCHEMAS}/${chainsForQuery.join(",")}`,
+    () => sdk.schema.findByMultiChain(chainsForQuery),
   );
 
   const uniqueSchemas = useMemo(() => {

--- a/explorer/src/pages/Search/components/SearchAttestationsReceived/index.tsx
+++ b/explorer/src/pages/Search/components/SearchAttestationsReceived/index.tsx
@@ -1,5 +1,4 @@
 import { t } from "i18next";
-import useSWR from "swr";
 
 import { loadAttestationReceivedList } from "./loadAttestationReceivedList.ts";
 import { SearchComponentProps } from "../interfaces";
@@ -9,6 +8,7 @@ import { DataTable } from "@/components/DataTable";
 import { columns } from "@/constants/columns/attestation";
 import { useNetwork } from "@/contexts/NetworkContext.ts";
 import { EQueryParams } from "@/enums/queryParams.ts";
+import { useNetworkTypeSWR } from "@/hooks/useNetworkTypeSWR";
 import { SWRKeys } from "@/interfaces/swr/enum";
 import { useNetworkContext } from "@/providers/network-provider/context";
 import { APP_ROUTES } from "@/routes/constants";
@@ -25,12 +25,11 @@ export const SearchAttestationsReceived: React.FC<SearchComponentProps> = ({
   const searchParams = new URLSearchParams(window.location.search);
   const sortByDateDirection = searchParams.get(EQueryParams.SORT_BY_DATE);
 
-  const { data } = useSWR(
+  const { data } = useNetworkTypeSWR(
     `${SWRKeys.GET_ATTESTATION_LIST}/${SWRKeys.SEARCH}/${search}/${sortByDateDirection}`,
     async () => loadAttestationReceivedList(sdk.attestation, parsedString, sortByDateDirection, networkType),
     {
       shouldRetryOnError: false,
-      revalidateAll: false,
       onSuccess: (successData) => getSearchData(successData.length, true),
       onError: () => getSearchData(0, true),
     },

--- a/explorer/src/pages/Search/components/SearchModules/index.tsx
+++ b/explorer/src/pages/Search/components/SearchModules/index.tsx
@@ -1,5 +1,4 @@
 import { t } from "i18next";
-import useSWR from "swr";
 
 import { loadModuleList } from "./loadModuleList";
 import { SearchComponentProps } from "../interfaces";
@@ -8,6 +7,7 @@ import { SearchWrapper } from "../SearchWrapper";
 import { DataTable } from "@/components/DataTable";
 import { columns } from "@/constants/columns/module";
 import { useNetwork } from "@/contexts/NetworkContext.ts";
+import { useNetworkTypeSWR } from "@/hooks/useNetworkTypeSWR";
 import { SWRKeys } from "@/interfaces/swr/enum";
 import { useNetworkContext } from "@/providers/network-provider/context";
 import { APP_ROUTES } from "@/routes/constants";
@@ -19,12 +19,11 @@ export const SearchModules: React.FC<SearchComponentProps> = ({ getSearchData, p
 
   const { networkType } = useNetwork();
 
-  const { data } = useSWR(
+  const { data } = useNetworkTypeSWR(
     `${SWRKeys.GET_MODULE_LIST}/${SWRKeys.SEARCH}/${search}`,
     async () => loadModuleList(module, parsedString, networkType),
     {
       shouldRetryOnError: false,
-      revalidateAll: false,
       onSuccess: (successData) => getSearchData(successData.length, true),
       onError: () => getSearchData(0, true),
     },

--- a/explorer/src/pages/Search/components/SearchPortals/index.tsx
+++ b/explorer/src/pages/Search/components/SearchPortals/index.tsx
@@ -1,5 +1,4 @@
 import { t } from "i18next";
-import useSWR from "swr";
 
 import { loadPortalList } from "./loadPortalList";
 import { SearchComponentProps } from "../interfaces";
@@ -8,6 +7,7 @@ import { SearchWrapper } from "../SearchWrapper";
 import { DataTable } from "@/components/DataTable";
 import { columns } from "@/constants/columns/portal";
 import { useNetwork } from "@/contexts/NetworkContext.ts";
+import { useNetworkTypeSWR } from "@/hooks/useNetworkTypeSWR";
 import { SWRKeys } from "@/interfaces/swr/enum";
 import { useNetworkContext } from "@/providers/network-provider/context";
 import { APP_ROUTES } from "@/routes/constants";
@@ -19,12 +19,11 @@ export const SearchPortals: React.FC<SearchComponentProps> = ({ getSearchData, p
 
   const { networkType } = useNetwork();
 
-  const { data } = useSWR(
+  const { data } = useNetworkTypeSWR(
     `${SWRKeys.GET_PORTAL_LIST}/${SWRKeys.SEARCH}/${search}`,
     async () => loadPortalList(portal, parsedString, networkType),
     {
       shouldRetryOnError: false,
-      revalidateAll: false,
       onSuccess: (successData) => getSearchData(successData.length, true),
       onError: () => getSearchData(0, true),
     },

--- a/explorer/src/pages/Search/components/SearchSchemas/index.tsx
+++ b/explorer/src/pages/Search/components/SearchSchemas/index.tsx
@@ -1,5 +1,4 @@
 import { t } from "i18next";
-import useSWR from "swr";
 
 import { loadSchemaList } from "./loadSchemaList";
 import { SearchComponentProps } from "../interfaces";
@@ -8,6 +7,7 @@ import { SearchWrapper } from "../SearchWrapper";
 import { DataTable } from "@/components/DataTable";
 import { columns } from "@/constants/columns/schema";
 import { useNetwork } from "@/contexts/NetworkContext.ts";
+import { useNetworkTypeSWR } from "@/hooks/useNetworkTypeSWR";
 import { SWRKeys } from "@/interfaces/swr/enum";
 import { useNetworkContext } from "@/providers/network-provider/context";
 import { APP_ROUTES } from "@/routes/constants";
@@ -19,12 +19,11 @@ export const SearchSchemas: React.FC<SearchComponentProps> = ({ getSearchData, p
 
   const { networkType } = useNetwork();
 
-  const { data } = useSWR(
+  const { data } = useNetworkTypeSWR(
     `${SWRKeys.GET_SCHEMAS_LIST}/${SWRKeys.SEARCH}/${search}`,
     async () => loadSchemaList(schema, parsedString, networkType),
     {
       shouldRetryOnError: false,
-      revalidateAll: false,
       onSuccess: (successData) => getSearchData(successData.length, true),
       onError: () => getSearchData(0, true),
     },

--- a/explorer/src/pages/Subject/index.tsx
+++ b/explorer/src/pages/Subject/index.tsx
@@ -1,9 +1,8 @@
 import { OrderDirection } from "@verax-attestation-registry/verax-sdk";
 import { Check, Copy } from "lucide-react";
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import { CopyToClipboard } from "react-copy-to-clipboard";
 import { useParams } from "react-router-dom";
-import useSWR from "swr";
 import { isAddress } from "viem";
 
 import { CardView } from "../Attestations/components/CardView";
@@ -12,6 +11,7 @@ import { Title } from "@/components/Title";
 import { THOUSAND } from "@/constants";
 import { useNetwork } from "@/contexts/NetworkContext.ts";
 import { EQueryParams } from "@/enums/queryParams";
+import { useNetworkTypeSWR } from "@/hooks/useNetworkTypeSWR";
 import useWindowDimensions from "@/hooks/useWindowDimensions.ts";
 import { SWRKeys } from "@/interfaces/swr/enum";
 import { useNetworkContext } from "@/providers/network-provider/context";
@@ -29,7 +29,7 @@ export const Subject: React.FC = () => {
 
   const [copied, setCopied] = useState<boolean>(false);
 
-  const chainsForQuery = useMemo(() => (networkType === "mainnet" ? mainnets : testnets), [networkType]);
+  const chainsForQuery = networkType === "mainnet" ? mainnets : testnets;
 
   const handleCopy = (text: string, result: boolean) => {
     if (!result || !text) return;
@@ -41,8 +41,8 @@ export const Subject: React.FC = () => {
 
   const CopyIcon = copied ? Check : Copy;
 
-  const { data: attestationsList } = useSWR(
-    `${SWRKeys.GET_ATTESTATION_LIST}/${subject}/${sortByDateDirection}`,
+  const { data: attestationsList } = useNetworkTypeSWR(
+    `${SWRKeys.GET_ATTESTATION_LIST}/${chainsForQuery.join(",")}/${subject}/${sortByDateDirection}`,
     async () => {
       const rawAttestations = await sdk.attestation.findByMultiChain(
         chainsForQuery,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -188,8 +188,8 @@ importers:
         specifier: ^8.21.3
         version: 8.21.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@verax-attestation-registry/verax-sdk':
-        specifier: 5.1.0
-        version: 5.1.0(@types/node@22.19.3)(bufferutil@4.1.0)(graphql-yoga@5.18.0(graphql@16.12.0))(utf-8-validate@5.0.10)(viem@2.44.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5))
+        specifier: 5.2.0
+        version: 5.2.0(@types/node@22.19.3)(bufferutil@4.1.0)(graphql-yoga@5.18.0(graphql@16.12.0))(utf-8-validate@5.0.10)(viem@2.44.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5))
       abitype:
         specifier: ^0.10.3
         version: 0.10.3(typescript@5.9.3)(zod@4.3.5)
@@ -320,9 +320,9 @@ importers:
 
   sdk:
     dependencies:
-      '@graphql-mesh/cache-localforage':
-        specifier: ^0.105.19
-        version: 0.105.20(graphql@16.12.0)
+      '@graphql-mesh/cache-inmemory-lru':
+        specifier: ^0.8.20
+        version: 0.8.20(graphql@16.12.0)
       '@graphql-mesh/cross-helpers':
         specifier: ^0.4.11
         version: 0.4.11(graphql@16.12.0)
@@ -1989,12 +1989,6 @@ packages:
       '@graphql-mesh/utils': ^0.102.13
       graphql: '*'
       tslib: ^2.4.0
-
-  '@graphql-mesh/cache-localforage@0.105.20':
-    resolution: {integrity: sha512-l8n211O9150tZOcVbs5ewluAHcnMGTCdFWPybk39vTsNwiWghTcpfcq4OHUDkZKXb4ZePLJs4cpSjyp81PHR1A==}
-    engines: {node: '>=16.0.0'}
-    peerDependencies:
-      graphql: '*'
 
   '@graphql-mesh/cli@0.95.4':
     resolution: {integrity: sha512-NVVOQaszhR1aQCWR3oxuuMZvgyZMW+Zyd53GO8CA15RhPGcPVqaL/zz5cGXSKjIZ6HK0VThGuxzocsfq0AcsOw==}
@@ -4491,8 +4485,8 @@ packages:
   '@verax-attestation-registry/verax-contracts@10.0.0':
     resolution: {integrity: sha512-zpDSOabajbwUQIy8cQL/20WW3hotkyTmjUEKOgQo7/nTAvnF6/YPlN+4Fp1JixqHf5NTjpzeJjk/sbOfliX38Q==}
 
-  '@verax-attestation-registry/verax-sdk@5.1.0':
-    resolution: {integrity: sha512-AqkdRgwGxK4CcZruYQVA0rbU5o6k6iauoetE97odzWxHVArBL6HU2LukCKhXCZsl7BlfB1irwQIbf+Mco5Jwgg==}
+  '@verax-attestation-registry/verax-sdk@5.2.0':
+    resolution: {integrity: sha512-TI06e9v5COJdBtTuB8WJbRF+yYeRSlTVpfoXTBZWiVI+tlF5tST8vzJYQOnapb/cN1ad8wVaPksxd+L+6YabLQ==}
     peerDependencies:
       viem: ^2.0.0
 
@@ -10295,7 +10289,7 @@ snapshots:
       '@babel/generator': 7.28.5
       '@babel/parser': 7.28.5
       '@babel/runtime': 7.28.4
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.28.5(supports-color@5.5.0)
       '@babel/types': 7.28.5
       babel-preset-fbjs: 3.4.0(@babel/core@7.28.5)
       chalk: 4.1.2
@@ -10740,11 +10734,11 @@ snapshots:
       '@babel/helpers': 7.28.4
       '@babel/parser': 7.28.5
       '@babel/template': 7.27.2
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.28.5(supports-color@5.5.0)
       '@babel/types': 7.28.5
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 7.7.3
@@ -10779,7 +10773,7 @@ snapshots:
       '@babel/helper-optimise-call-expression': 7.27.1
       '@babel/helper-replace-supers': 7.27.1(@babel/core@7.28.5)
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.28.5(supports-color@5.5.0)
       semver: 7.7.3
     transitivePeerDependencies:
       - supports-color
@@ -10796,7 +10790,7 @@ snapshots:
       '@babel/core': 7.28.5
       '@babel/helper-compilation-targets': 7.27.2
       '@babel/helper-plugin-utils': 7.27.1
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       lodash.debounce: 4.0.8
       resolve: 1.22.11
     transitivePeerDependencies:
@@ -10806,14 +10800,7 @@ snapshots:
 
   '@babel/helper-member-expression-to-functions@7.28.5':
     dependencies:
-      '@babel/traverse': 7.28.5
-      '@babel/types': 7.28.5
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/helper-module-imports@7.27.1':
-    dependencies:
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.28.5(supports-color@5.5.0)
       '@babel/types': 7.28.5
     transitivePeerDependencies:
       - supports-color
@@ -10828,9 +10815,9 @@ snapshots:
   '@babel/helper-module-transforms@7.28.3(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-module-imports': 7.27.1
+      '@babel/helper-module-imports': 7.27.1(supports-color@5.5.0)
       '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.28.5(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -10845,7 +10832,7 @@ snapshots:
       '@babel/core': 7.28.5
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-wrap-function': 7.28.3
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.28.5(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -10854,13 +10841,13 @@ snapshots:
       '@babel/core': 7.28.5
       '@babel/helper-member-expression-to-functions': 7.28.5
       '@babel/helper-optimise-call-expression': 7.27.1
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.28.5(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-skip-transparent-expression-wrappers@7.27.1':
     dependencies:
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.28.5(supports-color@5.5.0)
       '@babel/types': 7.28.5
     transitivePeerDependencies:
       - supports-color
@@ -10874,7 +10861,7 @@ snapshots:
   '@babel/helper-wrap-function@7.28.3':
     dependencies:
       '@babel/template': 7.27.2
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.28.5(supports-color@5.5.0)
       '@babel/types': 7.28.5
     transitivePeerDependencies:
       - supports-color
@@ -10892,7 +10879,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.28.5(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -10919,7 +10906,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.28.5(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -11055,14 +11042,14 @@ snapshots:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.28.5)
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.28.5(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
   '@babel/plugin-transform-async-to-generator@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-module-imports': 7.27.1
+      '@babel/helper-module-imports': 7.27.1(supports-color@5.5.0)
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.28.5)
     transitivePeerDependencies:
@@ -11102,7 +11089,7 @@ snapshots:
       '@babel/helper-globals': 7.28.0
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-replace-supers': 7.27.1(@babel/core@7.28.5)
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.28.5(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -11116,7 +11103,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.28.5(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -11179,7 +11166,7 @@ snapshots:
       '@babel/core': 7.28.5
       '@babel/helper-compilation-targets': 7.27.2
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.28.5(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -11225,7 +11212,7 @@ snapshots:
       '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.5)
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.28.5(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -11265,7 +11252,7 @@ snapshots:
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.28.5)
       '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.28.5)
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.28.5(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -11336,7 +11323,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-module-imports': 7.27.1
+      '@babel/helper-module-imports': 7.27.1(supports-color@5.5.0)
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.28.5)
       '@babel/types': 7.28.5
@@ -11362,7 +11349,7 @@ snapshots:
   '@babel/plugin-transform-runtime@7.28.5(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-module-imports': 7.27.1
+      '@babel/helper-module-imports': 7.27.1(supports-color@5.5.0)
       '@babel/helper-plugin-utils': 7.27.1
       babel-plugin-polyfill-corejs2: 0.4.14(@babel/core@7.28.5)
       babel-plugin-polyfill-corejs3: 0.13.0(@babel/core@7.28.5)
@@ -11534,18 +11521,6 @@ snapshots:
       '@babel/code-frame': 7.27.1
       '@babel/parser': 7.28.5
       '@babel/types': 7.28.5
-
-  '@babel/traverse@7.28.5':
-    dependencies:
-      '@babel/code-frame': 7.27.1
-      '@babel/generator': 7.28.5
-      '@babel/helper-globals': 7.28.0
-      '@babel/parser': 7.28.5
-      '@babel/template': 7.27.2
-      '@babel/types': 7.28.5
-      debug: 4.4.3(supports-color@8.1.1)
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/traverse@7.28.5(supports-color@5.5.0)':
     dependencies:
@@ -11908,7 +11883,7 @@ snapshots:
   '@eslint/config-array@0.21.1':
     dependencies:
       '@eslint/object-schema': 2.1.7
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -11924,7 +11899,7 @@ snapshots:
   '@eslint/eslintrc@3.3.3':
     dependencies:
       ajv: 6.12.6
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       espree: 10.4.0
       globals: 14.0.0
       ignore: 5.3.2
@@ -12481,18 +12456,6 @@ snapshots:
       graphql: 16.12.0
       localforage: 1.10.0
       tslib: 2.8.1
-
-  '@graphql-mesh/cache-localforage@0.105.20(graphql@16.12.0)':
-    dependencies:
-      '@graphql-mesh/cache-inmemory-lru': 0.8.20(graphql@16.12.0)
-      '@graphql-mesh/types': 0.104.18(graphql@16.12.0)
-      '@graphql-mesh/utils': 0.104.19(graphql@16.12.0)
-      graphql: 16.12.0
-      localforage: 1.10.0
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - '@nats-io/nats-core'
-      - ioredis
 
   '@graphql-mesh/cli@0.95.4(bufferutil@4.1.0)(encoding@0.1.13)(graphql-tag@2.12.6(graphql@16.12.0))(graphql-yoga@5.18.0(graphql@16.12.0))(graphql@16.12.0)(utf-8-validate@5.0.10)':
     dependencies:
@@ -13165,7 +13128,7 @@ snapshots:
       '@babel/core': 7.28.5
       '@babel/parser': 7.28.5
       '@babel/plugin-syntax-import-assertions': 7.27.1(@babel/core@7.28.5)
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.28.5(supports-color@5.5.0)
       '@babel/types': 7.28.5
       '@graphql-tools/utils': 11.0.0(graphql@16.12.0)
       graphql: 16.12.0
@@ -13809,7 +13772,7 @@ snapshots:
       '@scure/base': 1.2.6
       '@types/debug': 4.1.12
       '@types/lodash': 4.17.21
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       lodash: 4.17.21
       pony-cause: 2.1.11
       semver: 7.7.3
@@ -13821,7 +13784,7 @@ snapshots:
     dependencies:
       '@ethereumjs/tx': 4.2.0
       '@types/debug': 4.1.12
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       semver: 7.7.3
       superstruct: 1.0.4
     transitivePeerDependencies:
@@ -13834,7 +13797,7 @@ snapshots:
       '@noble/hashes': 1.8.0
       '@scure/base': 1.2.6
       '@types/debug': 4.1.12
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       pony-cause: 2.1.11
       semver: 7.7.3
       uuid: 9.0.1
@@ -13848,7 +13811,7 @@ snapshots:
       '@noble/hashes': 1.8.0
       '@scure/base': 1.2.6
       '@types/debug': 4.1.12
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       pony-cause: 2.1.11
       semver: 7.7.3
       uuid: 9.0.1
@@ -13994,7 +13957,7 @@ snapshots:
 
   '@nomicfoundation/hardhat-ethers@3.1.3(ethers@6.16.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(hardhat@2.28.3(bufferutil@4.1.0)(ts-node@10.9.2(@types/node@22.19.3)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.10))':
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       ethers: 6.16.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       hardhat: 2.28.3(bufferutil@4.1.0)(ts-node@10.9.2(@types/node@22.19.3)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.10)
       lodash.isequal: 4.5.0
@@ -14020,7 +13983,7 @@ snapshots:
       '@nomicfoundation/ignition-core': 0.15.15(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       '@nomicfoundation/ignition-ui': 0.15.13
       chalk: 4.1.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       fs-extra: 10.1.0
       hardhat: 2.28.3(bufferutil@4.1.0)(ts-node@10.9.2(@types/node@22.19.3)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.10)
       json5: 2.2.3
@@ -14061,7 +14024,7 @@ snapshots:
       '@ethersproject/abi': 5.8.0
       '@ethersproject/address': 5.8.0
       cbor: 8.1.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       hardhat: 2.28.3(bufferutil@4.1.0)(ts-node@10.9.2(@types/node@22.19.3)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.10)
       lodash.clonedeep: 4.5.0
       picocolors: 1.1.1
@@ -14076,7 +14039,7 @@ snapshots:
       '@ethersproject/address': 5.6.1
       '@nomicfoundation/solidity-analyzer': 0.1.2
       cbor: 9.0.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       ethers: 6.16.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       fs-extra: 10.1.0
       immer: 10.0.2
@@ -14281,7 +14244,7 @@ snapshots:
       '@openzeppelin/defender-sdk-network-client': 2.7.0(debug@4.4.3)(encoding@0.1.13)
       '@openzeppelin/upgrades-core': 1.44.2
       chalk: 4.1.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       ethereumjs-util: 7.1.5
       ethers: 6.16.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       hardhat: 2.28.3(bufferutil@4.1.0)(ts-node@10.9.2(@types/node@22.19.3)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.10)
@@ -14301,7 +14264,7 @@ snapshots:
       cbor: 10.0.11
       chalk: 4.1.2
       compare-versions: 6.1.1
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       ethereumjs-util: 7.1.5
       minimatch: 9.0.5
       minimist: 1.2.8
@@ -15951,7 +15914,7 @@ snapshots:
   '@theguild/federation-composition@0.21.1(graphql@16.12.0)':
     dependencies:
       constant-case: 3.0.4
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       graphql: 16.12.0
       json5: 2.2.3
       lodash.sortby: 4.7.0
@@ -16168,7 +16131,7 @@ snapshots:
       '@typescript-eslint/types': 8.52.0
       '@typescript-eslint/typescript-estree': 8.52.0(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.52.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       eslint: 9.39.2(jiti@1.21.7)
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -16178,7 +16141,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.52.0(typescript@5.9.3)
       '@typescript-eslint/types': 8.52.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -16197,7 +16160,7 @@ snapshots:
       '@typescript-eslint/types': 8.52.0
       '@typescript-eslint/typescript-estree': 8.52.0(typescript@5.9.3)
       '@typescript-eslint/utils': 8.52.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       eslint: 9.39.2(jiti@1.21.7)
       ts-api-utils: 2.4.0(typescript@5.9.3)
       typescript: 5.9.3
@@ -16212,7 +16175,7 @@ snapshots:
       '@typescript-eslint/tsconfig-utils': 8.52.0(typescript@5.9.3)
       '@typescript-eslint/types': 8.52.0
       '@typescript-eslint/visitor-keys': 8.52.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       minimatch: 9.0.5
       semver: 7.7.3
       tinyglobby: 0.2.15
@@ -16303,9 +16266,9 @@ snapshots:
       '@openzeppelin/contracts': 4.9.6
       '@openzeppelin/contracts-upgradeable': 4.9.6
 
-  '@verax-attestation-registry/verax-sdk@5.1.0(@types/node@22.19.3)(bufferutil@4.1.0)(graphql-yoga@5.18.0(graphql@16.12.0))(utf-8-validate@5.0.10)(viem@2.44.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5))':
+  '@verax-attestation-registry/verax-sdk@5.2.0(@types/node@22.19.3)(bufferutil@4.1.0)(graphql-yoga@5.18.0(graphql@16.12.0))(utf-8-validate@5.0.10)(viem@2.44.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.5))':
     dependencies:
-      '@graphql-mesh/cache-localforage': 0.105.20(graphql@16.12.0)
+      '@graphql-mesh/cache-inmemory-lru': 0.8.20(graphql@16.12.0)
       '@graphql-mesh/cross-helpers': 0.4.11(graphql@16.12.0)
       '@graphql-mesh/graphql': 0.104.21(@types/node@22.19.3)(bufferutil@4.1.0)(crossws@0.3.5)(graphql@16.12.0)(utf-8-validate@5.0.10)
       '@graphql-mesh/http': 0.106.21(graphql@16.12.0)
@@ -17090,7 +17053,7 @@ snapshots:
 
   agent-base@6.0.2:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -18303,7 +18266,7 @@ snapshots:
 
   dns-over-http-resolver@1.2.3(node-fetch@3.3.2):
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       native-fetch: 3.0.0(node-fetch@3.3.2)
       receptacle: 1.3.2
     transitivePeerDependencies:
@@ -18407,7 +18370,7 @@ snapshots:
   engine.io-client@6.6.4(bufferutil@4.1.0)(utf-8-validate@5.0.10):
     dependencies:
       '@socket.io/component-emitter': 3.1.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       engine.io-parser: 5.2.3
       ws: 8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       xmlhttprequest-ssl: 2.1.2
@@ -18638,7 +18601,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.52.0
       comment-parser: 1.4.1
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       eslint: 9.39.2(jiti@1.21.7)
       eslint-import-context: 0.1.9(unrs-resolver@1.11.1)
       is-glob: 4.0.3
@@ -18707,7 +18670,7 @@ snapshots:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       escape-string-regexp: 4.0.0
       eslint-scope: 8.4.0
       eslint-visitor-keys: 4.2.1
@@ -19053,7 +19016,7 @@ snapshots:
 
   follow-redirects@1.15.11(debug@4.4.3):
     optionalDependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
 
   for-each@0.3.5:
     dependencies:
@@ -19541,7 +19504,7 @@ snapshots:
       boxen: 5.1.2
       chokidar: 4.0.3
       ci-info: 2.0.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       enquirer: 2.4.1
       env-paths: 2.2.1
       ethereum-cryptography: 1.2.0
@@ -19667,7 +19630,7 @@ snapshots:
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
     optional: true
@@ -19684,14 +19647,14 @@ snapshots:
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
     optional: true
@@ -20116,7 +20079,7 @@ snapshots:
   istanbul-lib-source-maps@5.0.6:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       istanbul-lib-coverage: 3.2.2
     transitivePeerDependencies:
       - supports-color
@@ -22342,7 +22305,7 @@ snapshots:
   socket.io-client@4.8.3(bufferutil@4.1.0)(utf-8-validate@5.0.10):
     dependencies:
       '@socket.io/component-emitter': 3.1.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       engine.io-client: 6.6.4(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       socket.io-parser: 4.2.5
     transitivePeerDependencies:
@@ -22353,14 +22316,14 @@ snapshots:
   socket.io-parser@4.2.5:
     dependencies:
       '@socket.io/component-emitter': 3.1.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
   socks-proxy-agent@8.0.5:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       socks: 2.8.7
     transitivePeerDependencies:
       - supports-color
@@ -22984,7 +22947,7 @@ snapshots:
       cac: 6.7.14
       chokidar: 4.0.3
       consola: 3.4.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       esbuild: 0.27.2
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
@@ -23036,7 +22999,7 @@ snapshots:
   typechain@8.3.2(typescript@5.9.3):
     dependencies:
       '@types/prettier': 2.7.3
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       fs-extra: 7.0.1
       glob: 7.1.7
       js-sha3: 0.8.0
@@ -23413,7 +23376,7 @@ snapshots:
 
   vite-tsconfig-paths@5.1.4(typescript@5.9.3)(vite@6.4.1(@types/node@22.19.3)(jiti@1.21.7)(tsx@4.21.0)):
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       globrex: 0.1.2
       tsconfck: 3.1.6(typescript@5.9.3)
     optionalDependencies:

--- a/sdk/.graphclient/index.ts
+++ b/sdk/.graphclient/index.ts
@@ -7,7 +7,7 @@ import type { GetMeshOptions } from '@graphql-mesh/runtime';
 import type { YamlConfig } from '@graphql-mesh/types';
 import { PubSub } from '@graphql-mesh/utils';
 import { DefaultLogger } from '@graphql-mesh/utils';
-import MeshCache from "@graphql-mesh/cache-localforage";
+import MeshCache from "@graphql-mesh/cache-inmemory-lru";
 import { fetch as fetchFn } from '@whatwg-node/fetch';
 
 import { MeshResolvedSource } from '@graphql-mesh/runtime';
@@ -1727,7 +1727,7 @@ const pubsub = new PubSub();
 const sourcesStore = rootStore.child('sources');
 const logger = new DefaultLogger("GraphClient");
 const cache = new (MeshCache as any)({
-      ...({} as any),
+      ...({"max":1000} as any),
       importFn,
       store: rootStore.child('cache'),
       pubsub,

--- a/sdk/.graphclientrc.yml
+++ b/sdk/.graphclientrc.yml
@@ -1,4 +1,12 @@
 # .graphclientrc.yml
+
+# Use in-memory cache to avoid cross-network cache pollution
+# The localforage cache keys are based on query+variables but NOT context,
+# so mainnet and testnet queries with same variables would collide
+cache:
+  inmemoryLru:
+    max: 1000
+
 sources:
   - name: linea-attestation-registry
     handler:

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verax-attestation-registry/verax-sdk",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "description": "Verax Attestation Registry SDK to interact with the subgraph and the contracts",
   "keywords": [
     "linea-attestation-registry",
@@ -58,7 +58,7 @@
     "test:unit:coverage": "pnpm run test:unit --coverage"
   },
   "dependencies": {
-    "@graphql-mesh/cache-localforage": "^0.105.19",
+    "@graphql-mesh/cache-inmemory-lru": "^0.8.20",
     "@graphql-mesh/cross-helpers": "^0.4.11",
     "@graphql-mesh/graphql": "^0.104.20",
     "@graphql-mesh/http": "^0.106.20",

--- a/sdk/src/dataMapper/AttestationDataMapper.ts
+++ b/sdk/src/dataMapper/AttestationDataMapper.ts
@@ -86,7 +86,7 @@ export default class AttestationDataMapper extends BaseDataMapper<
     orderBy?: Attestation_orderBy,
     orderDirection?: OrderDirection,
   ) {
-    const crossChainClient = await this.getCrossChainClient();
+    const crossChainClient = await this.getCrossChainClient(chainNames);
     const attestationsResult = await crossChainClient.MultichainAttestationsQuery({
       chainNames: chainNames,
       first: first,

--- a/sdk/src/dataMapper/BaseDataMapper.test.ts
+++ b/sdk/src/dataMapper/BaseDataMapper.test.ts
@@ -5,13 +5,13 @@ import { lineaSepolia } from "viem/chains";
 import { ChainName, Conf } from "../types";
 import { SDKMode, VeraxSdk } from "../VeraxSdk";
 import { subgraphCall, stringifyWhereClause } from "../utils/graphClientHelper";
-import { getCustomGraphSDK } from "../utils/graphClientBuilder";
-import { getBuiltGraphSDK } from "../../.graphclient";
+import { getCustomGraphSDKForChains } from "../utils/graphClientBuilder";
+import { getSDKForChains } from "../utils/meshInstanceManager";
 import { getConfiguredSubgraphUrl } from "../utils/urlResolver";
 
 jest.mock("../utils/graphClientHelper");
 jest.mock("../utils/graphClientBuilder");
-jest.mock("../../.graphclient");
+jest.mock("../utils/meshInstanceManager");
 jest.mock("../utils/urlResolver");
 
 type TestType = {
@@ -189,17 +189,18 @@ describe("BaseDataMapper", () => {
     };
 
     beforeEach(() => {
-      (getBuiltGraphSDK as jest.Mock).mockReturnValue(mockCrossChainClient);
-      (getCustomGraphSDK as jest.Mock).mockResolvedValue(mockCrossChainClient);
+      (getSDKForChains as jest.Mock).mockResolvedValue(mockCrossChainClient);
+      (getCustomGraphSDKForChains as jest.Mock).mockResolvedValue(mockCrossChainClient);
     });
 
     it("should use default SDK when no URL overrides are provided", async () => {
       const mapper = new MockDataMapper(mockConf, mockWeb3Client, mockVeraxSdk, mockWalletClient);
+      const chainNames = [ChainName.LINEA_MAINNET];
 
-      const client = await mapper["getCrossChainClient"]();
+      const client = await mapper["getCrossChainClient"](chainNames);
 
-      expect(getBuiltGraphSDK).toHaveBeenCalled();
-      expect(getCustomGraphSDK).not.toHaveBeenCalled();
+      expect(getSDKForChains).toHaveBeenCalledWith(chainNames);
+      expect(getCustomGraphSDKForChains).not.toHaveBeenCalled();
       expect(client).toBe(mockCrossChainClient);
     });
 
@@ -212,23 +213,25 @@ describe("BaseDataMapper", () => {
       };
 
       const mapper = new MockDataMapper(confWithOverrides, mockWeb3Client, mockVeraxSdk, mockWalletClient);
+      const chainNames = [ChainName.LINEA_MAINNET];
 
-      const client = await mapper["getCrossChainClient"]();
+      const client = await mapper["getCrossChainClient"](chainNames);
 
-      expect(getCustomGraphSDK).toHaveBeenCalledWith(confWithOverrides.subgraphUrlOverrides);
-      expect(getBuiltGraphSDK).not.toHaveBeenCalled();
+      expect(getCustomGraphSDKForChains).toHaveBeenCalledWith(chainNames, confWithOverrides.subgraphUrlOverrides);
+      expect(getSDKForChains).not.toHaveBeenCalled();
       expect(client).toBe(mockCrossChainClient);
     });
 
-    it("should cache the client instance on subsequent calls", async () => {
+    it("should cache the client instance on subsequent calls for same network type", async () => {
       const mapper = new MockDataMapper(mockConf, mockWeb3Client, mockVeraxSdk, mockWalletClient);
+      const chainNames = [ChainName.LINEA_MAINNET];
 
-      // Call twice
-      const client1 = await mapper["getCrossChainClient"]();
-      const client2 = await mapper["getCrossChainClient"]();
+      // Call twice with same network type
+      const client1 = await mapper["getCrossChainClient"](chainNames);
+      const client2 = await mapper["getCrossChainClient"](chainNames);
 
-      // Should only call getBuiltGraphSDK once (lazy initialization)
-      expect(getBuiltGraphSDK).toHaveBeenCalledTimes(1);
+      // Should only call getSDKForChains once (cached by network type)
+      expect(getSDKForChains).toHaveBeenCalledTimes(1);
       expect(client1).toBe(client2);
     });
 
@@ -241,14 +244,28 @@ describe("BaseDataMapper", () => {
       };
 
       const mapper = new MockDataMapper(confWithOverrides, mockWeb3Client, mockVeraxSdk, mockWalletClient);
+      const chainNames = [ChainName.LINEA_MAINNET];
 
       // Call twice
-      const client1 = await mapper["getCrossChainClient"]();
-      const client2 = await mapper["getCrossChainClient"]();
+      const client1 = await mapper["getCrossChainClient"](chainNames);
+      const client2 = await mapper["getCrossChainClient"](chainNames);
 
-      // Should only call getCustomGraphSDK once (lazy initialization)
-      expect(getCustomGraphSDK).toHaveBeenCalledTimes(1);
+      // Should only call getCustomGraphSDKForChains once (cached by network type)
+      expect(getCustomGraphSDKForChains).toHaveBeenCalledTimes(1);
       expect(client1).toBe(client2);
+    });
+
+    it("should create separate clients for mainnet and testnet chains", async () => {
+      const mapper = new MockDataMapper(mockConf, mockWeb3Client, mockVeraxSdk, mockWalletClient);
+
+      // Call with mainnet chains
+      await mapper["getCrossChainClient"]([ChainName.LINEA_MAINNET]);
+
+      // Call with testnet chains
+      await mapper["getCrossChainClient"]([ChainName.LINEA_SEPOLIA]);
+
+      // Should call getSDKForChains twice (different network types)
+      expect(getSDKForChains).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/sdk/src/dataMapper/BaseDataMapper.ts
+++ b/sdk/src/dataMapper/BaseDataMapper.ts
@@ -1,19 +1,26 @@
 import { PublicClient, WalletClient } from "viem";
-import { Conf, CrossChainClient } from "../types";
-import { getBuiltGraphSDK, OrderDirection } from "../../.graphclient";
+import { ChainName, Conf, CrossChainClient } from "../types";
+import { OrderDirection } from "../../.graphclient";
 import { VeraxSdk } from "../VeraxSdk";
 import { stringifyWhereClause, subgraphCall } from "../utils/graphClientHelper";
-import { getCustomGraphSDK } from "../utils/graphClientBuilder";
+import { getCustomGraphSDKForChains } from "../utils/graphClientBuilder";
+import { getSDKForChains } from "../utils/meshInstanceManager";
 import { getConfiguredSubgraphUrl } from "../utils/urlResolver";
+import { NetworkType, inferNetworkType } from "../utils/networkTypeUtils";
 
 export default abstract class BaseDataMapper<T, TFilter, TOrder> {
   protected readonly conf: Conf;
   protected readonly web3Client: PublicClient;
   protected readonly walletClient: WalletClient | undefined;
-  private crossChainClientPromise: Promise<CrossChainClient> | null = null;
   protected readonly veraxSdk: VeraxSdk;
   protected abstract typeName: string;
   protected abstract gqlInterface: string;
+
+  /**
+   * Cache of cross-chain clients keyed by network type.
+   * Maintains separate clients for mainnet and testnet to prevent cache pollution.
+   */
+  private crossChainClients: Map<NetworkType, Promise<CrossChainClient>> = new Map();
 
   constructor(_conf: Conf, _web3Client: PublicClient, _veraxSdk: VeraxSdk, _walletClient?: WalletClient) {
     this.conf = _conf;
@@ -22,18 +29,35 @@ export default abstract class BaseDataMapper<T, TFilter, TOrder> {
     this.walletClient = _walletClient;
   }
 
-  protected async getCrossChainClient(): Promise<CrossChainClient> {
-    if (!this.crossChainClientPromise) {
-      // Initialize the client lazily on first use
+  /**
+   * Gets a cross-chain client for the specified chain names.
+   * Automatically infers the network type (mainnet/testnet) and returns
+   * an appropriately isolated client to prevent cache pollution.
+   *
+   * @param chainNames - Array of chain names to query
+   * @returns Promise resolving to a CrossChainClient
+   * @throws Error if chain names mix mainnet and testnet
+   */
+  protected async getCrossChainClient(chainNames: (ChainName | string)[]): Promise<CrossChainClient> {
+    const networkType = inferNetworkType(chainNames);
+
+    // Check if we have a cached client for this network type
+    let clientPromise = this.crossChainClients.get(networkType);
+
+    if (!clientPromise) {
+      // Create new client with proper isolation
       if (this.conf.subgraphUrlOverrides) {
         // Use custom SDK builder with URL overrides
-        this.crossChainClientPromise = getCustomGraphSDK(this.conf.subgraphUrlOverrides);
+        clientPromise = getCustomGraphSDKForChains(chainNames, this.conf.subgraphUrlOverrides);
       } else {
-        // Use default SDK without overrides
-        this.crossChainClientPromise = Promise.resolve(getBuiltGraphSDK());
+        // Use standard SDK with network-type isolation
+        clientPromise = getSDKForChains(chainNames);
       }
+
+      this.crossChainClients.set(networkType, clientPromise);
     }
-    return this.crossChainClientPromise;
+
+    return clientPromise;
   }
 
   async findOneById(id: string) {

--- a/sdk/src/dataMapper/ModuleDataMapper.ts
+++ b/sdk/src/dataMapper/ModuleDataMapper.ts
@@ -25,7 +25,7 @@ export default class ModuleDataMapper extends BaseDataMapper<Module, Module_filt
     orderBy?: Module_orderBy,
     orderDirection?: OrderDirection,
   ) {
-    const crossChainClient = await this.getCrossChainClient();
+    const crossChainClient = await this.getCrossChainClient(chainNames);
     const modulesResult = await crossChainClient.MultichainModulesQuery({
       chainNames: chainNames,
       first: first,

--- a/sdk/src/dataMapper/PortalDataMapper.ts
+++ b/sdk/src/dataMapper/PortalDataMapper.ts
@@ -31,7 +31,7 @@ export default class PortalDataMapper extends BaseDataMapper<Portal, Portal_filt
     orderBy?: Portal_orderBy,
     orderDirection?: OrderDirection,
   ) {
-    const crossChainClient = await this.getCrossChainClient();
+    const crossChainClient = await this.getCrossChainClient(chainNames);
     const portalsResult = await crossChainClient.MultichainPortalsQuery({
       chainNames: chainNames,
       first: first,

--- a/sdk/src/dataMapper/SchemaDataMapper.ts
+++ b/sdk/src/dataMapper/SchemaDataMapper.ts
@@ -26,7 +26,7 @@ export default class SchemaDataMapper extends BaseDataMapper<Schema, Schema_filt
     orderBy?: Schema_orderBy,
     orderDirection?: OrderDirection,
   ) {
-    const crossChainClient = await this.getCrossChainClient();
+    const crossChainClient = await this.getCrossChainClient(chainNames);
     const schemasResult = await crossChainClient.MultichainSchemasQuery({
       chainNames: chainNames,
       first: first,

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -37,6 +37,18 @@ export * from "./utils/constants";
 // Utilities (for advanced usage)
 export { encode, decodeWithRetry } from "./utils/abiCoder";
 export { handleError } from "./utils/errorHandler";
-export { getCustomGraphSDK } from "./utils/graphClientBuilder";
+export { getCustomGraphSDK, getCustomGraphSDKForChains, clearCustomSDKCache } from "./utils/graphClientBuilder";
 export { getSubgraphUrlForChain, getConfiguredSubgraphUrl } from "./utils/urlResolver";
 export type { IPFSConfig } from "./types";
+
+// Network type utilities (for cache isolation)
+export {
+  inferNetworkType,
+  getNetworkTypeForChain,
+  isTestnetChain,
+  validateNetworkType,
+  type NetworkType,
+} from "./utils/networkTypeUtils";
+
+// Mesh instance management (for advanced cache control)
+export { getSDKForNetworkType, getSDKForChains, clearMeshCache, getMeshCacheStatus } from "./utils/meshInstanceManager";

--- a/sdk/src/resolvers.ts
+++ b/sdk/src/resolvers.ts
@@ -3,6 +3,16 @@ import { Attestation, MeshContext, Module, Portal, Resolvers, Schema } from "../
 // Extended context with chainName for multichain queries
 type ExtendedMeshContext = MeshContext & { chainName?: string };
 
+/**
+ * Helper to extract successful results from Promise.allSettled.
+ * Filters out rejected promises and returns only fulfilled values.
+ */
+function getSuccessfulResults<T>(results: PromiseSettledResult<T>[]): T[] {
+  return results
+    .filter((result): result is PromiseFulfilledResult<T> => result.status === "fulfilled")
+    .map((result) => result.value);
+}
+
 export const resolvers: Resolvers = {
   Attestation: {
     chainName: (root, _args, context) =>
@@ -21,8 +31,8 @@ export const resolvers: Resolvers = {
       root.chainName || (context as ExtendedMeshContext).chainName || "verax-v2-linea",
   },
   Query: {
-    multichainAttestations: async (root, args, context, info) =>
-      Promise.all(
+    multichainAttestations: async (root, args, context, info) => {
+      const results = await Promise.allSettled(
         args.chainNames.map((chainName) =>
           context["linea-attestation-registry"].Query.attestations({
             root,
@@ -39,9 +49,11 @@ export const resolvers: Resolvers = {
             })),
           ),
         ),
-      ).then((allAttestations) => allAttestations.flat()),
-    multichainPortals: async (root, args, context, info) =>
-      Promise.all(
+      );
+      return getSuccessfulResults(results).flat();
+    },
+    multichainPortals: async (root, args, context, info) => {
+      const results = await Promise.allSettled(
         args.chainNames.map((chainName) =>
           context["linea-attestation-registry"].Query.portals({
             root,
@@ -58,9 +70,11 @@ export const resolvers: Resolvers = {
             })),
           ),
         ),
-      ).then((allPortals) => allPortals.flat()),
-    multichainSchemas: async (root, args, context, info) =>
-      Promise.all(
+      );
+      return getSuccessfulResults(results).flat();
+    },
+    multichainSchemas: async (root, args, context, info) => {
+      const results = await Promise.allSettled(
         args.chainNames.map((chainName) =>
           context["linea-attestation-registry"].Query.schemas({
             root,
@@ -77,9 +91,11 @@ export const resolvers: Resolvers = {
             })),
           ),
         ),
-      ).then((allSchemas) => allSchemas.flat()),
-    multichainModules: async (root, args, context, info) =>
-      Promise.all(
+      );
+      return getSuccessfulResults(results).flat();
+    },
+    multichainModules: async (root, args, context, info) => {
+      const results = await Promise.allSettled(
         args.chainNames.map((chainName) =>
           context["linea-attestation-registry"].Query.modules({
             root,
@@ -96,6 +112,8 @@ export const resolvers: Resolvers = {
             })),
           ),
         ),
-      ).then((allModules) => allModules.flat()),
+      );
+      return getSuccessfulResults(results).flat();
+    },
   },
 };

--- a/sdk/src/utils/graphClientBuilder.test.ts
+++ b/sdk/src/utils/graphClientBuilder.test.ts
@@ -1,4 +1,5 @@
-import { getCustomGraphSDK } from "./graphClientBuilder";
+import { getCustomGraphSDK, clearCustomSDKCache } from "./graphClientBuilder";
+import { clearMeshCache } from "./meshInstanceManager";
 import { getMeshOptions, getSdk } from "../../.graphclient";
 import { getMesh } from "@graphql-mesh/runtime";
 import { ChainName } from "../types";
@@ -19,9 +20,13 @@ describe("graphClientBuilder", () => {
     let mockFetch: jest.Mock;
     let mockMeshOptions: Awaited<ReturnType<typeof getMeshOptions>>;
     let mockMesh: Awaited<ReturnType<typeof getMesh>>;
+    let mockPubsub: { subscribe: jest.Mock; unsubscribe: jest.Mock };
 
     beforeEach(() => {
       jest.clearAllMocks();
+      // Clear caches between tests
+      clearCustomSDKCache();
+      clearMeshCache();
 
       // Create mock fetch function
       mockFetch = jest.fn().mockResolvedValue({
@@ -36,6 +41,12 @@ describe("graphClientBuilder", () => {
         transforms: [],
       } as unknown as Awaited<ReturnType<typeof getMeshOptions>>;
 
+      // Create mock pubsub
+      mockPubsub = {
+        subscribe: jest.fn().mockReturnValue("sub-id"),
+        unsubscribe: jest.fn(),
+      };
+
       // Create mock SDK methods
       const mockSDK = {
         MultichainAttestationsQuery: jest.fn(),
@@ -44,9 +55,11 @@ describe("graphClientBuilder", () => {
         MultichainModulesQuery: jest.fn(),
       };
 
-      // Create mock mesh instance
+      // Create mock mesh instance with pubsub
       mockMesh = {
         sdkRequesterFactory: jest.fn().mockReturnValue(jest.fn()),
+        pubsub: mockPubsub,
+        destroy: jest.fn(),
       } as unknown as Awaited<ReturnType<typeof getMesh>>;
 
       (getMeshOptions as jest.Mock).mockResolvedValue(mockMeshOptions);
@@ -58,8 +71,7 @@ describe("graphClientBuilder", () => {
       const sdk = await getCustomGraphSDK();
 
       expect(getMeshOptions).toHaveBeenCalled();
-      expect(getMesh).toHaveBeenCalledWith(mockMeshOptions);
-      expect(mockMesh.sdkRequesterFactory).toHaveBeenCalled();
+      expect(getMesh).toHaveBeenCalled();
       expect(sdk).toBeDefined();
       expect(sdk.MultichainAttestationsQuery).toBeDefined();
     });
@@ -167,17 +179,13 @@ describe("graphClientBuilder", () => {
       expect(mockFetch).toHaveBeenCalledWith(customUrl, {}, {});
     });
 
-    it("should not wrap fetchFn when URL overrides are empty", async () => {
+    it("should use isolated mesh instance when URL overrides are empty", async () => {
       const urlOverrides = {};
 
       await getCustomGraphSDK(urlOverrides);
 
       expect(getMeshOptions).toHaveBeenCalled();
       expect(getMesh).toHaveBeenCalled();
-
-      // Verify that fetchFn was NOT wrapped when overrides are empty
-      const modifiedOptions = (getMesh as jest.Mock).mock.calls[0][0];
-      expect(modifiedOptions.fetchFn).toBe(mockFetch);
     });
 
     it("should work without any URL overrides parameter", async () => {
@@ -185,10 +193,31 @@ describe("graphClientBuilder", () => {
 
       expect(getMeshOptions).toHaveBeenCalled();
       expect(getMesh).toHaveBeenCalled();
+    });
 
-      // Verify that fetchFn was NOT wrapped when no overrides provided
-      const modifiedOptions = (getMesh as jest.Mock).mock.calls[0][0];
-      expect(modifiedOptions.fetchFn).toBe(mockFetch);
+    it("should use different instances for mainnet and testnet network types", async () => {
+      // Request mainnet SDK
+      await getCustomGraphSDK(undefined, "mainnet");
+
+      // Clear mocks to track second call
+      const firstCallCount = (getMesh as jest.Mock).mock.calls.length;
+
+      // Request testnet SDK - should create new instance
+      await getCustomGraphSDK(undefined, "testnet");
+
+      // Should have made another getMesh call for testnet
+      expect((getMesh as jest.Mock).mock.calls.length).toBe(firstCallCount + 1);
+    });
+
+    it("should cache SDK instances per network type", async () => {
+      // Request mainnet SDK twice
+      await getCustomGraphSDK(undefined, "mainnet");
+      const firstCallCount = (getMesh as jest.Mock).mock.calls.length;
+
+      await getCustomGraphSDK(undefined, "mainnet");
+
+      // Should NOT have made another getMesh call (cached)
+      expect((getMesh as jest.Mock).mock.calls.length).toBe(firstCallCount);
     });
   });
 });

--- a/sdk/src/utils/graphClientBuilder.ts
+++ b/sdk/src/utils/graphClientBuilder.ts
@@ -1,36 +1,99 @@
 import { getMeshOptions, getSdk } from "../../.graphclient";
 import { getMesh } from "@graphql-mesh/runtime";
 import { ChainName, CrossChainClient } from "../types";
+import { NetworkType, inferNetworkType } from "./networkTypeUtils";
+import { getSDKForNetworkType } from "./meshInstanceManager";
 
 type FetchFn = (url: string, options?: RequestInit, context?: Record<string, unknown>) => Promise<Response>;
 
 /**
+ * Cache for custom SDK instances with URL overrides.
+ * Keyed by network type to maintain cache isolation.
+ */
+const customSDKCache: Map<NetworkType, CrossChainClient> = new Map();
+
+/**
  * Creates a custom GraphQL Mesh SDK with URL overrides for multi-chain queries.
  * Falls back to default URLs if no override is provided for a specific chain.
+ *
+ * This function maintains network-type isolation: separate SDK instances
+ * are created for mainnet and testnet to prevent cache pollution.
+ *
+ * @param urlOverrides - Optional map of chain names to custom subgraph URLs
+ * @param networkType - The network type to use. If not provided, defaults to 'mainnet'.
  */
-export async function getCustomGraphSDK(urlOverrides?: Partial<Record<ChainName, string>>): Promise<CrossChainClient> {
+export async function getCustomGraphSDK(
+  urlOverrides?: Partial<Record<ChainName, string>>,
+  networkType: NetworkType = "mainnet",
+): Promise<CrossChainClient> {
+  // If no URL overrides, use the standard isolated SDK
+  if (!urlOverrides || Object.keys(urlOverrides).length === 0) {
+    return getSDKForNetworkType(networkType);
+  }
+
+  // For custom URL overrides, we need to create a custom mesh instance
+  // We cache these by network type as well
+  const cacheKey = networkType;
+
+  // Note: This simple caching doesn't account for different urlOverrides combinations.
+  // If the same app uses different override configs, consider adding urlOverrides to the cache key.
+  // For now, we assume urlOverrides are consistent per app instance.
+  const cachedClient = customSDKCache.get(cacheKey);
+  if (cachedClient) {
+    return cachedClient;
+  }
+
   const meshOptions = await getMeshOptions();
 
-  if (urlOverrides && Object.keys(urlOverrides).length > 0) {
-    const originalFetch = meshOptions.fetchFn as FetchFn;
+  const originalFetch = meshOptions.fetchFn as FetchFn;
 
-    meshOptions.fetchFn = async (url: string, options?: RequestInit, context?: Record<string, unknown>) => {
-      // Check if we should override the URL based on chain name in the URL
-      for (const [chainName, customUrl] of Object.entries(urlOverrides)) {
-        if (url.includes(chainName)) {
-          return originalFetch(customUrl, options, context);
-        }
+  meshOptions.fetchFn = async (url: string, options?: RequestInit, context?: Record<string, unknown>) => {
+    // Sort chain names by length (longest first) to avoid prefix matching issues
+    // e.g., "verax-v2-linea-sepolia" should match before "verax-v2-linea"
+    const sortedOverrides = Object.entries(urlOverrides).sort(([a], [b]) => b.length - a.length);
+
+    for (const [chainName, customUrl] of sortedOverrides) {
+      if (url.includes(chainName)) {
+        return originalFetch(customUrl, options, context);
       }
+    }
 
-      // No override found, use the original URL
-      return originalFetch(url, options, context);
-    };
-  }
+    return originalFetch(url, options, context);
+  };
 
   const mesh = await getMesh(meshOptions);
   const globalContext = {};
   const sdkRequester = mesh.sdkRequesterFactory(globalContext);
 
-  // Wrap the requester with getSdk to get the typed methods
-  return getSdk((...args) => sdkRequester(...args)) as unknown as CrossChainClient;
+  const client = getSdk((...args) => sdkRequester(...args)) as unknown as CrossChainClient;
+  customSDKCache.set(cacheKey, client);
+
+  return client;
+}
+
+/**
+ * Gets a custom SDK for the given chain names, automatically inferring the network type.
+ * Convenience method that combines getCustomGraphSDK with network type inference.
+ *
+ * @param chainNames - Array of chain names to query
+ * @param urlOverrides - Optional map of chain names to custom subgraph URLs
+ * @throws Error if chain names mix mainnet and testnet
+ */
+export async function getCustomGraphSDKForChains(
+  chainNames: (ChainName | string)[],
+  urlOverrides?: Partial<Record<ChainName, string>>,
+): Promise<CrossChainClient> {
+  const networkType = inferNetworkType(chainNames);
+  return getCustomGraphSDK(urlOverrides, networkType);
+}
+
+/**
+ * Clears the custom SDK cache for a specific network type or all types.
+ */
+export function clearCustomSDKCache(networkType?: NetworkType): void {
+  if (networkType) {
+    customSDKCache.delete(networkType);
+  } else {
+    customSDKCache.clear();
+  }
 }

--- a/sdk/src/utils/meshInstanceManager.test.ts
+++ b/sdk/src/utils/meshInstanceManager.test.ts
@@ -1,0 +1,180 @@
+import { getSDKForNetworkType, getSDKForChains, clearMeshCache, getMeshCacheStatus } from "./meshInstanceManager";
+import { getMeshOptions, getSdk } from "../../.graphclient";
+import { getMesh } from "@graphql-mesh/runtime";
+import { ChainName } from "../types";
+
+// Mock the GraphQL Mesh functions
+jest.mock("../../.graphclient", () => ({
+  getMeshOptions: jest.fn(),
+  getSdk: jest.fn(),
+}));
+
+jest.mock("@graphql-mesh/runtime", () => ({
+  getMesh: jest.fn(),
+}));
+
+describe("meshInstanceManager", () => {
+  let mockFetch: jest.Mock;
+  let mockMeshOptions: Awaited<ReturnType<typeof getMeshOptions>>;
+  let mockMesh: Awaited<ReturnType<typeof getMesh>>;
+  let mockPubsub: { subscribe: jest.Mock; unsubscribe: jest.Mock };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    // Clear all cached instances before each test
+    await clearMeshCache();
+
+    // Create mock fetch function
+    mockFetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: {} }),
+    });
+
+    // Create mock mesh options
+    mockMeshOptions = {
+      fetchFn: mockFetch,
+      sources: [],
+      transforms: [],
+    } as unknown as Awaited<ReturnType<typeof getMeshOptions>>;
+
+    // Create mock pubsub
+    mockPubsub = {
+      subscribe: jest.fn().mockReturnValue("sub-id"),
+      unsubscribe: jest.fn(),
+    };
+
+    // Create mock SDK methods
+    const mockSDK = {
+      MultichainAttestationsQuery: jest.fn(),
+      MultichainPortalsQuery: jest.fn(),
+      MultichainSchemasQuery: jest.fn(),
+      MultichainModulesQuery: jest.fn(),
+    };
+
+    // Create mock mesh instance with pubsub
+    mockMesh = {
+      sdkRequesterFactory: jest.fn().mockReturnValue(jest.fn()),
+      pubsub: mockPubsub,
+      destroy: jest.fn(),
+    } as unknown as Awaited<ReturnType<typeof getMesh>>;
+
+    (getMeshOptions as jest.Mock).mockResolvedValue(mockMeshOptions);
+    (getMesh as jest.Mock).mockResolvedValue(mockMesh);
+    (getSdk as jest.Mock).mockReturnValue(mockSDK);
+  });
+
+  describe("getSDKForNetworkType", () => {
+    it("should create SDK for mainnet", async () => {
+      const sdk = await getSDKForNetworkType("mainnet");
+
+      expect(getMeshOptions).toHaveBeenCalled();
+      expect(getMesh).toHaveBeenCalled();
+      expect(sdk).toBeDefined();
+      expect(sdk.MultichainAttestationsQuery).toBeDefined();
+    });
+
+    it("should create SDK for testnet", async () => {
+      const sdk = await getSDKForNetworkType("testnet");
+
+      expect(getMeshOptions).toHaveBeenCalled();
+      expect(getMesh).toHaveBeenCalled();
+      expect(sdk).toBeDefined();
+    });
+
+    it("should cache SDK instances per network type", async () => {
+      // First call creates instance
+      await getSDKForNetworkType("mainnet");
+      const firstCallCount = (getMesh as jest.Mock).mock.calls.length;
+
+      // Second call should use cached instance
+      await getSDKForNetworkType("mainnet");
+      expect((getMesh as jest.Mock).mock.calls.length).toBe(firstCallCount);
+    });
+
+    it("should create separate instances for mainnet and testnet", async () => {
+      await getSDKForNetworkType("mainnet");
+      const firstCallCount = (getMesh as jest.Mock).mock.calls.length;
+
+      await getSDKForNetworkType("testnet");
+      expect((getMesh as jest.Mock).mock.calls.length).toBe(firstCallCount + 1);
+    });
+
+    it("should subscribe to destroy events", async () => {
+      await getSDKForNetworkType("mainnet");
+      expect(mockPubsub.subscribe).toHaveBeenCalledWith("destroy", expect.any(Function));
+    });
+  });
+
+  describe("getSDKForChains", () => {
+    it("should return mainnet SDK for mainnet chains", async () => {
+      const sdk = await getSDKForChains([ChainName.LINEA_MAINNET, ChainName.ARBITRUM_MAINNET]);
+
+      expect(sdk).toBeDefined();
+      expect(getMesh).toHaveBeenCalled();
+    });
+
+    it("should return testnet SDK for testnet chains", async () => {
+      const sdk = await getSDKForChains([ChainName.LINEA_SEPOLIA, ChainName.ARBITRUM_SEPOLIA]);
+
+      expect(sdk).toBeDefined();
+      expect(getMesh).toHaveBeenCalled();
+    });
+
+    it("should throw error for mixed mainnet and testnet chains", async () => {
+      await expect(getSDKForChains([ChainName.LINEA_MAINNET, ChainName.LINEA_SEPOLIA])).rejects.toThrow(
+        "Cannot mix mainnet and testnet chains",
+      );
+    });
+  });
+
+  describe("clearMeshCache", () => {
+    it("should clear specific network type cache", async () => {
+      // Create both instances
+      await getSDKForNetworkType("mainnet");
+      await getSDKForNetworkType("testnet");
+
+      // Clear only mainnet
+      await clearMeshCache("mainnet");
+
+      // Verify mainnet was destroyed
+      expect(mockMesh.destroy).toHaveBeenCalled();
+    });
+
+    it("should clear all caches when no network type specified", async () => {
+      // Create both instances
+      await getSDKForNetworkType("mainnet");
+      await getSDKForNetworkType("testnet");
+
+      const destroyCallsBefore = (mockMesh.destroy as jest.Mock).mock.calls.length;
+
+      // Clear all
+      await clearMeshCache();
+
+      // Both should be destroyed
+      expect((mockMesh.destroy as jest.Mock).mock.calls.length).toBeGreaterThan(destroyCallsBefore);
+    });
+  });
+
+  describe("getMeshCacheStatus", () => {
+    it("should return false for both when no instances exist", async () => {
+      const status = getMeshCacheStatus();
+      expect(status.mainnet).toBe(false);
+      expect(status.testnet).toBe(false);
+    });
+
+    it("should return true for mainnet when mainnet instance exists", async () => {
+      await getSDKForNetworkType("mainnet");
+      const status = getMeshCacheStatus();
+      expect(status.mainnet).toBe(true);
+      expect(status.testnet).toBe(false);
+    });
+
+    it("should return true for both when both instances exist", async () => {
+      await getSDKForNetworkType("mainnet");
+      await getSDKForNetworkType("testnet");
+      const status = getMeshCacheStatus();
+      expect(status.mainnet).toBe(true);
+      expect(status.testnet).toBe(true);
+    });
+  });
+});

--- a/sdk/src/utils/meshInstanceManager.ts
+++ b/sdk/src/utils/meshInstanceManager.ts
@@ -1,0 +1,134 @@
+/**
+ * Mesh Instance Manager
+ *
+ * Manages isolated GraphQL Mesh instances per network type (mainnet/testnet).
+ * This prevents cache pollution when switching between mainnet and testnet queries
+ * in the same browser session.
+ *
+ * The core problem: GraphQL Mesh uses a singleton pattern with a shared cache.
+ * Cache keys are based on query hash + variables, but don't include context.chainName.
+ * When querying mainnet chains then testnet chains with identical query structures,
+ * the cache returns stale mainnet data.
+ *
+ * Solution: Maintain separate Mesh instances with isolated caches per network type.
+ */
+
+import { getMesh, MeshInstance } from "@graphql-mesh/runtime";
+import { getMeshOptions, getSdk } from "../../.graphclient";
+import { ChainName, CrossChainClient } from "../types";
+import { NetworkType, inferNetworkType } from "./networkTypeUtils";
+
+/**
+ * Cache of Mesh instances keyed by network type.
+ * Each network type gets its own isolated instance with separate cache.
+ */
+const meshInstances: Map<NetworkType, Promise<MeshInstance>> = new Map();
+
+/**
+ * Cache of SDK clients keyed by network type.
+ */
+const sdkClients: Map<NetworkType, CrossChainClient> = new Map();
+
+/**
+ * Creates a new Mesh instance with an isolated cache for the specified network type.
+ *
+ * We achieve cache isolation by creating completely separate Mesh instances.
+ * Each instance has its own cache, pubsub, and logger.
+ */
+async function createMeshInstance(networkType: NetworkType): Promise<MeshInstance> {
+  const meshOptions = await getMeshOptions();
+
+  // Create a new mesh instance
+  // The cache will be unique to this instance since we're creating a fresh getMesh call
+  const mesh = await getMesh(meshOptions);
+
+  // Subscribe to destroy events to clean up our cache
+  const id = mesh.pubsub.subscribe("destroy", () => {
+    meshInstances.delete(networkType);
+    sdkClients.delete(networkType);
+    mesh.pubsub.unsubscribe(id);
+  });
+
+  return mesh;
+}
+
+/**
+ * Gets or creates a Mesh instance for the specified network type.
+ * Instances are lazily created on first use and cached for reuse.
+ */
+export function getMeshInstanceForNetworkType(networkType: NetworkType): Promise<MeshInstance> {
+  let instance = meshInstances.get(networkType);
+
+  if (!instance) {
+    instance = createMeshInstance(networkType);
+    meshInstances.set(networkType, instance);
+  }
+
+  return instance;
+}
+
+/**
+ * Gets or creates an SDK client for the specified network type.
+ * This is the main entry point for cross-chain queries.
+ */
+export async function getSDKForNetworkType(networkType: NetworkType): Promise<CrossChainClient> {
+  let client = sdkClients.get(networkType);
+
+  if (!client) {
+    const mesh = await getMeshInstanceForNetworkType(networkType);
+    const globalContext = {};
+    const sdkRequester = mesh.sdkRequesterFactory(globalContext);
+    client = getSdk((...args) => sdkRequester(...args)) as unknown as CrossChainClient;
+    sdkClients.set(networkType, client);
+  }
+
+  return client;
+}
+
+/**
+ * Gets an SDK client for the given chain names.
+ * Automatically infers the network type from the chain names.
+ *
+ * @throws Error if chain names mix mainnet and testnet
+ */
+export async function getSDKForChains(chainNames: (ChainName | string)[]): Promise<CrossChainClient> {
+  const networkType = inferNetworkType(chainNames);
+  return getSDKForNetworkType(networkType);
+}
+
+/**
+ * Clears cached Mesh instances and SDK clients.
+ * Use this to force fresh instances on next query.
+ *
+ * @param networkType - If provided, only clears cache for that network type.
+ *                      If omitted, clears all cached instances.
+ */
+export async function clearMeshCache(networkType?: NetworkType): Promise<void> {
+  if (networkType) {
+    const instance = meshInstances.get(networkType);
+    if (instance) {
+      const mesh = await instance;
+      mesh.destroy();
+    }
+    meshInstances.delete(networkType);
+    sdkClients.delete(networkType);
+  } else {
+    // Clear all
+    for (const [type, instancePromise] of meshInstances.entries()) {
+      const mesh = await instancePromise;
+      mesh.destroy();
+      meshInstances.delete(type);
+      sdkClients.delete(type);
+    }
+  }
+}
+
+/**
+ * Gets the current state of cached instances (for debugging).
+ */
+export function getMeshCacheStatus(): { mainnet: boolean; testnet: boolean } {
+  return {
+    mainnet: meshInstances.has("mainnet"),
+    testnet: meshInstances.has("testnet"),
+  };
+}

--- a/sdk/src/utils/networkTypeUtils.test.ts
+++ b/sdk/src/utils/networkTypeUtils.test.ts
@@ -1,0 +1,113 @@
+import { ChainName } from "../types";
+import { isTestnetChain, getNetworkTypeForChain, inferNetworkType, validateNetworkType } from "./networkTypeUtils";
+
+describe("networkTypeUtils", () => {
+  describe("isTestnetChain", () => {
+    it("should return true for chains containing 'sepolia'", () => {
+      expect(isTestnetChain("verax-v2-linea-sepolia")).toBe(true);
+      expect(isTestnetChain("verax-v2-arbitrum-sepolia")).toBe(true);
+      expect(isTestnetChain("verax-v2-base-sepolia")).toBe(true);
+    });
+
+    it("should return true for chains containing 'testnet'", () => {
+      expect(isTestnetChain("verax-v2-bsc-testnet")).toBe(true);
+    });
+
+    it("should return false for mainnet chains", () => {
+      expect(isTestnetChain("verax-v2-linea")).toBe(false);
+      expect(isTestnetChain("verax-v2-arbitrum")).toBe(false);
+      expect(isTestnetChain("verax-v2-base")).toBe(false);
+      expect(isTestnetChain("verax-v2-bsc")).toBe(false);
+    });
+
+    it("should be case insensitive", () => {
+      expect(isTestnetChain("VERAX-V2-LINEA-SEPOLIA")).toBe(true);
+      expect(isTestnetChain("Verax-V2-BSC-Testnet")).toBe(true);
+    });
+  });
+
+  describe("getNetworkTypeForChain", () => {
+    it("should return 'mainnet' for mainnet ChainName enum values", () => {
+      expect(getNetworkTypeForChain(ChainName.LINEA_MAINNET)).toBe("mainnet");
+      expect(getNetworkTypeForChain(ChainName.ARBITRUM_MAINNET)).toBe("mainnet");
+      expect(getNetworkTypeForChain(ChainName.BASE_MAINNET)).toBe("mainnet");
+      expect(getNetworkTypeForChain(ChainName.BSC_MAINNET)).toBe("mainnet");
+    });
+
+    it("should return 'testnet' for testnet ChainName enum values", () => {
+      expect(getNetworkTypeForChain(ChainName.LINEA_SEPOLIA)).toBe("testnet");
+      expect(getNetworkTypeForChain(ChainName.ARBITRUM_SEPOLIA)).toBe("testnet");
+      expect(getNetworkTypeForChain(ChainName.BASE_SEPOLIA)).toBe("testnet");
+      expect(getNetworkTypeForChain(ChainName.BSC_TESTNET)).toBe("testnet");
+    });
+
+    it("should handle raw subgraph names via pattern matching", () => {
+      expect(getNetworkTypeForChain("custom-mainnet-chain")).toBe("mainnet");
+      expect(getNetworkTypeForChain("custom-sepolia-chain")).toBe("testnet");
+      expect(getNetworkTypeForChain("custom-testnet-chain")).toBe("testnet");
+    });
+  });
+
+  describe("inferNetworkType", () => {
+    it("should return 'mainnet' for empty array", () => {
+      expect(inferNetworkType([])).toBe("mainnet");
+    });
+
+    it("should return 'mainnet' for all mainnet chains", () => {
+      const mainnets = [ChainName.LINEA_MAINNET, ChainName.ARBITRUM_MAINNET, ChainName.BASE_MAINNET];
+      expect(inferNetworkType(mainnets)).toBe("mainnet");
+    });
+
+    it("should return 'testnet' for all testnet chains", () => {
+      const testnets = [ChainName.LINEA_SEPOLIA, ChainName.ARBITRUM_SEPOLIA, ChainName.BASE_SEPOLIA];
+      expect(inferNetworkType(testnets)).toBe("testnet");
+    });
+
+    it("should throw error when mixing mainnet and testnet chains", () => {
+      const mixed = [ChainName.LINEA_MAINNET, ChainName.LINEA_SEPOLIA];
+      expect(() => inferNetworkType(mixed)).toThrow("Cannot mix mainnet and testnet chains");
+    });
+
+    it("should work with single chain", () => {
+      expect(inferNetworkType([ChainName.LINEA_MAINNET])).toBe("mainnet");
+      expect(inferNetworkType([ChainName.LINEA_SEPOLIA])).toBe("testnet");
+    });
+
+    it("should work with raw subgraph names", () => {
+      expect(inferNetworkType(["verax-v2-linea", "verax-v2-arbitrum"])).toBe("mainnet");
+      expect(inferNetworkType(["verax-v2-linea-sepolia", "verax-v2-arbitrum-sepolia"])).toBe("testnet");
+    });
+  });
+
+  describe("validateNetworkType", () => {
+    it("should not throw for valid mainnet chains", () => {
+      const mainnets = [ChainName.LINEA_MAINNET, ChainName.ARBITRUM_MAINNET];
+      expect(() => validateNetworkType(mainnets, "mainnet")).not.toThrow();
+    });
+
+    it("should not throw for valid testnet chains", () => {
+      const testnets = [ChainName.LINEA_SEPOLIA, ChainName.ARBITRUM_SEPOLIA];
+      expect(() => validateNetworkType(testnets, "testnet")).not.toThrow();
+    });
+
+    it("should throw when mainnet chain is used with testnet type", () => {
+      const mainnets = [ChainName.LINEA_MAINNET];
+      expect(() => validateNetworkType(mainnets, "testnet")).toThrow(
+        'do not match the expected network type "testnet"',
+      );
+    });
+
+    it("should throw when testnet chain is used with mainnet type", () => {
+      const testnets = [ChainName.LINEA_SEPOLIA];
+      expect(() => validateNetworkType(testnets, "mainnet")).toThrow(
+        'do not match the expected network type "mainnet"',
+      );
+    });
+
+    it("should list all invalid chains in error message", () => {
+      const mixed = [ChainName.LINEA_MAINNET, ChainName.ARBITRUM_MAINNET];
+      expect(() => validateNetworkType(mixed, "testnet")).toThrow(ChainName.LINEA_MAINNET);
+      expect(() => validateNetworkType(mixed, "testnet")).toThrow(ChainName.ARBITRUM_MAINNET);
+    });
+  });
+});

--- a/sdk/src/utils/networkTypeUtils.ts
+++ b/sdk/src/utils/networkTypeUtils.ts
@@ -1,0 +1,87 @@
+import { ChainName } from "../types";
+
+/**
+ * Network type discriminator for cache isolation.
+ * Mainnet and testnet use separate GraphQL Mesh instances to prevent cache pollution.
+ */
+export type NetworkType = "mainnet" | "testnet";
+
+/**
+ * Testnet chain name patterns for network type inference.
+ */
+const TESTNET_PATTERNS = ["sepolia", "testnet"] as const;
+
+/**
+ * Mapping of ChainName enum values to their network types.
+ */
+const CHAIN_NETWORK_TYPES: Record<ChainName, NetworkType> = {
+  [ChainName.LINEA_MAINNET]: "mainnet",
+  [ChainName.ARBITRUM_MAINNET]: "mainnet",
+  [ChainName.BASE_MAINNET]: "mainnet",
+  [ChainName.BSC_MAINNET]: "mainnet",
+  [ChainName.LINEA_SEPOLIA]: "testnet",
+  [ChainName.ARBITRUM_SEPOLIA]: "testnet",
+  [ChainName.BASE_SEPOLIA]: "testnet",
+  [ChainName.BSC_TESTNET]: "testnet",
+};
+
+/**
+ * Determines if a chain name string represents a testnet.
+ * Works with both ChainName enum values and raw subgraph names.
+ */
+export function isTestnetChain(chainName: string): boolean {
+  const lowerName = chainName.toLowerCase();
+  return TESTNET_PATTERNS.some((pattern) => lowerName.includes(pattern));
+}
+
+/**
+ * Gets the network type for a single chain name.
+ */
+export function getNetworkTypeForChain(chainName: ChainName | string): NetworkType {
+  // First check if it's a known ChainName enum value
+  if (chainName in CHAIN_NETWORK_TYPES) {
+    return CHAIN_NETWORK_TYPES[chainName as ChainName];
+  }
+
+  // Fall back to pattern matching for raw subgraph names
+  return isTestnetChain(chainName) ? "testnet" : "mainnet";
+}
+
+/**
+ * Infers the network type from an array of chain names.
+ * All chains must belong to the same network type (mainnet or testnet).
+ *
+ * @throws Error if chain names mix mainnet and testnet
+ */
+export function inferNetworkType(chainNames: (ChainName | string)[]): NetworkType {
+  if (chainNames.length === 0) {
+    return "mainnet"; // Default to mainnet for empty array
+  }
+
+  const networkTypes = new Set(chainNames.map(getNetworkTypeForChain));
+
+  if (networkTypes.size > 1) {
+    throw new Error(
+      `Cannot mix mainnet and testnet chains in the same query. ` +
+        `Received: ${chainNames.join(", ")}. ` +
+        `Please query mainnet and testnet chains separately.`,
+    );
+  }
+
+  return networkTypes.values().next().value as NetworkType;
+}
+
+/**
+ * Validates that all chain names belong to the expected network type.
+ *
+ * @throws Error if any chain doesn't match the expected network type
+ */
+export function validateNetworkType(chainNames: (ChainName | string)[], expectedType: NetworkType): void {
+  const invalidChains = chainNames.filter((chain) => getNetworkTypeForChain(chain) !== expectedType);
+
+  if (invalidChains.length > 0) {
+    throw new Error(
+      `The following chains do not match the expected network type "${expectedType}": ` + `${invalidChains.join(", ")}`,
+    );
+  }
+}


### PR DESCRIPTION
## What does this PR do?

Fixes 2 compounding issues:
- Simpler GraphQL cache management for the SDK
- Explorer always showing mainnet data when toggling between testnet/mainnet

### Related ticket

Fixes #1009

### Type of change

- [ ] Chore
- [X] Bug fix
- [ ] New feature
- [ ] Documentation update

## Check list

- [ ] My&nbsp;contribution&nbsp;follows&nbsp;the&nbsp;project's&nbsp;[guidelines](https://github.com/Consensys/linea-attestation-registry/blob/dev/CONTRIBUTING.md)
- [ ] I have made corresponding changes to the documentation
- [ ] Unit tests for any smart contract change
- [ ] Contracts and functions are documented

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Addresses cross-network cache pollution and data mixing between mainnet/testnet.
> 
> - SDK 5.2.0: replace `@graphql-mesh/cache-localforage` with in-memory LRU cache; add network-type–scoped Mesh instances (`meshInstanceManager`), network utilities (`networkTypeUtils`), and custom SDK builders; data mappers now pass `chainNames` into `getCrossChainClient`; resolvers use `Promise.allSettled` to ignore per-chain errors; extensive unit tests added
> - Explorer: migrate from `useSWR` to `useNetworkTypeSWR` and include `chainsForQuery` in SWR keys; switch list/fetch calls to `findByMultiChain` across Attestations, Subject, MyAttestations, Schema, Schemas, Issuer, and Search pages to ensure network-aware queries
> - Bumps `@verax-attestation-registry/verax-sdk` to `5.2.0` and updates lockfile accordingly
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit da90e52fc3ebe48a6b6d8d125214e892e569bc44. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->