### PR TITLE
chore(contracts): upgrade Solhint to 6

### DIFF
--- a/contracts/.solhint.json
+++ b/contracts/.solhint.json
@@ -16,6 +16,7 @@
     "named-parameters-mapping": "warn",
     "no-empty-blocks": "off",
     "not-rely-on-time": "off",
+    "use-natspec": "off",
     "var-name-mixedcase": "off",
     "gas-calldata-parameters": "warn"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,8 +64,8 @@ catalogs:
       specifier: 4.9.6
       version: 4.9.6
     solhint:
-      specifier: 5.2.0
-      version: 5.2.0
+      specifier: 6.2.1
+      version: 6.2.1
   types:
     '@types/node':
       specifier: 22.19.17
@@ -101,7 +101,6 @@ overrides:
   protobufjs@<7.5.5: '>=7.5.5'
   semver@>=7.0.0 <7.5.2: '>=7.5.2'
   serialize-javascript@<=7.0.4: '>=7.0.5'
-  solhint>ajv: 6.14.0
   tar@<7.5.13: '>=7.5.13'
   tmp@<=0.2.3: '>=0.2.5'
   undici@<6.24.1: '>=6.24.1'
@@ -186,7 +185,7 @@ importers:
         version: 2.10.1(hardhat@2.28.6(bufferutil@4.1.0)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.10))
       solhint:
         specifier: catalog:solidity
-        version: 5.2.0(typescript@5.9.3)
+        version: 6.2.1(typescript@5.9.3)
       solhint-plugin-prettier:
         specifier: 0.1.0
         version: 0.1.0(prettier-plugin-solidity@2.3.1(prettier@3.8.3))(prettier@3.8.3)
@@ -205,7 +204,7 @@ importers:
     devDependencies:
       solhint:
         specifier: catalog:solidity
-        version: 5.2.0(typescript@5.9.3)
+        version: 6.2.1(typescript@5.9.3)
 
   explorer:
     dependencies:
@@ -3507,10 +3506,6 @@ packages:
     resolution: {integrity: sha512-YcPQ8a0jwYU9bTdJDpXjMi7Brhkr1mXsXrUJvjqM2mQDgkRiz8jFaQGOdaLxgjtUfQgZhKy/O3cG/YwmgKaxLA==}
     engines: {node: '>=12.22.0'}
 
-  '@pnpm/npm-conf@2.3.1':
-    resolution: {integrity: sha512-c83qWb22rNRuB0UaVCI0uRPNRr8Z0FWnEIvT47jiHAmOIUHbBOg5XvV7pM5x+rKn9HRpjxquDbXYSXr3fAKFcw==}
-    engines: {node: '>=12'}
-
   '@pnpm/npm-conf@3.0.2':
     resolution: {integrity: sha512-h104Kh26rR8tm+a3Qkc5S4VLYint3FE48as7+/5oCEcKR2idC/pF1G6AhIXKI+eHPJa/3J9i5z0Al47IeGHPkA==}
     engines: {node: '>=12'}
@@ -5351,10 +5346,10 @@ packages:
     resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==}
     engines: {node: '>=8'}
 
-  ajv-errors@1.0.1:
-    resolution: {integrity: sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==}
+  ajv-errors@3.0.0:
+    resolution: {integrity: sha512-V3wD15YHfHz6y0KdhYFjyy9vWtEVALT9UrxfN3zqlI6dMioHnJrqOYfyPKol3oqrnCM9uwkcdCwkJ0WUcbLMTQ==}
     peerDependencies:
-      ajv: '>=5.0.0'
+      ajv: ^8.0.1
 
   ajv-formats@3.0.1:
     resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
@@ -5411,10 +5406,6 @@ packages:
   ansis@3.17.0:
     resolution: {integrity: sha512-0qWUglt9JEqLFr3w1I1pbrChn1grhaiAR2ocX1PP/flRmxgtwTzPFFFnfIlD6aMOLQZgSuCRlidD70lvx8yhzg==}
     engines: {node: '>=14'}
