### PR TITLE
fix(sdk): use GraphQL variables and validate query arguments

### DIFF
--- a/sdk/src/dataMapper/BaseDataMapper.test.ts
+++ b/sdk/src/dataMapper/BaseDataMapper.test.ts
@@ -4,7 +4,7 @@ import { lineaSepolia } from "viem/chains";
 
 import { ChainName, Conf } from "../types";
 import { SDKMode, VeraxSdk } from "../VeraxSdk";
-import { subgraphCall, stringifyWhereClause } from "../utils/graphClientHelper";
+import { subgraphCall } from "../utils/graphClientHelper";
 import { getCustomGraphSDKForChains } from "../utils/graphClientBuilder";
 import { getSDKForChains } from "../utils/meshInstanceManager";
 import { getConfiguredSubgraphUrl } from "../utils/urlResolver";
@@ -25,6 +25,11 @@ type TestFilter = {
 
 class MockDataMapper extends BaseDataMapper<TestType, TestFilter, unknown> {
   protected typeName = "TestType";
+  protected gqlInterface = "{ id, name }";
+}
+
+class MockModuleDataMapper extends BaseDataMapper<TestType, Record<string, unknown>, unknown> {
+  protected typeName = "module";
   protected gqlInterface = "{ id, name }";
 }
 
@@ -59,10 +64,17 @@ describe("BaseDataMapper", () => {
       const result = await mockDataMapper.findOneById("1");
 
       expect(subgraphCall).toHaveBeenCalledWith(
-        `query get_TestType { TestType(id: "1") { id, name } }`,
+        `query get_TestType($id: ID!) { TestType(id: $id) { id, name } }`,
         mockConf.subgraphUrl,
+        { id: "1" },
       );
       expect(result).toEqual({ id: "1", name: "Test" });
+    });
+
+    it("should reject unsafe ids before calling subgraphCall", async () => {
+      await expect(mockDataMapper.findOneById('1") { id } malicious { id: "2')).rejects.toThrow("Invalid TestType id");
+
+      expect(subgraphCall).not.toHaveBeenCalled();
     });
 
     it("should throw an error if the status is not 200", async () => {
@@ -97,25 +109,37 @@ describe("BaseDataMapper", () => {
       };
       (subgraphCall as jest.Mock).mockResolvedValueOnce(mockResponse);
 
-      const filter: TestFilter | undefined = { name: "Test" };
-      (stringifyWhereClause as jest.Mock).mockReturnValueOnce('{name:"Test"}');
+      const filter: TestFilter = { name: "Test" };
 
       const result = await mockDataMapper.findBy(10, 0, filter, "name", "asc");
 
       expect(subgraphCall).toHaveBeenCalledWith(
         `
-        query get_TestTypes{
+        query get_TestTypes(
+          $first: Int
+          $skip: Int
+          $where: TestType_filter
+          $orderBy: TestType_orderBy
+          $orderDirection: OrderDirection
+        ){
           TestTypes(
-            first: 10
-            skip: 0
-            where: {name:"Test"}
-            orderBy: name
-            orderDirection: asc
+            first: $first
+            skip: $skip
+            where: $where
+            orderBy: $orderBy
+            orderDirection: $orderDirection
           )
           { id, name }
         }
     `,
         mockConf.subgraphUrl,
+        {
+          first: 10,
+          skip: 0,
+          where: filter,
+          orderBy: "name",
+          orderDirection: "asc",
+        },
       );
       expect(result).toEqual([
         { id: "1", name: "Test1" },
@@ -129,6 +153,13 @@ describe("BaseDataMapper", () => {
 
       const result = await mockDataMapper.findBy();
 
+      expect(subgraphCall).toHaveBeenCalledWith(expect.any(String), mockConf.subgraphUrl, {
+        first: 100,
+        skip: 0,
+        where: null,
+        orderBy: null,
+        orderDirection: null,
+      });
       expect(result).toEqual([]);
     });
 
@@ -146,6 +177,67 @@ describe("BaseDataMapper", () => {
       (subgraphCall as jest.Mock).mockResolvedValueOnce(mockResponse);
 
       await expect(mockDataMapper.findBy()).rejects.toThrow("Error(s) while fetching TestTypes");
+    });
+
+    it("should reject invalid pagination before calling subgraphCall", async () => {
+      await expect(mockDataMapper.findBy(-1)).rejects.toThrow("Invalid pagination value for first");
+      await expect(mockDataMapper.findBy(10, 1.5)).rejects.toThrow("Invalid pagination value for skip");
+
+      expect(subgraphCall).not.toHaveBeenCalled();
+    });
+
+    it("should reject invalid order direction before calling subgraphCall", async () => {
+      await expect(mockDataMapper.findBy(10, 0, undefined, undefined, "sideways" as never)).rejects.toThrow(
+        "Invalid orderDirection for TestTypes",
+      );
+
+      expect(subgraphCall).not.toHaveBeenCalled();
+    });
+
+    it("should reject unsafe order fields before calling subgraphCall", async () => {
+      await expect(mockDataMapper.findBy(10, 0, undefined, "name) { id }" as never)).rejects.toThrow(
+        "Invalid orderBy field for TestTypes",
+      );
+
+      expect(subgraphCall).not.toHaveBeenCalled();
+    });
+
+    it("should reject unknown order fields for known mapper types before calling subgraphCall", async () => {
+      const moduleMapper = new MockModuleDataMapper(mockConf, mockWeb3Client, mockVeraxSdk, mockWalletClient);
+
+      await expect(moduleMapper.findBy(10, 0, undefined, "unknownField")).rejects.toThrow(
+        "Invalid orderBy field for modules",
+      );
+
+      expect(subgraphCall).not.toHaveBeenCalled();
+    });
+
+    it("should reject unsafe filter keys before calling subgraphCall", async () => {
+      await expect(mockDataMapper.findBy(10, 0, { 'name") { id }': "Test" } as unknown as TestFilter)).rejects.toThrow(
+        'Invalid filter key "where.name") { id }"',
+      );
+
+      expect(subgraphCall).not.toHaveBeenCalled();
+    });
+
+    it("should reject unknown filter keys for known mapper types before calling subgraphCall", async () => {
+      const moduleMapper = new MockModuleDataMapper(mockConf, mockWeb3Client, mockVeraxSdk, mockWalletClient);
+
+      await expect(moduleMapper.findBy(10, 0, { notAFilter: "Test" })).rejects.toThrow(
+        'Invalid filter key "where.notAFilter"',
+      );
+
+      expect(subgraphCall).not.toHaveBeenCalled();
+    });
+
+    it("should validate nested known filters before calling subgraphCall", async () => {
+      const moduleMapper = new MockModuleDataMapper(mockConf, mockWeb3Client, mockVeraxSdk, mockWalletClient);
+
+      await expect(
+        moduleMapper.findBy(10, 0, { auditInformation_: { creation_: { badField: "Test" } } }),
+      ).rejects.toThrow('Invalid filter key "where.auditInformation_.creation_.badField"');
+
+      expect(subgraphCall).not.toHaveBeenCalled();
     });
   });
 

--- a/sdk/src/dataMapper/BaseDataMapper.ts
+++ b/sdk/src/dataMapper/BaseDataMapper.ts
@@ -2,11 +2,233 @@ import { PublicClient, WalletClient } from "viem";
 import { ChainName, Conf, CrossChainClient } from "../types";
 import { OrderDirection } from "../../.graphclient";
 import { VeraxSdk } from "../VeraxSdk";
-import { stringifyWhereClause, subgraphCall } from "../utils/graphClientHelper";
+import { subgraphCall } from "../utils/graphClientHelper";
 import { getCustomGraphSDKForChains } from "../utils/graphClientBuilder";
 import { getSDKForChains } from "../utils/meshInstanceManager";
 import { getConfiguredSubgraphUrl } from "../utils/urlResolver";
 import { NetworkType, inferNetworkType } from "../utils/networkTypeUtils";
+
+type FilterTypeName = "attestation" | "module" | "portal" | "schema" | "auditInformation" | "audit" | "blockChanged";
+
+const GRAPHQL_NAME_PATTERN = /^[_A-Za-z][_0-9A-Za-z]*$/;
+const GRAPHQL_ID_PATTERN = /^[A-Za-z0-9_.:-]+$/;
+const MAX_GRAPHQL_INT = 2147483647;
+
+const ID_FILTER_SUFFIXES = ["", "_not", "_gt", "_lt", "_gte", "_lte", "_in", "_not_in"] as const;
+const STRING_FILTER_SUFFIXES = [
+  ...ID_FILTER_SUFFIXES,
+  "_contains",
+  "_contains_nocase",
+  "_not_contains",
+  "_not_contains_nocase",
+  "_starts_with",
+  "_starts_with_nocase",
+  "_not_starts_with",
+  "_not_starts_with_nocase",
+  "_ends_with",
+  "_ends_with_nocase",
+  "_not_ends_with",
+  "_not_ends_with_nocase",
+] as const;
+const BYTES_FILTER_SUFFIXES = [...ID_FILTER_SUFFIXES, "_contains", "_not_contains"] as const;
+const BOOLEAN_FILTER_SUFFIXES = ["", "_not", "_in", "_not_in"] as const;
+const ARRAY_FILTER_SUFFIXES = ["", "_not", "_contains", "_not_contains"] as const;
+const ARRAY_STRING_FILTER_SUFFIXES = [
+  "",
+  "_not",
+  "_contains",
+  "_contains_nocase",
+  "_not_contains",
+  "_not_contains_nocase",
+] as const;
+
+function buildFilterKeys(
+  fields: Record<string, readonly string[]>,
+  nestedFilterKeys: readonly string[] = [],
+): ReadonlySet<string> {
+  return new Set([
+    ...Object.entries(fields).flatMap(([field, suffixes]) => suffixes.map((suffix) => `${field}${suffix}`)),
+    ...nestedFilterKeys,
+    "_change_block",
+    "and",
+    "or",
+  ]);
+}
+
+const FILTER_KEYS_BY_TYPE: Record<FilterTypeName, ReadonlySet<string>> = {
+  attestation: buildFilterKeys(
+    {
+      id: ID_FILTER_SUFFIXES,
+      schema: STRING_FILTER_SUFFIXES,
+      replacedBy: BYTES_FILTER_SUFFIXES,
+      attester: BYTES_FILTER_SUFFIXES,
+      portal: STRING_FILTER_SUFFIXES,
+      attestedDate: ID_FILTER_SUFFIXES,
+      expirationDate: ID_FILTER_SUFFIXES,
+      revocationDate: ID_FILTER_SUFFIXES,
+      version: ID_FILTER_SUFFIXES,
+      revoked: BOOLEAN_FILTER_SUFFIXES,
+      subject: BYTES_FILTER_SUFFIXES,
+      encodedSubject: BYTES_FILTER_SUFFIXES,
+      attestationData: BYTES_FILTER_SUFFIXES,
+      decodedData: ARRAY_STRING_FILTER_SUFFIXES,
+      auditInformation: STRING_FILTER_SUFFIXES,
+    },
+    ["schema_", "portal_", "auditInformation_"],
+  ),
+  module: buildFilterKeys(
+    {
+      id: ID_FILTER_SUFFIXES,
+      moduleAddress: BYTES_FILTER_SUFFIXES,
+      name: STRING_FILTER_SUFFIXES,
+      description: STRING_FILTER_SUFFIXES,
+      auditInformation: STRING_FILTER_SUFFIXES,
+    },
+    ["auditInformation_"],
+  ),
+  portal: buildFilterKeys(
+    {
+      id: ID_FILTER_SUFFIXES,
+      ownerAddress: BYTES_FILTER_SUFFIXES,
+      modules: ARRAY_FILTER_SUFFIXES,
+      isRevocable: BOOLEAN_FILTER_SUFFIXES,
+      name: STRING_FILTER_SUFFIXES,
+      description: STRING_FILTER_SUFFIXES,
+      ownerName: STRING_FILTER_SUFFIXES,
+      attestationCounter: ID_FILTER_SUFFIXES,
+      auditInformation: STRING_FILTER_SUFFIXES,
+    },
+    ["auditInformation_"],
+  ),
+  schema: buildFilterKeys(
+    {
+      id: ID_FILTER_SUFFIXES,
+      name: STRING_FILTER_SUFFIXES,
+      description: STRING_FILTER_SUFFIXES,
+      context: STRING_FILTER_SUFFIXES,
+      schema: STRING_FILTER_SUFFIXES,
+      attestationCounter: ID_FILTER_SUFFIXES,
+      auditInformation: STRING_FILTER_SUFFIXES,
+    },
+    ["auditInformation_"],
+  ),
+  auditInformation: buildFilterKeys(
+    {
+      id: ID_FILTER_SUFFIXES,
+      creation: STRING_FILTER_SUFFIXES,
+      lastModification: STRING_FILTER_SUFFIXES,
+      modifications: ARRAY_STRING_FILTER_SUFFIXES,
+    },
+    ["creation_", "lastModification_", "modifications_"],
+  ),
+  audit: buildFilterKeys({
+    id: ID_FILTER_SUFFIXES,
+    blockNumber: ID_FILTER_SUFFIXES,
+    transactionHash: BYTES_FILTER_SUFFIXES,
+    transactionTimestamp: ID_FILTER_SUFFIXES,
+    fromAddress: BYTES_FILTER_SUFFIXES,
+    toAddress: BYTES_FILTER_SUFFIXES,
+    valueTransferred: ID_FILTER_SUFFIXES,
+    gasPrice: ID_FILTER_SUFFIXES,
+  }),
+  blockChanged: new Set(["number_gte"]),
+};
+
+const NESTED_FILTER_TYPES: Partial<Record<FilterTypeName, Record<string, FilterTypeName>>> = {
+  attestation: {
+    schema_: "schema",
+    portal_: "portal",
+    auditInformation_: "auditInformation",
+    _change_block: "blockChanged",
+  },
+  module: {
+    auditInformation_: "auditInformation",
+    _change_block: "blockChanged",
+  },
+  portal: {
+    auditInformation_: "auditInformation",
+    _change_block: "blockChanged",
+  },
+  schema: {
+    auditInformation_: "auditInformation",
+    _change_block: "blockChanged",
+  },
+  auditInformation: {
+    creation_: "audit",
+    lastModification_: "audit",
+    modifications_: "audit",
+    _change_block: "blockChanged",
+  },
+  audit: {
+    _change_block: "blockChanged",
+  },
+};
+
+const ORDER_FIELDS_BY_TYPE: Partial<Record<FilterTypeName, ReadonlySet<string>>> = {
+  attestation: new Set([
+    "id",
+    "schema",
+    "schema__id",
+    "schema__name",
+    "schema__description",
+    "schema__context",
+    "schema__schema",
+    "schema__attestationCounter",
+    "replacedBy",
+    "attester",
+    "portal",
+    "portal__id",
+    "portal__ownerAddress",
+    "portal__isRevocable",
+    "portal__name",
+    "portal__description",
+    "portal__ownerName",
+    "portal__attestationCounter",
+    "attestedDate",
+    "expirationDate",
+    "revocationDate",
+    "version",
+    "revoked",
+    "subject",
+    "encodedSubject",
+    "attestationData",
+    "decodedData",
+    "auditInformation",
+    "auditInformation__id",
+  ]),
+  module: new Set(["id", "moduleAddress", "name", "description", "auditInformation", "auditInformation__id"]),
+  portal: new Set([
+    "id",
+    "ownerAddress",
+    "modules",
+    "isRevocable",
+    "name",
+    "description",
+    "ownerName",
+    "attestationCounter",
+    "auditInformation",
+    "auditInformation__id",
+  ]),
+  schema: new Set([
+    "id",
+    "name",
+    "description",
+    "context",
+    "schema",
+    "attestationCounter",
+    "auditInformation",
+    "auditInformation__id",
+  ]),
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false;
+  }
+
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
 
 export default abstract class BaseDataMapper<T, TFilter, TOrder> {
   protected readonly conf: Conf;
@@ -61,10 +283,11 @@ export default abstract class BaseDataMapper<T, TFilter, TOrder> {
   }
 
   async findOneById(id: string) {
-    const query = `query get_${this.typeName} { ${this.typeName}(id: "${id}") ${this.gqlInterface} }`;
+    const safeId = this.validateId(id);
+    const query = `query get_${this.typeName}($id: ID!) { ${this.typeName}(id: $id) ${this.gqlInterface} }`;
 
     const subgraphUrl = getConfiguredSubgraphUrl(this.conf);
-    const { data, status } = await subgraphCall(query, subgraphUrl);
+    const { data, status } = await subgraphCall(query, subgraphUrl, { id: safeId });
 
     if (status != 200) {
       throw new Error(`Error(s) while fetching ${this.typeName}`);
@@ -74,21 +297,35 @@ export default abstract class BaseDataMapper<T, TFilter, TOrder> {
   }
 
   async findBy(first?: number, skip?: number, where?: TFilter, orderBy?: TOrder, orderDirection?: OrderDirection) {
+    const variables = {
+      first: this.validatePaginationValue("first", first, 100),
+      skip: this.validatePaginationValue("skip", skip, 0),
+      where: this.validateWhere(where),
+      orderBy: this.validateOrderBy(orderBy),
+      orderDirection: this.validateOrderDirection(orderDirection),
+    };
+    const graphQLTypeName = this.getGraphQLTypeName();
     const query = `
-        query get_${this.typeName}s{
+        query get_${this.typeName}s(
+          $first: Int
+          $skip: Int
+          $where: ${graphQLTypeName}_filter
+          $orderBy: ${graphQLTypeName}_orderBy
+          $orderDirection: OrderDirection
+        ){
           ${this.typeName}s(
-            first: ${first || 100}
-            skip: ${skip || 0}
-            where: ${where ? stringifyWhereClause(where) : null}
-            orderBy: ${orderBy || null}
-            orderDirection: ${orderDirection || null}
+            first: $first
+            skip: $skip
+            where: $where
+            orderBy: $orderBy
+            orderDirection: $orderDirection
           )
           ${this.gqlInterface}
         }
     `;
 
     const subgraphUrl = getConfiguredSubgraphUrl(this.conf);
-    const { data, status } = await subgraphCall(query, subgraphUrl);
+    const { data, status } = await subgraphCall(query, subgraphUrl, variables);
 
     if (status != 200) {
       throw new Error(`Error(s) while fetching ${this.typeName}s`);
@@ -108,5 +345,111 @@ export default abstract class BaseDataMapper<T, TFilter, TOrder> {
     }
 
     return data?.data ? data.data["counters"][0][`${this.typeName}s`] : 0;
+  }
+
+  private getGraphQLTypeName() {
+    return `${this.typeName.charAt(0).toUpperCase()}${this.typeName.slice(1)}`;
+  }
+
+  private getFilterTypeName() {
+    return `${this.typeName.charAt(0).toLowerCase()}${this.typeName.slice(1)}`;
+  }
+
+  private validateId(id: unknown) {
+    if (typeof id !== "string" || id.length === 0 || !GRAPHQL_ID_PATTERN.test(id)) {
+      throw new Error(`Invalid ${this.typeName} id`);
+    }
+
+    return id;
+  }
+
+  private validatePaginationValue(name: string, value: unknown, defaultValue: number) {
+    if (value === undefined) {
+      return defaultValue;
+    }
+
+    if (!Number.isInteger(value) || (value as number) < 0 || (value as number) > MAX_GRAPHQL_INT) {
+      throw new Error(`Invalid pagination value for ${name}`);
+    }
+
+    return value as number;
+  }
+
+  private validateWhere(where: unknown) {
+    if (where === undefined || where === null) {
+      return null;
+    }
+
+    this.validateFilterObject(where, this.getFilterTypeName(), "where");
+    return where as Record<string, unknown>;
+  }
+
+  private validateOrderBy(orderBy: unknown) {
+    if (orderBy === undefined || orderBy === null) {
+      return null;
+    }
+
+    if (typeof orderBy !== "string" || !GRAPHQL_NAME_PATTERN.test(orderBy)) {
+      throw new Error(`Invalid orderBy field for ${this.typeName}s`);
+    }
+
+    const orderFields = ORDER_FIELDS_BY_TYPE[this.getFilterTypeName() as FilterTypeName];
+    if (orderFields && !orderFields.has(orderBy)) {
+      throw new Error(`Invalid orderBy field for ${this.typeName}s`);
+    }
+
+    return orderBy;
+  }
+
+  private validateOrderDirection(orderDirection: unknown) {
+    if (orderDirection === undefined || orderDirection === null) {
+      return null;
+    }
+
+    if (orderDirection !== "asc" && orderDirection !== "desc") {
+      throw new Error(`Invalid orderDirection for ${this.typeName}s`);
+    }
+
+    return orderDirection;
+  }
+
+  private validateFilterObject(filter: unknown, filterTypeName: string, path: string) {
+    if (filter === null || filter === undefined) {
+      return;
+    }
+
+    if (!isRecord(filter)) {
+      throw new Error(`Invalid filter at ${path}`);
+    }
+
+    const filterType = filterTypeName as FilterTypeName;
+    const allowedKeys = FILTER_KEYS_BY_TYPE[filterType];
+    const nestedTypes = NESTED_FILTER_TYPES[filterType] ?? {};
+
+    for (const [key, value] of Object.entries(filter)) {
+      if (!GRAPHQL_NAME_PATTERN.test(key)) {
+        throw new Error(`Invalid filter key "${path}.${key}"`);
+      }
+
+      if (allowedKeys && !allowedKeys.has(key)) {
+        throw new Error(`Invalid filter key "${path}.${key}"`);
+      }
+
+      if (key === "and" || key === "or") {
+        if (!Array.isArray(value)) {
+          throw new Error(`Invalid filter at ${path}.${key}`);
+        }
+
+        value.forEach((nestedFilter, index) => {
+          this.validateFilterObject(nestedFilter, filterTypeName, `${path}.${key}[${index}]`);
+        });
+        continue;
+      }
+
+      const nestedType = nestedTypes[key];
+      if (nestedType) {
+        this.validateFilterObject(value, nestedType, `${path}.${key}`);
+      }
+    }
   }
 }

--- a/sdk/src/dataMapper/ModuleDataMapper.test.ts
+++ b/sdk/src/dataMapper/ModuleDataMapper.test.ts
@@ -49,13 +49,14 @@ describe("ModuleDataMapper", () => {
     const result = await moduleDataMapper.findOneById("1");
 
     expect(subgraphCall).toHaveBeenCalledWith(
-      `query get_module { module(id: "1") {
+      `query get_module($id: ID!) { module(id: $id) {
         id
         moduleAddress
         name
         description
   } }`,
       "http://mock-subgraph.com",
+      { id: "1" },
     );
     expect(result).toEqual(mockData.data.module);
   });
@@ -80,26 +81,13 @@ describe("ModuleDataMapper", () => {
 
     const result = await moduleDataMapper.findBy();
 
-    expect(subgraphCall).toHaveBeenCalledWith(
-      `
-        query get_modules{
-          modules(
-            first: 100
-            skip: 0
-            where: null
-            orderBy: null
-            orderDirection: null
-          )
-          {
-        id
-        moduleAddress
-        name
-        description
-  }
-        }
-    `,
-      mockConf.subgraphUrl,
-    );
+    expect(subgraphCall).toHaveBeenCalledWith(expect.stringContaining("$where: Module_filter"), mockConf.subgraphUrl, {
+      first: 100,
+      skip: 0,
+      where: null,
+      orderBy: null,
+      orderDirection: null,
+    });
     expect(result).toEqual(mockData.data.modules);
   });
 

--- a/sdk/src/dataMapper/PortalDataMapper.test.ts
+++ b/sdk/src/dataMapper/PortalDataMapper.test.ts
@@ -59,7 +59,7 @@ describe("PortalDataMapper", () => {
     const result = await portalDataMapper.findOneById("1");
 
     expect(subgraphCall).toHaveBeenCalledWith(
-      `query get_portal { portal(id: "1") {
+      `query get_portal($id: ID!) { portal(id: $id) {
         id
         ownerAddress
         modules
@@ -70,6 +70,7 @@ describe("PortalDataMapper", () => {
         attestationCounter
   } }`,
       "http://mock-subgraph.com",
+      { id: "1" },
     );
     expect(result).toEqual(mockData.data.portal);
   });
@@ -94,30 +95,13 @@ describe("PortalDataMapper", () => {
 
     const result = await portalDataMapper.findBy();
 
-    expect(subgraphCall).toHaveBeenCalledWith(
-      `
-        query get_portals{
-          portals(
-            first: 100
-            skip: 0
-            where: null
-            orderBy: null
-            orderDirection: null
-          )
-          {
-        id
-        ownerAddress
-        modules
-        isRevocable
-        name
-        description
-        ownerName
-        attestationCounter
-  }
-        }
-    `,
-      mockConf.subgraphUrl,
-    );
+    expect(subgraphCall).toHaveBeenCalledWith(expect.stringContaining("$where: Portal_filter"), mockConf.subgraphUrl, {
+      first: 100,
+      skip: 0,
+      where: null,
+      orderBy: null,
+      orderDirection: null,
+    });
     expect(result).toEqual(mockData.data.portals);
   });
 

--- a/sdk/src/dataMapper/SchemaDataMapper.test.ts
+++ b/sdk/src/dataMapper/SchemaDataMapper.test.ts
@@ -49,7 +49,7 @@ describe("SchemaDataMapper", () => {
     const result = await schemaDataMapper.findOneById("1");
 
     expect(subgraphCall).toHaveBeenCalledWith(
-      `query get_schema { schema(id: "1") {
+      `query get_schema($id: ID!) { schema(id: $id) {
         id
         name
         description
@@ -58,6 +58,7 @@ describe("SchemaDataMapper", () => {
         attestationCounter
   } }`,
       "http://mock-subgraph.com",
+      { id: "1" },
     );
     expect(result).toEqual(mockData.data.schema);
   });
@@ -82,28 +83,13 @@ describe("SchemaDataMapper", () => {
 
     const result = await schemaDataMapper.findBy();
 
-    expect(subgraphCall).toHaveBeenCalledWith(
-      `
-        query get_schemas{
-          schemas(
-            first: 100
-            skip: 0
-            where: null
-            orderBy: null
-            orderDirection: null
-          )
-          {
-        id
-        name
-        description
-        context
-        schema
-        attestationCounter
-  }
-        }
-    `,
-      mockConf.subgraphUrl,
-    );
+    expect(subgraphCall).toHaveBeenCalledWith(expect.stringContaining("$where: Schema_filter"), mockConf.subgraphUrl, {
+      first: 100,
+      skip: 0,
+      where: null,
+      orderBy: null,
+      orderDirection: null,
+    });
     expect(result).toEqual(mockData.data.schemas);
   });
 

--- a/sdk/src/utils/graphClientHelper.test.ts
+++ b/sdk/src/utils/graphClientHelper.test.ts
@@ -7,10 +7,10 @@ describe("graphClientHelper", () => {
   const mockedAxios = axios as jest.Mocked<typeof axios>;
 
   describe("stringifyWhereClause", () => {
-    it("should stringify an object and remove double quotes from keys", () => {
+    it("should stringify an object without changing its keys", () => {
       const input = { key1: "value1", key2: 123, key3: true };
       const result = stringifyWhereClause(input);
-      expect(result).toBe('{key1:"value1",key2:123,key3:true}');
+      expect(result).toBe('{"key1":"value1","key2":123,"key3":true}');
     });
 
     it("should handle an empty object", () => {
@@ -22,13 +22,14 @@ describe("graphClientHelper", () => {
     it("should handle special characters in keys", () => {
       const input = { "key-name": "value" };
       const result = stringifyWhereClause(input);
-      expect(result).toBe('{key-name:"value"}');
+      expect(result).toBe('{"key-name":"value"}');
     });
   });
 
   describe("subgraphCall", () => {
     const mockUrl = "http://mocked-url.com";
     const mockQuery = "{ mockQuery }";
+    const mockVariables = { id: "1" };
 
     afterEach(() => {
       jest.clearAllMocks();
@@ -43,6 +44,26 @@ describe("graphClientHelper", () => {
       expect(mockedAxios.post).toHaveBeenCalledWith(
         mockUrl,
         { query: mockQuery },
+        {
+          headers: {
+            "Content-Type": "application/json",
+            Accept: "application/json",
+          },
+        },
+      );
+
+      expect(result).toBe(mockResponse);
+    });
+
+    it("should include variables when provided", async () => {
+      const mockResponse = { data: { someData: "testData" } };
+      mockedAxios.post.mockResolvedValue(mockResponse);
+
+      const result = await subgraphCall(mockQuery, mockUrl, mockVariables);
+
+      expect(mockedAxios.post).toHaveBeenCalledWith(
+        mockUrl,
+        { query: mockQuery, variables: mockVariables },
         {
           headers: {
             "Content-Type": "application/json",

--- a/sdk/src/utils/graphClientHelper.test.ts
+++ b/sdk/src/utils/graphClientHelper.test.ts
@@ -1,30 +1,10 @@
 import axios from "axios";
-import { stringifyWhereClause, subgraphCall } from "./graphClientHelper";
+import { subgraphCall } from "./graphClientHelper";
 
 jest.mock("axios");
 
 describe("graphClientHelper", () => {
   const mockedAxios = axios as jest.Mocked<typeof axios>;
-
-  describe("stringifyWhereClause", () => {
-    it("should stringify an object without changing its keys", () => {
-      const input = { key1: "value1", key2: 123, key3: true };
-      const result = stringifyWhereClause(input);
-      expect(result).toBe('{"key1":"value1","key2":123,"key3":true}');
-    });
-
-    it("should handle an empty object", () => {
-      const input = {};
-      const result = stringifyWhereClause(input);
-      expect(result).toBe("{}");
-    });
-
-    it("should handle special characters in keys", () => {
-      const input = { "key-name": "value" };
-      const result = stringifyWhereClause(input);
-      expect(result).toBe('{"key-name":"value"}');
-    });
-  });
 
   describe("subgraphCall", () => {
     const mockUrl = "http://mocked-url.com";

--- a/sdk/src/utils/graphClientHelper.ts
+++ b/sdk/src/utils/graphClientHelper.ts
@@ -1,19 +1,16 @@
 import axios from "axios";
 
 export function stringifyWhereClause(whereClauseObj: Record<string, unknown>) {
-  const json = JSON.stringify(whereClauseObj);
-  return json.replace(/"([^"]+)":/g, "$1:");
+  return JSON.stringify(whereClauseObj);
 }
 
-export function subgraphCall(query: string, url: string) {
-  return axios.post(
-    url,
-    { query },
-    {
-      headers: {
-        "Content-Type": "application/json",
-        Accept: "application/json",
-      },
+export function subgraphCall(query: string, url: string, variables?: Record<string, unknown>) {
+  const body = variables === undefined ? { query } : { query, variables };
+
+  return axios.post(url, body, {
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json",
     },
-  );
+  });
 }

--- a/sdk/src/utils/graphClientHelper.ts
+++ b/sdk/src/utils/graphClientHelper.ts
@@ -1,9 +1,5 @@
 import axios from "axios";
 
-export function stringifyWhereClause(whereClauseObj: Record<string, unknown>) {
-  return JSON.stringify(whereClauseObj);
-}
-
 export function subgraphCall(query: string, url: string, variables?: Record<string, unknown>) {
   const body = variables === undefined ? { query } : { query, variables };
 


### PR DESCRIPTION
## Summary

Moves SDK single-chain GraphQL reads to variables and validates query arguments before subgraph calls, preventing runtime input from changing GraphQL query syntax.

## Related issue

Closes #1074

## Type of change

- [ ] Chore
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update

## Affected areas

- [ ] Root / contributor docs
- [ ] Contracts
- [ ] Examples
- [x] SDK
- [ ] Subgraph
- [ ] Explorer
- [ ] Tutorial
- [ ] GitBook source (`doc/`)

## Validation

- [x] I followed the contributor guide in [`CONTRIBUTING.md`](https://github.com/Consensys/linea-attestation-registry/blob/dev/CONTRIBUTING.md)
- [x] I ran the relevant local commands for the areas I changed
- [x] I updated documentation, env/config notes, or public matrices when behavior changed
- [ ] I noted any follow-up deployment or release work if applicable

Commands run:

- `pnpm --dir sdk exec jest src/utils/graphClientHelper.test.ts src/dataMapper/BaseDataMapper.test.ts src/dataMapper/ModuleDataMapper.test.ts src/dataMapper/PortalDataMapper.test.ts src/dataMapper/SchemaDataMapper.test.ts --runInBand`
- `pnpm --dir sdk exec jest --testPathIgnorePatterns=integration --runInBand`
- `pnpm --dir sdk run build`
- `pnpm exec prettier --check ...`
- `git diff --check`

Notes:

- No Solidity files were modified.
- SDK build emitted existing Graph Client duplicate-key warnings during generated artifact bundling.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core SDK subgraph read paths (`findOneById`/`findBy`) and adds strict input validation/allowlists, which could break existing callers that relied on previously accepted (but unsafe) values or unsupported filter/order fields.
> 
> **Overview**
> Single-chain subgraph reads in `BaseDataMapper` now use **GraphQL variables** instead of string interpolation for `id`, pagination, `where`, and ordering, and `subgraphCall` can send an optional `variables` payload.
> 
> Adds **pre-flight validation/allowlists** for `id`, pagination bounds, `orderDirection`, `orderBy`, and filter keys (including nested filters for known entity types), rejecting unsafe/unknown fields before any request is made. Tests for `BaseDataMapper` and the specific mappers are updated/expanded accordingly, and the old `stringifyWhereClause` helper is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 017e57126374614edf14a99d1f703cb22fa10b70. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->