### PR TITLE
fix(sdk): read multichain attestation counts per chain

### DIFF
--- a/sdk/src/dataMapper/AttestationDataMapper.test.ts
+++ b/sdk/src/dataMapper/AttestationDataMapper.test.ts
@@ -2,15 +2,21 @@ import AttestationDataMapper from "./AttestationDataMapper";
 import { Constants, SDKMode } from "../utils/constants";
 import { decodeWithRetry } from "../utils/abiCoder";
 import { getIPFSContent } from "../utils/ipfsClient";
-import { Attestation, Conf } from "../types";
+import { abiAttestationRegistry } from "../abi/AttestationRegistry";
+import { Attestation, ChainName, Conf } from "../types";
 import BaseDataMapper from "./BaseDataMapper";
 import { lineaSepolia } from "viem/chains";
-import { PublicClient, WalletClient } from "viem";
+import { createPublicClient, http, PublicClient, WalletClient } from "viem";
 import { VeraxSdk } from "../VeraxSdk";
 
 jest.mock("./BaseDataMapper");
 jest.mock("../utils/abiCoder");
 jest.mock("../utils/ipfsClient");
+jest.mock("viem", () => ({
+  ...jest.requireActual("viem"),
+  createPublicClient: jest.fn(),
+  http: jest.fn(),
+}));
 
 describe("AttestationDataMapper", () => {
   let attestationDataMapper: AttestationDataMapper;
@@ -72,7 +78,7 @@ describe("AttestationDataMapper", () => {
     ...overrides,
   });
 
-  const mockWeb3Client = {} as PublicClient;
+  const mockWeb3Client = { readContract: jest.fn() } as unknown as PublicClient;
   const mockWalletClient = {} as WalletClient;
   const mockVeraxSdk = {
     schema: {
@@ -126,6 +132,50 @@ describe("AttestationDataMapper", () => {
       expect(BaseDataMapper.prototype.findBy).toHaveBeenCalledWith(10, 0, {}, "attestedDate", "desc");
       expect(decodeWithRetry).toHaveBeenCalledTimes(1);
       expect(result).toEqual(attestations);
+    });
+  });
+
+  describe("getAttestationCountMultiChain", () => {
+    it("should read counts from each requested chain and sum them", async () => {
+      const lineaReadContract = jest.fn().mockResolvedValue(7);
+      const arbitrumReadContract = jest.fn().mockResolvedValue(11n);
+      const lineaTransport = { name: "linea-transport" };
+      const arbitrumTransport = { name: "arbitrum-transport" };
+
+      (http as jest.Mock).mockReturnValueOnce(lineaTransport).mockReturnValueOnce(arbitrumTransport);
+      (createPublicClient as jest.Mock)
+        .mockReturnValueOnce({ readContract: lineaReadContract })
+        .mockReturnValueOnce({ readContract: arbitrumReadContract });
+
+      const result = await attestationDataMapper.getAttestationCountMultiChain([
+        ChainName.LINEA_MAINNET,
+        ChainName.ARBITRUM_MAINNET,
+      ]);
+
+      expect(result).toBe(18);
+      expect(mockWeb3Client.readContract).not.toHaveBeenCalled();
+      expect(http).toHaveBeenNthCalledWith(1, VeraxSdk.DEFAULT_LINEA_MAINNET.rpcUrl);
+      expect(http).toHaveBeenNthCalledWith(2, VeraxSdk.DEFAULT_ARBITRUM.rpcUrl);
+      expect(createPublicClient).toHaveBeenNthCalledWith(1, {
+        chain: VeraxSdk.DEFAULT_LINEA_MAINNET.chain,
+        transport: lineaTransport,
+      });
+      expect(createPublicClient).toHaveBeenNthCalledWith(2, {
+        chain: VeraxSdk.DEFAULT_ARBITRUM.chain,
+        transport: arbitrumTransport,
+      });
+      expect(lineaReadContract).toHaveBeenCalledWith({
+        abi: abiAttestationRegistry,
+        address: VeraxSdk.DEFAULT_LINEA_MAINNET.attestationRegistryAddress,
+        functionName: "getAttestationIdCounter",
+        args: [],
+      });
+      expect(arbitrumReadContract).toHaveBeenCalledWith({
+        abi: abiAttestationRegistry,
+        address: VeraxSdk.DEFAULT_ARBITRUM.attestationRegistryAddress,
+        functionName: "getAttestationIdCounter",
+        args: [],
+      });
     });
   });
 

--- a/sdk/src/dataMapper/AttestationDataMapper.ts
+++ b/sdk/src/dataMapper/AttestationDataMapper.ts
@@ -9,7 +9,7 @@ import {
   OrderDirection,
 } from "../../.graphclient";
 import { handleError } from "../utils/errorHandler";
-import { Address, Hex, WriteContractParameters } from "viem";
+import { Address, createPublicClient, Hex, http, PublicClient, WriteContractParameters } from "viem";
 import { decodeWithRetry, encode } from "../utils/abiCoder";
 import { executeTransaction } from "../utils/transactionSender";
 import { getIPFSContent } from "../utils/ipfsClient";
@@ -29,6 +29,8 @@ export default class AttestationDataMapper extends BaseDataMapper<
   Attestation_filter,
   Attestation_orderBy
 > {
+  private readonly chainReadClients = new Map<ChainName, PublicClient>();
+
   typeName = "attestation";
   gqlInterface = `{
             id
@@ -120,7 +122,7 @@ export default class AttestationDataMapper extends BaseDataMapper<
     const countPromises = chainNames.map(async (chainName) => {
       try {
         const count = await this.executeReadMethodForChain(chainName, "getAttestationIdCounter", []);
-        return typeof count === "number" ? count : 0;
+        return this.toAttestationCount(count);
       } catch (_error) {
         return 0;
       }
@@ -346,23 +348,47 @@ export default class AttestationDataMapper extends BaseDataMapper<
   }
 
   private async executeReadMethodForChain(chainName: ChainName, functionName: string, args: unknown[]) {
-    const registryAddresses = {
-      [ChainName.LINEA_MAINNET]: VeraxSdk.DEFAULT_LINEA_MAINNET.attestationRegistryAddress,
-      [ChainName.LINEA_SEPOLIA]: VeraxSdk.DEFAULT_LINEA_SEPOLIA.attestationRegistryAddress,
-      [ChainName.ARBITRUM_MAINNET]: VeraxSdk.DEFAULT_ARBITRUM.attestationRegistryAddress,
-      [ChainName.ARBITRUM_SEPOLIA]: VeraxSdk.DEFAULT_ARBITRUM_SEPOLIA.attestationRegistryAddress,
-      [ChainName.BASE_MAINNET]: VeraxSdk.DEFAULT_BASE.attestationRegistryAddress,
-      [ChainName.BASE_SEPOLIA]: VeraxSdk.DEFAULT_BASE_SEPOLIA.attestationRegistryAddress,
-      [ChainName.BSC_MAINNET]: VeraxSdk.DEFAULT_BSC.attestationRegistryAddress,
-      [ChainName.BSC_TESTNET]: VeraxSdk.DEFAULT_BSC_TESTNET.attestationRegistryAddress,
-    };
-
-    const contractAddress = registryAddresses[chainName] as Address;
-    if (!contractAddress) {
+    const chainConf = this.getConfForChain(chainName);
+    if (!chainConf?.attestationRegistryAddress) {
       throw new Error(`No contract address found for chain ${chainName}`);
     }
 
-    return this.executeReadMethod(functionName, args);
+    let chainReadClient = this.chainReadClients.get(chainName);
+    if (!chainReadClient) {
+      chainReadClient = createPublicClient({
+        chain: chainConf.chain,
+        transport: http(chainConf.rpcUrl),
+      });
+      this.chainReadClients.set(chainName, chainReadClient);
+    }
+
+    return chainReadClient.readContract({
+      abi: abiAttestationRegistry,
+      address: chainConf.attestationRegistryAddress,
+      functionName,
+      args,
+    });
+  }
+
+  private toAttestationCount(count: unknown) {
+    if (typeof count === "number") return count;
+    if (typeof count === "bigint") return Number(count);
+    return 0;
+  }
+
+  private getConfForChain(chainName: ChainName) {
+    const confByChainName = {
+      [ChainName.LINEA_MAINNET]: VeraxSdk.DEFAULT_LINEA_MAINNET,
+      [ChainName.LINEA_SEPOLIA]: VeraxSdk.DEFAULT_LINEA_SEPOLIA,
+      [ChainName.ARBITRUM_MAINNET]: VeraxSdk.DEFAULT_ARBITRUM,
+      [ChainName.ARBITRUM_SEPOLIA]: VeraxSdk.DEFAULT_ARBITRUM_SEPOLIA,
+      [ChainName.BASE_MAINNET]: VeraxSdk.DEFAULT_BASE,
+      [ChainName.BASE_SEPOLIA]: VeraxSdk.DEFAULT_BASE_SEPOLIA,
+      [ChainName.BSC_MAINNET]: VeraxSdk.DEFAULT_BSC,
+      [ChainName.BSC_TESTNET]: VeraxSdk.DEFAULT_BSC_TESTNET,
+    };
+
+    return confByChainName[chainName];
   }
 
   private async simulateContract(functionName: string, args: unknown[]): Promise<WriteContractParameters> {


### PR DESCRIPTION
## Summary

Fix `getAttestationCountMultiChain` so it reads each requested chain with that chain's `PublicClient` and attestation registry address, instead of reusing the SDK's configured chain. Add regression coverage for summing distinct chain counts.

## Related issue

Closes #1081

## Type of change

- [ ] Chore
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update

## Affected areas

- [ ] Root / contributor docs
- [ ] Contracts
- [ ] Examples
- [x] SDK
- [ ] Subgraph
- [ ] Explorer
- [ ] Tutorial
- [ ] GitBook source (`doc/`)

## Validation

- [x] I followed the contributor guide in
      [`CONTRIBUTING.md`](https://github.com/Consensys/linea-attestation-registry/blob/dev/CONTRIBUTING.md)
- [x] I ran the relevant local commands for the areas I changed
- [ ] I updated documentation, env/config notes, or public matrices when behavior changed
- [x] I noted any follow-up deployment or release work if applicable

No documentation, deployment, or release follow-up is required for this SDK bug fix.

Local commands run:

- `pnpm --dir sdk test -- AttestationDataMapper.test.ts --runInBand`
- `pnpm --dir sdk exec jest --testPathIgnorePatterns=integration --runInBand`
- `pnpm --dir sdk exec tsc --noEmit -p tsconfig.json`
- `pnpm exec prettier --check sdk/src/dataMapper/AttestationDataMapper.ts sdk/src/dataMapper/AttestationDataMapper.test.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped SDK read-path bug fix with unit tests; no auth, writes, or contract changes.
> 
> **Overview**
> Fixes **`getAttestationCountMultiChain`** so each requested chain is queried with that chain’s **RPC**, **viem `PublicClient`**, and **attestation registry address** (from `VeraxSdk` defaults), instead of reusing the SDK’s configured `web3Client` for every chain.
> 
> Per-chain clients are **cached** in `chainReadClients`, and counter values are normalized via **`toAttestationCount`** (including **`bigint`**). Adds a unit test that mocks per-chain `readContract` calls and asserts the **sum** and that the default client is **not** used.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d079f24277ebca9cf65781cb176a651c4579952. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->