-
-  antlr4@4.13.2:
-    resolution: {integrity: sha512-QiVbZhyy4xAZ17UPEuG3YTOt8ZaoeOR1CvEAqrEsDBsOqINslaB147i9xqljZqoyf5S+EUlGStaj+t22LT9MOg==}
-    engines: {node: '>=16'}
 
   any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
@@ -7009,10 +7000,6 @@ packages:
     resolution: {integrity: sha512-Xr9F6z6up6Ws+NjzMCZc6WXg2YFRlrLP9NQDO3VQrWrfiojdhS56TzueT88ze0uBdCTwEIhQ3ptnmKeWGFAe0A==}
     engines: {node: '>=14.14'}
 
-  fs-extra@11.3.3:
-    resolution: {integrity: sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg==}
-    engines: {node: '>=14.14'}
-
   fs-extra@7.0.1:
     resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
     engines: {node: '>=6 <7 || >=8'}
@@ -7124,6 +7111,10 @@ packages:
   glob@13.0.0:
     resolution: {integrity: sha512-tvZgpqk6fz4BaNZ66ZsRaZnbHvP/jG3uKJvAZOwEVUL4RTA5nJeeLYfyN9/VA8NX/V3IBG+hkeuGpKjvELkVhA==}
     engines: {node: 20 || >=22}
+
+  glob@13.0.6:
+    resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
+    engines: {node: 18 || 20 || >=22}
 
   global-modules@2.0.0:
     resolution: {integrity: sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==}
@@ -8452,6 +8443,10 @@ packages:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
     engines: {node: '>=16 || 14 >=14.17'}
 
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
   minizlib@2.1.2:
     resolution: {integrity: sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==}
     engines: {node: '>= 8'}
@@ -8918,6 +8913,10 @@ packages:
   path-scurry@2.0.1:
     resolution: {integrity: sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==}
     engines: {node: 20 || >=22}
+
+  path-scurry@2.0.2:
+    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
+    engines: {node: 18 || 20 || >=22}
 
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
@@ -9436,10 +9435,6 @@ packages:
     resolution: {integrity: sha512-0ghuzq67LI9bLXpOX/ISfve/Mq33a4aFRzoQYhnnok1JOFpmE/A2TBGkNVenOGEeSBCjIiWcc6MVOG5HEQv0sA==}
     engines: {node: '>=4'}
 
-  registry-auth-token@5.1.0:
-    resolution: {integrity: sha512-GdekYuwLXLxMuFTwAPg5UKGLW/UXzQrZvH/Zj791BQif5T05T0RsaLfHc9q3ZOKi7n+BoprPD9mJ0O0k4xzUlw==}
-    engines: {node: '>=14'}
-
   registry-auth-token@5.1.1:
     resolution: {integrity: sha512-P7B4+jq8DeD2nMsAcdfaqHbssgHtZ7Z5+++a5ask90fvmJ8p5je4mOa+wzu+DB4vQ5tdJV/xywY+UnVFeQLV5Q==}
     engines: {node: '>=14'}
@@ -9775,8 +9770,9 @@ packages:
       prettier: ^3.0.0
       prettier-plugin-solidity: ^1.0.0
 
-  solhint@5.2.0:
-    resolution: {integrity: sha512-9NZC1zt+O2K7zEZOhTT9rFeB6GdxC6qTX5pWX70RaQoflR9RejJQUC+/19LNi+e7K9Ptb4k7XAWO9wY5mkprHg==}
+  solhint@6.2.1:
+    resolution: {integrity: sha512-+VHSa84CRjm2s+KZWYxIDnI+NokcLsZHOSpRtg5nBFmnVfh6RPmPaFd5TN922Cfrm2i85kNoQtLiapALe26b5w==}
+    engines: {node: '>=20'}
     hasBin: true
 
   solidity-ast@0.4.61:
