### PR TITLE
fix(sdk): harden off-chain attestation enrichment

### DIFF
--- a/sdk/src/dataMapper/AttestationDataMapper.test.ts
+++ b/sdk/src/dataMapper/AttestationDataMapper.test.ts
@@ -60,27 +60,46 @@ describe("AttestationDataMapper", () => {
     offchainData: undefined,
   };
 
+  const createMockAttestation = (overrides: Partial<Attestation> = {}): Attestation => ({
+    ...mockAttestation,
+    schema: {
+      ...mockAttestation.schema,
+    },
+    portal: {
+      ...mockAttestation.portal,
+    },
+    offchainData: undefined,
+    ...overrides,
+  });
+
   const mockWeb3Client = {} as PublicClient;
   const mockWalletClient = {} as WalletClient;
-  const mockVeraxSdk = {} as VeraxSdk;
+  const mockVeraxSdk = {
+    schema: {
+      findOneById: jest.fn(),
+    },
+  } as unknown as VeraxSdk;
 
   beforeEach(() => {
     attestationDataMapper = new AttestationDataMapper(mockConf, mockWeb3Client, mockVeraxSdk, mockWalletClient);
+    (attestationDataMapper as unknown as { veraxSdk: VeraxSdk }).veraxSdk = mockVeraxSdk;
     jest.clearAllMocks();
   });
 
   describe("findOneById", () => {
     it("should find attestation by id and enrich it", async () => {
-      (BaseDataMapper.prototype.findOneById as jest.Mock).mockResolvedValue(mockAttestation);
+      const attestation = createMockAttestation();
+      (BaseDataMapper.prototype.findOneById as jest.Mock).mockResolvedValue(attestation);
       (decodeWithRetry as jest.Mock).mockReturnValue([
         { schemaId: Constants.OFFCHAIN_DATA_SCHEMA_ID, uri: "ipfs://QmHash" },
       ]);
+      (getIPFSContent as jest.Mock).mockResolvedValue("data");
 
       const result = await attestationDataMapper.findOneById("1");
 
       expect(BaseDataMapper.prototype.findOneById).toHaveBeenCalledWith("1");
-      expect(decodeWithRetry).toHaveBeenCalledWith(mockAttestation.schema.schema, mockAttestation.attestationData);
-      expect(result).toEqual(mockAttestation);
+      expect(decodeWithRetry).toHaveBeenCalledWith(attestation.schema.schema, attestation.attestationData);
+      expect(result).toEqual(attestation);
     });
 
     it("should return undefined if no attestation is found", async () => {
@@ -95,11 +114,12 @@ describe("AttestationDataMapper", () => {
 
   describe("findBy", () => {
     it("should find attestations and enrich each of them", async () => {
-      const attestations = [mockAttestation];
+      const attestations = [createMockAttestation()];
       (BaseDataMapper.prototype.findBy as jest.Mock).mockResolvedValue(attestations);
       (decodeWithRetry as jest.Mock).mockReturnValue([
         { schemaId: Constants.OFFCHAIN_DATA_SCHEMA_ID, uri: "ipfs://QmHash" },
       ]);
+      (getIPFSContent as jest.Mock).mockResolvedValue("data");
 
       const result = await attestationDataMapper.findBy(10, 0, {}, "attestedDate", "desc");
 
@@ -111,7 +131,8 @@ describe("AttestationDataMapper", () => {
 
   describe("enrichAttestation", () => {
     it("should enrich attestation with decoded payload for off-chain data schema", async () => {
-      (BaseDataMapper.prototype.findOneById as jest.Mock).mockResolvedValue(mockAttestation);
+      const attestation = createMockAttestation();
+      (BaseDataMapper.prototype.findOneById as jest.Mock).mockResolvedValue(attestation);
       (decodeWithRetry as jest.Mock).mockReturnValue([
         { schemaId: Constants.OFFCHAIN_DATA_SCHEMA_ID, uri: "ipfs://QmHash" },
       ]);
@@ -127,7 +148,8 @@ describe("AttestationDataMapper", () => {
     });
 
     it("should set offchainData.error if IPFS request fails", async () => {
-      (BaseDataMapper.prototype.findOneById as jest.Mock).mockResolvedValue(mockAttestation);
+      const attestation = createMockAttestation();
+      (BaseDataMapper.prototype.findOneById as jest.Mock).mockResolvedValue(attestation);
       (decodeWithRetry as jest.Mock).mockReturnValue([
         { schemaId: Constants.OFFCHAIN_DATA_SCHEMA_ID, uri: "ipfs://QmHash" },
       ]);
@@ -139,9 +161,91 @@ describe("AttestationDataMapper", () => {
       expect(result?.offchainData?.error).toBe("IPFS Error");
     });
 
+    it.each([
+      { name: "empty decoded payload", decodedPayload: [] },
+      { name: "non-object pointer", decodedPayload: ["invalid"] },
+      { name: "non-string URI", decodedPayload: [{ schemaId: Constants.OFFCHAIN_DATA_SCHEMA_ID, uri: 42 }] },
+    ])("should set structured offchainData.error for malformed pointer: $name", async ({ decodedPayload }) => {
+      const attestation = createMockAttestation();
+      (BaseDataMapper.prototype.findOneById as jest.Mock).mockResolvedValue(attestation);
+      (decodeWithRetry as jest.Mock).mockReturnValue(decodedPayload);
+
+      const result = await attestationDataMapper.findOneById("1");
+
+      expect(result?.decodedPayload).toEqual({});
+      expect(result?.offchainData).toEqual({
+        schemaId: "",
+        uri: "",
+        error: {
+          code: "MALFORMED_POINTER",
+          message: "Malformed off-chain pointer: expected decoded payload with string schemaId and uri.",
+        },
+      });
+      expect(getIPFSContent).not.toHaveBeenCalled();
+    });
+
+    it("should decode fetched IPFS hex content with the referenced schema", async () => {
+      const attestation = createMockAttestation();
+      const referencedSchema = {
+        id: "0xReferencedSchema",
+        name: "Referenced Schema",
+        description: "Referenced schema",
+        context: "http://schema.org",
+        schema: "bool isBuidler",
+        attestationCounter: 1,
+      };
+      const decodedFetchedPayload = [{ isBuidler: true }];
+      (BaseDataMapper.prototype.findOneById as jest.Mock).mockResolvedValue(attestation);
+      (decodeWithRetry as jest.Mock)
+        .mockReturnValueOnce([{ schemaId: referencedSchema.id, uri: "ipfs://QmHash" }])
+        .mockReturnValueOnce(decodedFetchedPayload);
+      (getIPFSContent as jest.Mock).mockResolvedValue("0x01");
+      (mockVeraxSdk.schema.findOneById as jest.Mock).mockResolvedValue(referencedSchema);
+
+      const result = await attestationDataMapper.findOneById("1");
+
+      expect(mockVeraxSdk.schema.findOneById).toHaveBeenCalledWith(referencedSchema.id);
+      expect(decodeWithRetry).toHaveBeenNthCalledWith(2, referencedSchema.schema, "0x01");
+      expect(result?.decodedPayload).toEqual(decodedFetchedPayload);
+      expect(result?.offchainData).toEqual({
+        schemaId: referencedSchema.id,
+        uri: "ipfs://QmHash",
+      });
+    });
+
+    it("should set structured offchainData.error if fetched IPFS hex content cannot be decoded", async () => {
+      const attestation = createMockAttestation();
+      const referencedSchema = {
+        id: "0xReferencedSchema",
+        name: "Referenced Schema",
+        description: "Referenced schema",
+        context: "http://schema.org",
+        schema: "bool isBuidler",
+        attestationCounter: 1,
+      };
+      (BaseDataMapper.prototype.findOneById as jest.Mock).mockResolvedValue(attestation);
+      (decodeWithRetry as jest.Mock)
+        .mockReturnValueOnce([{ schemaId: referencedSchema.id, uri: "ipfs://QmHash" }])
+        .mockReturnValueOnce([]);
+      (getIPFSContent as jest.Mock).mockResolvedValue("0x01");
+      (mockVeraxSdk.schema.findOneById as jest.Mock).mockResolvedValue(referencedSchema);
+
+      const result = await attestationDataMapper.findOneById("1");
+
+      expect(result?.decodedPayload).toEqual({});
+      expect(result?.offchainData).toEqual({
+        schemaId: referencedSchema.id,
+        uri: "ipfs://QmHash",
+        error: {
+          code: "MALFORMED_FETCHED_CONTENT",
+          message: "Malformed fetched off-chain content: could not decode IPFS response with referenced schema.",
+        },
+      });
+    });
+
     it("should not enrich if schema ID is not offchain data", async () => {
       const nonOffchainAttestation = {
-        ...mockAttestation,
+        ...createMockAttestation(),
         schema: { ...mockAttestation.schema, id: "0x123" },
         offchainData: undefined,
       };

--- a/sdk/src/dataMapper/AttestationDataMapper.ts
+++ b/sdk/src/dataMapper/AttestationDataMapper.ts
@@ -15,6 +15,15 @@ import { executeTransaction } from "../utils/transactionSender";
 import { getIPFSContent } from "../utils/ipfsClient";
 import { VeraxSdk } from "../VeraxSdk";
 
+type StructuredOffchainDataError = {
+  code: "MALFORMED_POINTER" | "MALFORMED_FETCHED_CONTENT";
+  message: string;
+};
+
+type EnrichedOffchainData = Omit<OffchainData, "error"> & {
+  error?: OffchainData["error"] | StructuredOffchainDataError;
+};
+
 export default class AttestationDataMapper extends BaseDataMapper<
   Attestation,
   Attestation_filter,
@@ -171,20 +180,39 @@ export default class AttestationDataMapper extends BaseDataMapper<
 
     // Check if data is stored off-chain
     if (attestation.schema.id === Constants.OFFCHAIN_DATA_SCHEMA_ID) {
-      attestation.offchainData = {
-        schemaId: (attestation.decodedPayload as OffchainData[])[0].schemaId,
-        uri: (attestation.decodedPayload as OffchainData[])[0].uri,
-      };
+      attestation.offchainData = this.getOffchainDataPointer(attestation.decodedPayload);
       attestation.decodedPayload = {};
+      if (attestation.offchainData.error) {
+        return;
+      }
       if (attestation.offchainData.uri.startsWith("ipfs://")) {
         try {
           const ipfsHash = attestation.offchainData.uri.split("//")[1];
           const response = await getIPFSContent(ipfsHash);
-          if (response.toString().startsWith("0x")) {
-            const offChainDataSchema = (await this.veraxSdk.schema.findOneById(
-              attestation.offchainData.schemaId,
-            )) as Schema;
-            attestation.decodedPayload = decodeWithRetry(offChainDataSchema.schema, attestation.attestationData as Hex);
+          const responseContent = response.toString();
+          if (responseContent.startsWith("0x")) {
+            const offChainDataSchema = (await this.veraxSdk.schema.findOneById(attestation.offchainData.schemaId)) as
+              | Schema
+              | undefined;
+
+            if (!offChainDataSchema) {
+              this.setStructuredOffchainDataError(attestation.offchainData, {
+                code: "MALFORMED_FETCHED_CONTENT",
+                message: "Malformed fetched off-chain content: referenced schema was not found.",
+              });
+              return;
+            }
+
+            const decodedPayload = decodeWithRetry(offChainDataSchema.schema, responseContent as Hex);
+            if (!decodedPayload.length) {
+              this.setStructuredOffchainDataError(attestation.offchainData, {
+                code: "MALFORMED_FETCHED_CONTENT",
+                message: "Malformed fetched off-chain content: could not decode IPFS response with referenced schema.",
+              });
+              return;
+            }
+
+            attestation.decodedPayload = decodedPayload as object;
           } else {
             attestation.decodedPayload = response as unknown as object;
           }
@@ -193,6 +221,43 @@ export default class AttestationDataMapper extends BaseDataMapper<
         }
       }
     }
+  }
+
+  private getOffchainDataPointer(decodedPayload: unknown): OffchainData {
+    const pointer = Array.isArray(decodedPayload) ? decodedPayload[0] : undefined;
+
+    if (
+      !this.isRecord(pointer) ||
+      typeof pointer.schemaId !== "string" ||
+      pointer.schemaId.length === 0 ||
+      typeof pointer.uri !== "string" ||
+      pointer.uri.length === 0
+    ) {
+      return this.createOffchainData("", "", {
+        code: "MALFORMED_POINTER",
+        message: "Malformed off-chain pointer: expected decoded payload with string schemaId and uri.",
+      });
+    }
+
+    return this.createOffchainData(pointer.schemaId, pointer.uri);
+  }
+
+  private createOffchainData(schemaId: string, uri: string, error?: StructuredOffchainDataError): OffchainData {
+    const offchainData: EnrichedOffchainData = { schemaId, uri };
+
+    if (error) {
+      offchainData.error = error;
+    }
+
+    return offchainData as OffchainData;
+  }
+
+  private setStructuredOffchainDataError(offchainData: OffchainData, error: StructuredOffchainDataError) {
+    (offchainData as EnrichedOffchainData).error = error;
+  }
+
+  private isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === "object" && value !== null && !Array.isArray(value);
   }
 
   async getRelatedAttestations(id: string) {

--- a/sdk/src/types/index.ts
+++ b/sdk/src/types/index.ts
@@ -39,7 +39,9 @@ export type Attestation = OnChainAttestation & {
   chainName?: string;
 };
 
-export type OffchainData = { schemaId: string; uri: string; error?: string };
+export type OffchainDataError = string | { code: string; message: string };
+
+export type OffchainData = { schemaId: string; uri: string; error?: OffchainDataError };
 
 export interface IPFSConfig {
   projectId: string;


### PR DESCRIPTION
## Summary

Hardens SDK off-chain attestation enrichment by validating decoded pointer shape before dereferencing and decoding fetched IPFS hex content instead of the original pointer bytes.

## Related issue

Closes #1068

## Type of change

- [ ] Chore
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update

## Affected areas

- [ ] Root / contributor docs
- [ ] Contracts
- [ ] Examples
- [x] SDK
- [ ] Subgraph
- [ ] Explorer
- [ ] Tutorial
- [ ] GitBook source (`doc/`)

## Validation

- [x] I followed the contributor guide in [`CONTRIBUTING.md`](https://github.com/Consensys/linea-attestation-registry/blob/dev/CONTRIBUTING.md)
- [x] I ran the relevant local commands for the areas I changed
- [x] I updated documentation, env/config notes, or public matrices when behavior changed
- [ ] I noted any follow-up deployment or release work if applicable

Commands run:

- `pnpm --dir sdk exec jest src/dataMapper/AttestationDataMapper.test.ts --runInBand`
- `pnpm --dir sdk exec jest --testPathIgnorePatterns=integration --runInBand`
- `pnpm --dir sdk run build`
- `pnpm exec prettier --check sdk/src/dataMapper/AttestationDataMapper.ts sdk/src/dataMapper/AttestationDataMapper.test.ts sdk/src/types/index.ts`
- `git diff --check`

Notes:

- No Solidity files were modified.
- SDK build emitted existing Graph Client duplicate-key warnings during generated artifact bundling.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes off-chain attestation enrichment behavior and widens `OffchainData.error` from `string` to a structured union, which may affect downstream consumers expecting the previous shape. Logic touches IPFS dereferencing and schema-based decoding paths, so edge cases may surface despite added tests.
> 
> **Overview**
> **Off-chain attestation enrichment is hardened and made more fault-tolerant.** The mapper now validates the decoded off-chain pointer (`schemaId`/`uri`) before dereferencing, and returns a structured `offchainData.error` (e.g. `MALFORMED_POINTER`) instead of attempting IPFS fetches with bad data.
> 
> When the IPFS response is hex-encoded, the mapper now looks up the referenced schema and decodes the *fetched* content (not the original on-chain pointer bytes), surfacing structured `MALFORMED_FETCHED_CONTENT` errors when the schema is missing or decoding yields no data. Types are updated so `OffchainData.error` can be a string or `{ code, message }`, and unit tests are expanded to cover the new validation and decoding/error cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11cb4e48669cd0127547119f6a1d61ded4a6aad7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->