### PR TITLE
Danialzivehdadr patch 3

### DIFF
--- a/+get_file_1
+++ b/+get_file_1
@@ -1,0 +1,38 @@
+# ファイルを取得
++get_file_1:
+  action>: GetFile
+  display_name>: 'ファイルを取得'
+  provider: local
+  filename: rc_36b0011677688bf489d7
+  private: false
+  meta:
+    display:
+      filename:
+        label: 'sample-card.png'
+        icon: text
+        type: chip
+    action:
+      disabled: false
+# Document Forceでドキュメントを解析
++d_f_analyze_document_1:
+  action>: DFAnalyzeDocument
+  display_name>: 'Document Forceでドキュメントを解析'
+  provider_id: documentforce_03f3151d6f9accddcffa
+  endpoint: 'https://app.aipuncher.com/api/v2/analyse/****************'
+  file: +get_file_1
+  tags:
+    AUTORO DevOps:
+      - '開発テストタグ'
+  wait_for_result: false
+  private: false
+  meta:
+    display:
+      provider_id:
+        type: chip
+        label: 'Documentforce (AUTORO連携用)'
+        icon: documentforce
+    action:
+      disabled: false
+# {
+#   "document_id": 1027
+# }

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -1,0 +1,42 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+# This workflow will install Deno then run `deno lint` and `deno test`.
+# For more information see: https://github.com/denoland/setup-deno
+
+name: Deno
+
+on:
+  push:
+    branches: ["dev"]
+  pull_request:
+    branches: ["dev"]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Setup repo
+        uses: actions/checkout@v4
+
+      - name: Setup Deno
+        # uses: denoland/setup-deno@v1
+        uses: denoland/setup-deno@61fe2df320078202e33d7d5ad347e7dcfa0e8f31  # v1.1.2
+        with:
+          deno-version: v1.x
+
+      # Uncomment this step to verify the use of 'deno fmt' on each commit.
+      # - name: Verify formatting
+      #   run: deno fmt --check
+
+      - name: Run linter
+        run: deno lint
+
+      - name: Run tests
+        run: deno test -A


### PR DESCRIPTION
## Summary

Describe the change and why it is needed.

## Related issue

Closes #

## Type of change

- [ ] Chore
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update

## Affected areas

- [ ] Root / contributor docs
- [ ] Contracts
- [ ] Examples
- [ ] SDK
- [ ] Subgraph
- [ ] Explorer
- [ ] Tutorial
- [√] GitBook source (`doc/`)

## Validation

- [ ] I followed the contributor guide in
      [`CONTRIBUTING.md`](https://github.com/Consensys/linea-attestation-registry/blob/dev/CONTRIBUTING.md)
- [ ] I ran the relevant local commands for the areas I changed
- [ ] I updated documentation, env/config notes, or public matrices when behavior changed
- [ ] I noted any follow-up deployment or release work if applicable

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The AUTORO snippet exposes integration metadata and may be an accidental commit; the Deno job may fail or add noise if the repo has no Deno config.
> 
> **Overview**
> Adds a new **Deno** GitHub Actions workflow on `dev` that checks out the repo, pins `denoland/setup-deno`, and runs **`deno lint`** and **`deno test -A`** on push and pull requests.
> 
> Also introduces a new root file **`+get_file_1`** with an AUTORO-style recipe: **GetFile** for `sample-card.png`, then **DFAnalyzeDocument** against a Document Force provider and analyse API endpoint, with dev/test tags and a sample `document_id` comment.
> 
> These two additions look unrelated to each other and to the attestation-registry stack; the AUTORO YAML in particular reads like workflow export material committed to the wrong path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5da3fbec717a97b039da6c24545bb21e5e0b926d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->