@@ -15918,12 +15914,6 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.10
 
-  '@pnpm/npm-conf@2.3.1':
-    dependencies:
-      '@pnpm/config.env-replace': 1.1.0
-      '@pnpm/network.ca-file': 1.0.2
-      config-chain: 1.1.13
-
   '@pnpm/npm-conf@3.0.2':
     dependencies:
       '@pnpm/config.env-replace': 1.1.0
@@ -19952,9 +19942,9 @@ snapshots:
       clean-stack: 2.2.0
       indent-string: 4.0.0
 
-  ajv-errors@1.0.1(ajv@6.14.0):
+  ajv-errors@3.0.0(ajv@8.18.0):
     dependencies:
-      ajv: 6.14.0
+      ajv: 8.18.0
 
   ajv-formats@3.0.1(ajv@8.18.0):
     optionalDependencies:
@@ -20012,8 +20002,6 @@ snapshots:
   ansi-styles@5.2.0: {}
 
   ansis@3.17.0: {}
-
-  antlr4@4.13.2: {}
 
   any-promise@1.3.0: {}
 
@@ -20389,11 +20377,11 @@ snapshots:
 
   baseline-browser-mapping@2.9.13: {}
 
-  better-ajv-errors@2.0.3(ajv@6.14.0):
+  better-ajv-errors@2.0.3(ajv@8.18.0):
     dependencies:
-      '@babel/code-frame': 7.27.1
+      '@babel/code-frame': 7.29.0
       '@humanwhocodes/momoa': 2.0.4
-      ajv: 6.14.0
+      ajv: 8.18.0
       chalk: 4.1.2
       jsonpointer: 5.0.1
       leven: 3.1.0
@@ -22007,12 +21995,6 @@ snapshots:
       jsonfile: 6.2.0
       universalify: 2.0.1
 
-  fs-extra@11.3.3:
-    dependencies:
-      graceful-fs: 4.2.11
-      jsonfile: 6.2.0
-      universalify: 2.0.1
-
   fs-extra@7.0.1:
     dependencies:
       graceful-fs: 4.2.11
@@ -22154,6 +22136,12 @@ snapshots:
       minimatch: 10.2.5
       minipass: 7.1.2
       path-scurry: 2.0.1
+
+  glob@13.0.6:
+    dependencies:
+      minimatch: 10.2.5
+      minipass: 7.1.3
+      path-scurry: 2.0.2
 
   global-modules@2.0.0:
     dependencies:
@@ -23782,6 +23770,8 @@ snapshots:
 
   minipass@7.1.2: {}
 
+  minipass@7.1.3: {}
+
   minizlib@2.1.2:
     dependencies:
       minipass: 3.3.6
@@ -24313,7 +24303,7 @@ snapshots:
   package-json@8.1.1:
     dependencies:
       got: 12.6.1
-      registry-auth-token: 5.1.0
+      registry-auth-token: 5.1.1
       registry-url: 6.0.1
       semver: 7.7.4
 
@@ -24376,6 +24366,11 @@ snapshots:
     dependencies:
       lru-cache: 11.3.5
       minipass: 7.1.2
+
+  path-scurry@2.0.2:
+    dependencies:
+      lru-cache: 11.3.5
+      minipass: 7.1.3
 
   path-type@4.0.0: {}
 
@@ -24904,10 +24899,6 @@ snapshots:
       unicode-match-property-ecmascript: 2.0.0
       unicode-match-property-value-ecmascript: 2.2.1
 
-  registry-auth-token@5.1.0:
-    dependencies:
-      '@pnpm/npm-conf': 2.3.1
-
   registry-auth-token@5.1.1:
     dependencies:
       '@pnpm/npm-conf': 3.0.2
@@ -25309,31 +25300,28 @@ snapshots:
       prettier-linter-helpers: 1.0.1
       prettier-plugin-solidity: 2.3.1(prettier@3.8.3)
 
