### PR TITLE
fix(contracts): optimize gas usage in Attestation struct

### DIFF
--- a/contracts/src/AttestationRegistry.sol
+++ b/contracts/src/AttestationRegistry.sol
@@ -119,20 +119,20 @@ contract AttestationRegistry is OwnableUpgradeable {
     bytes32 id = generateAttestationId(attestationIdCounter);
     assert(id != 0x0 && !isRegistered(id));
     // Create attestation
-    attestations[id] = Attestation(
-      id,
-      attestationPayload.schemaId,
-      bytes32(0),
-      attester,
-      msg.sender,
-      uint64(block.timestamp),
-      attestationPayload.expirationDate,
-      0,
-      version,
-      false,
-      attestationPayload.subject,
-      attestationPayload.attestationData
-    );
+    attestations[id] = Attestation({
+      attestationId: id,
+      schemaId: attestationPayload.schemaId,
+      replacedBy: bytes32(0),
+      attester: attester,
+      portal: msg.sender,
+      attestedDate: uint64(block.timestamp),
+      expirationDate: attestationPayload.expirationDate,
+      revocationDate: 0,
+      version: version,
+      revoked: false,
+      subject: attestationPayload.subject,
+      attestationData: attestationPayload.attestationData
+    });
     emit AttestationRegistered(id);
   }
 
@@ -154,20 +154,20 @@ contract AttestationRegistry is OwnableUpgradeable {
       bytes32 id = generateAttestationId(attestationIdCounter);
       assert(id != 0x0 && !isRegistered(id));
       // Create attestation
-      attestations[id] = Attestation(
-        id,
-        attestationsPayloads[i].schemaId,
-        bytes32(0),
-        msg.sender,
-        portal,
-        uint64(block.timestamp),
-        attestationsPayloads[i].expirationDate,
-        0,
-        version,
-        false,
-        attestationsPayloads[i].subject,
-        attestationsPayloads[i].attestationData
-      );
+      attestations[id] = Attestation({
+        attestationId: id,
+        schemaId: attestationsPayloads[i].schemaId,
+        replacedBy: bytes32(0),
+        attester: msg.sender,
+        portal: portal,
+        attestedDate: uint64(block.timestamp),
+        expirationDate: attestationsPayloads[i].expirationDate,
+        revocationDate: 0,
+        version: version,
+        revoked: false,
+        subject: attestationsPayloads[i].subject,
+        attestationData: attestationsPayloads[i].attestationData
+      });
       emit AttestationRegistered(id);
     }
   }

--- a/contracts/src/stdlib/IndexerModuleV2.sol
+++ b/contracts/src/stdlib/IndexerModuleV2.sol
@@ -190,19 +190,19 @@ contract IndexerModuleV2 is AbstractModuleV2 {
     address portal
   ) internal view returns (Attestation memory) {
     return
-      Attestation(
-        attestationRegistry.getNextAttestationId(),
-        attestationPayload.schemaId,
-        bytes32(0),
-        attester,
-        portal,
-        uint64(block.timestamp),
-        attestationPayload.expirationDate,
-        0,
-        attestationRegistry.getVersionNumber(),
-        false,
-        attestationPayload.subject,
-        attestationPayload.attestationData
-      );
+      Attestation({
+        attestationId: attestationRegistry.getNextAttestationId(),
+        schemaId: attestationPayload.schemaId,
+        replacedBy: bytes32(0),
+        attester: attester,
+        portal: portal,
+        attestedDate: uint64(block.timestamp),
+        expirationDate: attestationPayload.expirationDate,
+        revocationDate: 0,
+        version: attestationRegistry.getVersionNumber(),
+        revoked: false,
+        subject: attestationPayload.subject,
+        attestationData: attestationPayload.attestationData
+      });
   }
 }


### PR DESCRIPTION
## Summary

This PR addresses #918 by converting all `Attestation` struct instantiations from positional notation to named field `{}` notation.

## Changes

- **`contracts/src/AttestationRegistry.sol`**: Updated `attest()` and `massImport()` functions to use named field notation for `Attestation` struct initialization
- **`contracts/src/stdlib/IndexerModuleV2.sol`**: Updated `_buildAttestation()` to use named field notation

## Why

Using named field notation (`Attestation({field: value, ...})`) instead of positional arguments (`Attestation(value, ...)`) can save gas because the Solidity compiler handles struct packing more efficiently with named initialization. It also improves readability and reduces the risk of field ordering bugs.

## Testing

No logic changes — only struct initialization syntax is modified. All field values remain identical.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only switch `Attestation` struct construction from positional to named-field syntax, with the same values assigned. Main risk is accidental field/value mismatch, but named initialization reduces that likelihood.
> 
> **Overview**
> Switches `Attestation` struct construction to named-field initialization in `AttestationRegistry.attest()`, `AttestationRegistry.massImport()`, and `IndexerModuleV2._buildAttestation()`.
> 
> This is a syntactic refactor intended to improve readability and potentially reduce gas, without changing the data written into stored attestations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9dca6d76b14dcb664e6fa3793d3dd9ee60b84817. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->