### PR TITLE
fix(explorer): crash on search when chainName is missing from results

### DIFF
--- a/explorer/src/constants/columns/module.tsx
+++ b/explorer/src/constants/columns/module.tsx
@@ -22,7 +22,12 @@ interface ColumnsProps {
   isDarkMode: boolean;
 }
 
-export const columns = ({ isDarkMode }: ColumnsProps): ColumnDef<Module>[] => [
+interface ModuleWithNetworks extends Module {
+  networks?: string[];
+  networkCount?: number;
+}
+
+export const columns = ({ isDarkMode }: ColumnsProps): ColumnDef<ModuleWithNetworks>[] => [
   {
     accessorKey: "name",
     header: () => (
@@ -33,24 +38,41 @@ export const columns = ({ isDarkMode }: ColumnsProps): ColumnDef<Module>[] => [
     ),
     cell: ({ row }) => {
       const { name, id } = row.original;
-      const chainName = row.original.chainName as ChainName;
-      const network = NetworkResolver.getNetworkSlugFromChainName(chainName);
-      const networkName = NetworkResolver.getNetworkNameFromChainName(chainName);
+      const networks = row.original.networks || (row.original.chainName ? [row.original.chainName] : []);
+      const networkCount = row.original.networkCount || networks.length;
+
+      const primaryNetwork = networks[0] as ChainName | undefined;
+      const network = primaryNetwork ? NetworkResolver.getNetworkSlugFromChainName(primaryNetwork) : undefined;
 
       return (
         <div className="flex space-x-2 items-center">
-          <Tooltip
-            content={<div style={NETWORK_TOOLTIP_STYLE}>{networkName}</div>}
-            placement="top"
-            isDarkMode={isDarkMode}
-            minWidth="auto"
-            compact
-          >
-            <div className="w-[24px]">{NetworkResolver.getNetworkLogoByChainName(chainName, isDarkMode)}</div>
-          </Tooltip>
-          <Link to={toModuleById(id, network)} className="hover:underline" onClick={(e) => e.stopPropagation()}>
-            {name}
-          </Link>
+          <div className="flex items-center">
+            {primaryNetwork && (
+              <Tooltip
+                content={
+                  <div style={NETWORK_TOOLTIP_STYLE}>{NetworkResolver.getNetworkNameFromChainName(primaryNetwork)}</div>
+                }
+                placement="top"
+                isDarkMode={isDarkMode}
+                minWidth="auto"
+                compact
+              >
+                <div className="w-[24px]">{NetworkResolver.getNetworkLogoByChainName(primaryNetwork, isDarkMode)}</div>
+              </Tooltip>
+            )}
+            {networkCount > 1 && (
+              <div className="ml-1 text-xs font-semibold bg-gray-200 dark:bg-gray-700 rounded-full px-1.5 py-0.5">
+                +{networkCount - 1}
+              </div>
+            )}
+          </div>
+          {network ? (
+            <Link to={toModuleById(id, network)} className="hover:underline" onClick={(e) => e.stopPropagation()}>
+              {name}
+            </Link>
+          ) : (
+            <span>{name}</span>
+          )}
         </div>
       );
     },
@@ -66,16 +88,17 @@ export const columns = ({ isDarkMode }: ColumnsProps): ColumnDef<Module>[] => [
     cell: ({ row }) => {
       const address = row.original.moduleAddress;
       const id = row.original.id;
-      const chainName = row.original.chainName as ChainName;
-      const network = NetworkResolver.getNetworkSlugFromChainName(chainName);
-      const networkConfig = chains.find((chain) => chain.network === network);
+      const networks = row.original.networks || (row.original.chainName ? [row.original.chainName] : []);
+      const primaryNetwork = networks[0] as ChainName | undefined;
+      const network = primaryNetwork ? NetworkResolver.getNetworkSlugFromChainName(primaryNetwork) : undefined;
+      const networkConfig = network ? chains.find((chain) => chain.network === network) : undefined;
       const blockExplorerLink = networkConfig ? getBlockExplorerLink(networkConfig.chain) : "";
 
       return (
         <TdHandler
-          valueUrl={`${blockExplorerLink}/${address}`}
+          valueUrl={blockExplorerLink ? `${blockExplorerLink}/${address}` : undefined}
           value={cropString(address)}
-          to={toModuleById(id, network)}
+          to={network ? toModuleById(id, network) : ""}
         />
       );
     },

--- a/explorer/src/constants/columns/portal.tsx
+++ b/explorer/src/constants/columns/portal.tsx
@@ -19,7 +19,12 @@ interface ColumnsProps {
   isDarkMode: boolean;
 }
 
-export const columns = ({ isDarkMode }: ColumnsProps): ColumnDef<Portal>[] => [
+interface PortalWithNetworks extends Portal {
+  networks?: string[];
+  networkCount?: number;
+}
+
+export const columns = ({ isDarkMode }: ColumnsProps): ColumnDef<PortalWithNetworks>[] => [
   {
     accessorKey: "name",
     header: () => (
@@ -31,26 +36,41 @@ export const columns = ({ isDarkMode }: ColumnsProps): ColumnDef<Portal>[] => [
     cell: ({ row }) => {
       const name = row.getValue("name") as string;
       const id = row.original.id;
-      const chainName = row.original.chainName as ChainName;
-      const network = NetworkResolver.getNetworkSlugFromChainName(chainName);
-      const networkName = NetworkResolver.getNetworkNameFromChainName(chainName);
+      const networks = row.original.networks || (row.original.chainName ? [row.original.chainName] : []);
+      const networkCount = row.original.networkCount || networks.length;
+
+      const primaryNetwork = networks[0] as ChainName | undefined;
+      const network = primaryNetwork ? NetworkResolver.getNetworkSlugFromChainName(primaryNetwork) : undefined;
 
       return (
         <div className="flex space-x-2 items-center">
-          <Tooltip
-            content={<div style={NETWORK_TOOLTIP_STYLE}>{networkName}</div>}
-            placement="top"
-            isDarkMode={isDarkMode}
-            minWidth="auto"
-            compact
-          >
-            <div className="w-[24px]">
-              {NetworkResolver.getNetworkLogoByChainName(chainName as ChainName, isDarkMode)}
-            </div>
-          </Tooltip>
-          <Link to={toPortalById(id, network)} className="hover:underline" onClick={(e) => e.stopPropagation()}>
-            {name}
-          </Link>
+          <div className="flex items-center">
+            {primaryNetwork && (
+              <Tooltip
+                content={
+                  <div style={NETWORK_TOOLTIP_STYLE}>{NetworkResolver.getNetworkNameFromChainName(primaryNetwork)}</div>
+                }
+                placement="top"
+                isDarkMode={isDarkMode}
+                minWidth="auto"
+                compact
+              >
+                <div className="w-[24px]">{NetworkResolver.getNetworkLogoByChainName(primaryNetwork, isDarkMode)}</div>
+              </Tooltip>
+            )}
+            {networkCount > 1 && (
+              <div className="ml-1 text-xs font-semibold bg-gray-200 dark:bg-gray-700 rounded-full px-1.5 py-0.5">
+                +{networkCount - 1}
+              </div>
+            )}
+          </div>
+          {network ? (
+            <Link to={toPortalById(id, network)} className="hover:underline" onClick={(e) => e.stopPropagation()}>
+              {name}
+            </Link>
+          ) : (
+            <span>{name}</span>
+          )}
         </div>
       );
     },
@@ -69,17 +89,18 @@ export const columns = ({ isDarkMode }: ColumnsProps): ColumnDef<Portal>[] => [
     cell: ({ row }) => {
       const address = row.original.ownerAddress;
       const id = row.original.id;
-      const chainName = row.original.chainName as ChainName;
-      const network = NetworkResolver.getNetworkSlugFromChainName(chainName);
+      const networks = row.original.networks || (row.original.chainName ? [row.original.chainName] : []);
+      const primaryNetwork = networks[0] as ChainName | undefined;
+      const network = primaryNetwork ? NetworkResolver.getNetworkSlugFromChainName(primaryNetwork) : undefined;
 
-      const networkConfig = chains.find((chain) => chain.network === network);
+      const networkConfig = network ? chains.find((chain) => chain.network === network) : undefined;
       const blockExplorerLink = networkConfig ? getBlockExplorerLink(networkConfig.chain) : "";
 
       return (
         <TdHandler
-          valueUrl={`${blockExplorerLink}/${address}`}
+          valueUrl={blockExplorerLink ? `${blockExplorerLink}/${address}` : undefined}
           value={cropString(address)}
-          to={toPortalById(id, network)}
+          to={network ? toPortalById(id, network) : ""}
         />
       );
     },

--- a/explorer/src/constants/columns/schema.tsx
+++ b/explorer/src/constants/columns/schema.tsx
@@ -34,24 +34,27 @@ export const columns = ({ isDarkMode }: ColumnsProps): ColumnDef<SchemaWithNetwo
     cell: ({ row }) => {
       const name = row.getValue("name") as string;
       const id = row.original.id;
-      const networks = row.original.networks || [row.original.chainName as string];
-      const networkCount = row.original.networkCount || 1;
+      const networks = row.original.networks || (row.original.chainName ? [row.original.chainName] : []);
+      const networkCount = row.original.networkCount || networks.length;
 
-      const primaryNetwork = networks[0] as ChainName;
-      const networkName = NetworkResolver.getNetworkNameFromChainName(primaryNetwork);
+      const primaryNetwork = networks[0] as ChainName | undefined;
 
       return (
         <div className="flex space-x-2 items-center">
           <div className="flex items-center">
-            <Tooltip
-              content={<div style={NETWORK_TOOLTIP_STYLE}>{networkName}</div>}
-              placement="top"
-              isDarkMode={isDarkMode}
-              minWidth="auto"
-              compact
-            >
-              <div className="w-[24px]">{NetworkResolver.getNetworkLogoByChainName(primaryNetwork, isDarkMode)}</div>
-            </Tooltip>
+            {primaryNetwork && (
+              <Tooltip
+                content={
+                  <div style={NETWORK_TOOLTIP_STYLE}>{NetworkResolver.getNetworkNameFromChainName(primaryNetwork)}</div>
+                }
+                placement="top"
+                isDarkMode={isDarkMode}
+                minWidth="auto"
+                compact
+              >
+                <div className="w-[24px]">{NetworkResolver.getNetworkLogoByChainName(primaryNetwork, isDarkMode)}</div>
+              </Tooltip>
+            )}
             {networkCount > 1 && (
               <div className="ml-1 text-xs font-semibold bg-gray-200 dark:bg-gray-700 rounded-full px-1.5 py-0.5">
                 +{networkCount - 1}

--- a/explorer/src/pages/Search/components/SearchModules/loadModuleList.ts
+++ b/explorer/src/pages/Search/components/SearchModules/loadModuleList.ts
@@ -3,8 +3,8 @@ import { ModuleDataMapper } from "@verax-attestation-registry/verax-sdk";
 import { ITEMS_PER_PAGE_DEFAULT } from "@/constants";
 import { NetworkType } from "@/contexts/NetworkContext.ts";
 import { ResultParseSearch } from "@/interfaces/components";
-import { isNotNullOrUndefined, mainnets, testnets } from "@/utils";
-import { uniqMap } from "@/utils/searchUtils";
+import { mainnets, testnets } from "@/utils";
+import { aggregateByNetwork } from "@/utils/searchUtils";
 
 export const loadModuleList = async (
   module: ModuleDataMapper,
@@ -24,11 +24,14 @@ export const loadModuleList = async (
       ])
     : [];
 
-  const listByIds = (
-    parsedString.address ? await Promise.all(parsedString.address.map((id) => module.findOneById(id))) : []
-  ).filter(isNotNullOrUndefined);
+  const listByIds =
+    parsedString.address && parsedString.address.length > 0
+      ? await module.findByMultiChain(chainsToSearch, ITEMS_PER_PAGE_DEFAULT, undefined, {
+          id_in: parsedString.address,
+        })
+      : [];
 
   const results = [...(listByIds || []), ...(listByName || []), ...(listByDescription || [])];
 
-  return uniqMap(results, "id");
+  return aggregateByNetwork(results, "id");
 };

--- a/explorer/src/pages/Search/components/SearchPortals/loadPortalList.ts
+++ b/explorer/src/pages/Search/components/SearchPortals/loadPortalList.ts
@@ -3,8 +3,8 @@ import { PortalDataMapper } from "@verax-attestation-registry/verax-sdk";
 import { ITEMS_PER_PAGE_DEFAULT } from "@/constants";
 import { NetworkType } from "@/contexts/NetworkContext.ts";
 import { ResultParseSearch } from "@/interfaces/components";
-import { isNotNullOrUndefined, mainnets, testnets } from "@/utils";
-import { uniqMap } from "@/utils/searchUtils.ts";
+import { mainnets, testnets } from "@/utils";
+import { aggregateByNetwork } from "@/utils/searchUtils.ts";
 
 export const loadPortalList = async (
   portal: PortalDataMapper,
@@ -24,11 +24,14 @@ export const loadPortalList = async (
       ])
     : [];
 
-  const listByIds = (
-    parsedString.address ? await Promise.all(parsedString.address.map((id) => portal.findOneById(id))) : []
-  ).filter(isNotNullOrUndefined);
+  const listByIds =
+    parsedString.address && parsedString.address.length > 0
+      ? await portal.findByMultiChain(chainsToSearch, ITEMS_PER_PAGE_DEFAULT, undefined, {
+          id_in: parsedString.address,
+        })
+      : [];
 
   const results = [...(listByIds || []), ...(listByName || []), ...(listByDescription || [])];
 
-  return uniqMap(results, "id");
+  return aggregateByNetwork(results, "id");
 };

--- a/explorer/src/pages/Search/components/SearchSchemas/loadSchemaList.ts
+++ b/explorer/src/pages/Search/components/SearchSchemas/loadSchemaList.ts
@@ -3,8 +3,8 @@ import { SchemaDataMapper } from "@verax-attestation-registry/verax-sdk";
 import { ITEMS_PER_PAGE_DEFAULT } from "@/constants";
 import { NetworkType } from "@/contexts/NetworkContext.ts";
 import { ResultParseSearch } from "@/interfaces/components";
-import { isNotNullOrUndefined, mainnets, testnets } from "@/utils";
-import { uniqMap } from "@/utils/searchUtils";
+import { mainnets, testnets } from "@/utils";
+import { aggregateByNetwork } from "@/utils/searchUtils";
 
 export const loadSchemaList = async (
   schema: SchemaDataMapper,
@@ -24,27 +24,36 @@ export const loadSchemaList = async (
       ])
     : [];
 
-  const listByIds = (
-    parsedString.schemasIds ? await Promise.all(parsedString.schemasIds.map((id) => schema.findOneById(id))) : []
-  ).filter(isNotNullOrUndefined);
+  const listByIds =
+    parsedString.schemasIds && parsedString.schemasIds.length > 0
+      ? await schema.findByMultiChain(chainsToSearch, ITEMS_PER_PAGE_DEFAULT, undefined, {
+          id_in: parsedString.schemasIds,
+        })
+      : [];
 
   const listBySchemaString = parsedString.schema
-    ? await schema.findBy(ITEMS_PER_PAGE_DEFAULT, undefined, { schema_contains: parsedString.schema })
+    ? await schema.findByMultiChain(chainsToSearch, ITEMS_PER_PAGE_DEFAULT, undefined, {
+        schema_contains: parsedString.schema,
+      })
     : [];
 
-  const [listByContext] = parsedString.urls
-    ? await Promise.all(
-        parsedString.urls.map((url) => schema.findBy(ITEMS_PER_PAGE_DEFAULT, undefined, { context_contains: url })),
-      )
+  const listByContext = parsedString.urls
+    ? (
+        await Promise.all(
+          parsedString.urls.map((url) =>
+            schema.findByMultiChain(chainsToSearch, ITEMS_PER_PAGE_DEFAULT, undefined, { context_contains: url }),
+          ),
+        )
+      ).flat()
     : [];
 
   const results = [
     ...(listByIds || []),
-    ...listBySchemaString,
+    ...(listBySchemaString || []),
     ...(listByName || []),
     ...(listByDescription || []),
     ...(listByContext || []),
   ];
 
-  return uniqMap(results, "id");
+  return aggregateByNetwork(results, "id");
 };

--- a/explorer/src/utils/networkResolver.ts
+++ b/explorer/src/utils/networkResolver.ts
@@ -34,7 +34,11 @@ export class NetworkResolver {
     return chain.network;
   }
 
-  static getNetworkFromChainName(chainName: ChainName | string): INetwork {
+  static getNetworkFromChainName(chainName: ChainName | string | null | undefined): INetwork {
+    if (!chainName) {
+      throw new NetworkResolverError(`No network found for chain name: ${String(chainName)}`);
+    }
+
     const chainBySubgraph = chains.find((chain) => chain.subgraphName === chainName);
     if (chainBySubgraph) {
       return chainBySubgraph;

--- a/explorer/src/utils/searchUtils.ts
+++ b/explorer/src/utils/searchUtils.ts
@@ -78,3 +78,40 @@ export const parseSearch = (search: string | null, chainPrefix?: Hex): Partial<R
 export const uniqMap = <T>(array: T[], by: keyof T): T[] => [
   ...new Map(array.map((result) => [result[by], result])).values(),
 ];
+
+interface WithChainName {
+  chainName?: string;
+}
+
+export interface WithNetworks {
+  networks: string[];
+  networkCount: number;
+}
+
+/**
+ * Groups items by `id`, collecting distinct `chainName` values
+ * into `networks[]` and `networkCount` for multi-chain display.
+ */
+export const aggregateByNetwork = <T extends WithChainName>(items: T[], by: keyof T): (T & WithNetworks)[] => {
+  const map = new Map<unknown, T & WithNetworks>();
+
+  for (const item of items) {
+    const key = item[by];
+    const existing = map.get(key);
+
+    if (existing) {
+      if (item.chainName && !existing.networks.includes(item.chainName)) {
+        existing.networks.push(item.chainName);
+        existing.networkCount = existing.networks.length;
+      }
+    } else {
+      map.set(key, {
+        ...item,
+        networks: item.chainName ? [item.chainName] : [],
+        networkCount: item.chainName ? 1 : 0,
+      });
+    }
+  }
+
+  return Array.from(map.values());
+};


### PR DESCRIPTION
## What does this PR do?

- Replace single-chain SDK calls (`findOneById`, `findBy`) with `findByMultiChain` + filters (`id_in`, `schema_contains`, `context_contains`) in all search loaders so `chainName` is always present
- Add `aggregateByNetwork` utility to group search results by ID and collect networks, enabling the "+N" multi-chain badge on search results (consistent with list pages)
- Add defensive guards in column renderers and `NetworkResolver` to handle missing `chainName` gracefully

### Related ticket

Fixes #1016 

### Type of change

- [ ] Chore
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update

## Check list

- [ ] My&nbsp;contribution&nbsp;follows&nbsp;the&nbsp;project's&nbsp;[guidelines](https://github.com/Consensys/linea-attestation-registry/blob/dev/CONTRIBUTING.md)
- [ ] I have made corresponding changes to the documentation
- [ ] Unit tests for any smart contract change
- [ ] Contracts and functions are documented

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes search query strategy and result-shaping across modules/portals/schemas; low security risk but moderate chance of UI/link regressions when network data is missing or multi-chain aggregated.
> 
> **Overview**
> Fixes explorer search crashes and improves multi-chain result display by ensuring module/portal/schema searches use `findByMultiChain` filters (including ID, schema, and context queries) and then grouping results with a new `aggregateByNetwork` helper that collects per-ID `networks`/`networkCount`.
> 
> Updates module/portal/schema table columns to render a primary network logo plus a `+N` badge, and adds defensive handling for missing `chainName` (skip tooltip/logo, avoid building invalid links/explorer URLs). `NetworkResolver.getNetworkFromChainName` now explicitly guards against null/undefined inputs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2ba1dca6ac640ac1e720948e64ab5480029dd7c8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->