-  solhint@5.2.0(typescript@5.9.3):
+  solhint@6.2.1(typescript@5.9.3):
     dependencies:
       '@solidity-parser/parser': 0.20.2
-      ajv: 6.14.0
-      ajv-errors: 1.0.1(ajv@6.14.0)
-      antlr4: 4.13.2
+      ajv: 8.18.0
+      ajv-errors: 3.0.0(ajv@8.18.0)
       ast-parents: 0.0.1
-      better-ajv-errors: 2.0.3(ajv@6.14.0)
+      better-ajv-errors: 2.0.3(ajv@8.18.0)
       chalk: 4.1.2
       commander: 10.0.1
       cosmiconfig: 8.3.6(typescript@5.9.3)
       fast-diff: 1.3.0
-      fs-extra: 11.3.3
-      glob: 13.0.0
+      glob: 13.0.6
       ignore: 5.3.2
       js-yaml: 4.1.1
       latest-version: 7.0.0
       lodash: 4.18.1
       pluralize: 8.0.0
-      semver: 7.7.3
-      strip-ansi: 6.0.1
+      semver: 7.7.4
       table: 6.9.0
       text-table: 0.2.0
     optionalDependencies:
-      prettier: 2.8.8
+      prettier: 3.8.3
     transitivePeerDependencies:
       - typescript
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -29,7 +29,7 @@ catalogs:
   solidity:
     '@openzeppelin/contracts': 4.9.6
     '@openzeppelin/contracts-upgradeable': 4.9.6
-    solhint: 5.2.0
+    solhint: 6.2.1
   types:
     '@types/node': 22.19.17
   web3:
@@ -61,7 +61,6 @@ overrides:
   protobufjs@<7.5.5: '>=7.5.5'
   semver@>=7.0.0 <7.5.2: '>=7.5.2'
   serialize-javascript@<=7.0.4: '>=7.0.5'
-  solhint>ajv: '6.14.0' # Required by solhint 5.x
   tar@<7.5.13: '>=7.5.13'
   tmp@<=0.2.3: '>=0.2.5'
   undici@<6.24.1: '>=6.24.1'


### PR DESCRIPTION
## Summary
- upgrade the Solidity catalog solhint entry from 5.2.0 to 6.2.1
- remove the solhint>ajv override that was only needed for solhint 5.x
- disable `use-natspec` in the shared Solhint config so the Solhint 6 upgrade does not flood CI with documentation-completeness warnings from existing contracts/tests
- refresh the pnpm lockfile

## Validation
- pnpm install
- pnpm --filter @verax-attestation-registry/verax-contracts --filter @verax-attestation-registry/verax-examples -r run lint
- pnpm --filter @verax-attestation-registry/verax-contracts --filter @verax-attestation-registry/verax-examples -r run build
- pre-commit hook ran prettier, full lint, and contracts forge test successfully
- GitHub Actions `Lint` run 24895284932, job 72898272223 completed successfully and was not skipped
- GitHub Actions PR checks are green; `size-contracts` initially hit an external Hardhat compiler download timeout and passed on rerun

## Warning surface
Solhint 6 substantially increased the warning output because `solhint:recommended` now surfaces `use-natspec` documentation checks across contracts, tests, mocks, and examples.

Before tuning, the PR had 1131 Solhint warnings total:

- `contracts`: 902 warnings, including 818 from `use-natspec`
- `examples`: 229 warnings, including 208 from `use-natspec`

After disabling only `use-natspec`, local Solhint output is back to a readable level while preserving the code-oriented warnings:

- `contracts`: 84 warnings, 0 errors
- `examples`: 21 warnings, 0 errors

The warnings shown in the linked `build-contracts` job are Foundry/Solidity compiler lint notes, not Solhint output. They are identical to the latest successful `dev` Contracts run and are not introduced by this Solhint PR.

Closes #1050
