### PR TITLE
fix(ci): lockfile regeneration on Dependabot PRs

### DIFF
--- a/.github/workflows/contracts-examples.yml
+++ b/.github/workflows/contracts-examples.yml
@@ -22,7 +22,7 @@ env:
 jobs:
   build-examples:
     # Skip initial Dependabot PR run - will re-run after lockfile update
-    if: github.actor != 'dependabot[bot]' || github.event.action == 'synchronize'
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
 
     defaults:

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -22,7 +22,7 @@ env:
 jobs:
   build-contracts:
     # Skip initial Dependabot PR run - will re-run after lockfile update
-    if: github.actor != 'dependabot[bot]' || github.event.action == 'synchronize'
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
 
     defaults:

--- a/.github/workflows/explorer-build.yml
+++ b/.github/workflows/explorer-build.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   build-explorer:
     # Skip initial Dependabot PR run - will re-run after lockfile update
-    if: github.actor != 'dependabot[bot]' || github.event.action == 'synchronize'
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
 
     defaults:

--- a/.github/workflows/explorer-deploy-preview.yml
+++ b/.github/workflows/explorer-deploy-preview.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   deploy-explorer-preview:
     # Skip initial Dependabot PR run - will re-run after lockfile update
-    if: github.actor != 'dependabot[bot]' || github.event.action == 'synchronize'
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
 
     defaults:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   lint:
     # Skip initial Dependabot PR run - will re-run after lockfile update
-    if: github.actor != 'dependabot[bot]' || github.event.action == 'synchronize'
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   unit-test-sdk:
     # Skip initial Dependabot PR run - will re-run after lockfile update
-    if: github.actor != 'dependabot[bot]' || github.event.action == 'synchronize'
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
 
     defaults:
@@ -74,7 +74,7 @@ jobs:
 
   integration-test-sdk:
     # Skip initial Dependabot PR run - will re-run after lockfile update
-    if: github.actor != 'dependabot[bot]' || github.event.action == 'synchronize'
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
 
     defaults:

--- a/.github/workflows/subgraph.yml
+++ b/.github/workflows/subgraph.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   test-subgraph:
     # Skip initial Dependabot PR run - will re-run after lockfile update
-    if: github.actor != 'dependabot[bot]' || github.event.action == 'synchronize'
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-22.04
 
     defaults:


### PR DESCRIPTION
## What does this PR do?

Iterates on the lockfile regeneration

### Type of change

- [ ] Chore
- [X] Bug fix
- [ ] New feature
- [ ] Documentation update

## Check list

- [ ] My&nbsp;contribution&nbsp;follows&nbsp;the&nbsp;project's&nbsp;[guidelines](https://github.com/Consensys/linea-attestation-registry/blob/dev/CONTRIBUTING.md)
- [ ] I have made corresponding changes to the documentation
- [ ] Unit tests for any smart contract change
- [ ] Contracts and functions are documented

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts CI job conditions to consistently skip execution when the actor is `dependabot[bot]`, removing the previous `|| github.event.action == 'synchronize'` exception.
> 
> - Updated `if` conditions in `contracts-examples.yml`, `contracts.yml`, `explorer-build.yml`, `explorer-deploy-preview.yml`, `lint.yml`, `sdk.yml` (both unit and integration jobs), and `subgraph.yml` to `github.actor != 'dependabot[bot]'`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8d7438ad9663c52f534f86d7b4bd96615e42b25e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->