### PR TITLE
chore(global): remove code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,0 @@
-* @alainncls @orbmis @arthur-remy @thedarkjester
-/contracts/ @alainncls @orbmis @arthur-remy @Consensys/linea-contract-team


### PR DESCRIPTION
## What does this PR do?

Removes code owners to align with Linea's practices

### Type of change

- [X] Chore
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update

## Check list

- [ ] My&nbsp;contribution&nbsp;follows&nbsp;the&nbsp;project's&nbsp;[guidelines](https://github.com/Consensys/linea-attestation-registry/blob/dev/CONTRIBUTING.md)
- [ ] I have made corresponding changes to the documentation
- [ ] Unit tests for any smart contract change
- [ ] Contracts and functions are documented

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because it only removes GitHub review assignment/ownership metadata and does not change runtime code or behavior.
> 
> **Overview**
> Removes the `.github/CODEOWNERS` file, eliminating automatic code owner-based review routing for the repository (including the `/contracts/` ownership rule).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d26dd188bd0d58ef7e59467ff53e5fd5bc20567. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->