### PR TITLE
ci: restrict release workflow to trusted main ref

### DIFF
--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -12,8 +12,7 @@ concurrency:
 jobs:
   release:
     if: >-
-      github.ref == 'refs/heads/main' &&
-      (
+      github.ref == 'refs/heads/main' && (
         github.actor == 'alainncls' ||
         github.actor == 'satyajeetkolhapure' ||
         github.actor == 'orbmis' ||

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -5,13 +5,23 @@ on:
 
 permissions: {} # lock everything by default (least-privilege)
 
+concurrency:
+  group: production-release
+  cancel-in-progress: false
+
 jobs:
   release:
-    if:
-      github.actor == 'alainncls' || github.actor  == 'satyajeetkolhapure' || github.actor  == 'orbmis' ||
-      github.actor  == 'arthur-remy'
+    if: >-
+      github.ref == 'refs/heads/main' &&
+      (
+        github.actor == 'alainncls' ||
+        github.actor == 'satyajeetkolhapure' ||
+        github.actor == 'orbmis' ||
+        github.actor == 'arthur-remy'
+      )
 
     runs-on: ubuntu-latest
+    environment: production-release
     permissions:
       contents: read
 
@@ -20,6 +30,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          ref: main
           token: ${{ secrets.PROD_RELEASER_GH_TOKEN }}
 
       - name: "Run release script"

--- a/release.sh
+++ b/release.sh
@@ -1,15 +1,23 @@
 #!/bin/bash
 
-set -e
+set -euo pipefail
+
+if [[ "${GITHUB_REF:-}" != "refs/heads/main" ]]; then
+  echo "Refusing to run release from GITHUB_REF='${GITHUB_REF:-<unset>}'; expected refs/heads/main." >&2
+  exit 1
+fi
 
 git config user.name github-actions[bot]
 git config user.email github-actions[bot]@users.noreply.github.com
 
-git checkout main
+git fetch origin \
+  +refs/heads/main:refs/remotes/origin/main \
+  +refs/heads/dev:refs/remotes/origin/dev
 
-git merge --no-edit --no-ff dev
-git push origin main
+git checkout -B main refs/remotes/origin/main
+git merge --no-edit --no-ff refs/remotes/origin/dev
+git push origin HEAD:refs/heads/main
 
-git checkout dev
-git rebase main
-git push origin dev
+git checkout -B dev refs/remotes/origin/dev
+git rebase refs/heads/main
+git push origin HEAD:refs/heads/dev


### PR DESCRIPTION
## Summary

Restricts the manual release workflow to the trusted `main` ref before using the release token and hardens `release.sh` so it fails closed outside `refs/heads/main`.

## Related issue

Closes #1067

## Type of change

- [x] Chore
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update

## Affected areas

- [x] Root / contributor docs
- [ ] Contracts
- [ ] Examples
- [ ] SDK
- [ ] Subgraph
- [ ] Explorer
- [ ] Tutorial
- [ ] GitBook source (`doc/`)

## Validation

- [x] I followed the contributor guide in [`CONTRIBUTING.md`](https://github.com/Consensys/linea-attestation-registry/blob/dev/CONTRIBUTING.md)
- [x] I ran the relevant local commands for the areas I changed
- [x] I updated documentation, env/config notes, or public matrices when behavior changed
- [x] I noted any follow-up deployment or release work if applicable

Commands run:

- `bash -n release.sh`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/releaser.yml"); puts "workflow yaml parsed"'`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest -color=false .github/workflows/releaser.yml`
- `GITHUB_REF=refs/heads/dev bash release.sh` to verify the guard fails closed
- `env -u GITHUB_REF bash release.sh` to verify the guard fails closed
- `git diff --check -- .github/workflows/releaser.yml release.sh`

Notes:

- No Solidity files were modified.
- Key rotation is intentionally out of scope and will be handled separately.
- The `production-release` GitHub environment must be configured with the release secret and approval policy before relying on the environment gate.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the production release workflow and `release.sh` git operations that run with a privileged token; misconfiguration could block releases or push unintended refs. Changes are primarily additional guards and deterministic ref handling, which lowers but doesn’t eliminate risk.
> 
> **Overview**
> **Hardens the manual production release path to only run from `main`.** The workflow now gates execution on `github.ref == refs/heads/main`, adds `production-release` environment + concurrency, and checks out an explicit `main` ref before using the release token.
> 
> **Makes `release.sh` fail closed and operate on explicit remote refs.** It now aborts unless `GITHUB_REF` is `refs/heads/main`, enables `set -euo pipefail`, fetches `main`/`dev` into `refs/remotes/origin/*`, and performs merge/rebase/push using `HEAD:refs/heads/*` rather than relying on local branch state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20d9cef03ae32d0fb77ddd8d7bd338a490c844e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->