### PR TITLE
ci(global): update dependency-maintenance skill and refresh GitHub Actions

### DIFF
--- a/.agents/skills/linea-dependency-maintenance/SKILL.md
+++ b/.agents/skills/linea-dependency-maintenance/SKILL.md
@@ -1,12 +1,13 @@
 ---
 name: linea-dependency-maintenance
 description:
-  Safely plan and execute JavaScript/TypeScript dependency maintenance across npm and pnpm repositories, including npm
-  lockfiles, pnpm workspaces, catalogs, overrides, release-age policies, audits, CI validation, Dependabot boundaries,
-  PRs, and GitHub tracking issues. Use whenever the user asks to update, bump, refresh, audit, clean, modernize, or
-  review dependencies, reduce vulnerabilities, clean overrides, or prepare dependency PRs/issues.
+  Safely plan and execute dependency maintenance for JavaScript/TypeScript (npm, pnpm) and GitHub Actions, including npm
+  lockfiles, pnpm workspaces, catalogs, overrides, SHA-pinned action versions, release-age policies, audits, CI
+  validation, Dependabot boundaries, PRs, and GitHub tracking issues. Use whenever the user asks to update, bump,
+  refresh, audit, clean, modernize, or review dependencies or GitHub Actions, reduce vulnerabilities, clean overrides, or
+  prepare dependency PRs/issues.
 metadata:
-  short-description: Safe npm/pnpm dependency maintenance
+  short-description: Safe npm/pnpm and GitHub Actions dependency maintenance
 ---
 
 # Dependency Maintenance
@@ -27,7 +28,8 @@ hiding remaining risk.
    - Do not introduce a different lockfile, workspace file, package-manager metadata, or install command.
 3. Check branch and worktree state with `git status --short --branch`. If unrelated changes are present, use an isolated
    worktree or avoid touching those files.
-4. Read `.nvmrc`, `.node-version`, `engines`, `.npmrc`, CI workflows, deploy config, and `dependabot.yml`.
+4. Read `.nvmrc`, `.node-version`, `engines`, `.npmrc`, deploy config, `dependabot.yml`, and the GitHub Actions pins in
+   `.github/workflows/*.yml` and `.github/actions/**/action.yml`.
 5. Capture the baseline: outdated report, audit report, lockfile state, and relevant validation commands.
 
 ## Policy
@@ -37,8 +39,16 @@ hiding remaining risk.
   list as read-only: respect the existing entries, but never add or widen it to push a fresher version through — the
   maturity window is a hard gate, not a hurdle to bypass.
 - Treat npm/pnpm dependency updates as owned by this skill. Do not re-enable Dependabot npm/pnpm package-ecosystem jobs
-  unless the user explicitly asks; GitHub Actions, Docker, and other non-JavaScript ecosystems may remain under
-  Dependabot.
+  unless the user explicitly asks.
+- GitHub Actions are in scope for manual/agent sweeps and for policy enforcement, but Dependabot keeps opening the
+  routine `github-actions` PRs: its cooldown in `dependabot.yml` (7 days) matches the action maturity window, so leave
+  that job enabled and let the two coexist. Docker and other non-JavaScript ecosystems also stay under Dependabot.
+- Pin GitHub Actions to a full 40-character commit SHA, never a tag or branch ref (`@v4`, `@main`). A movable ref lets
+  the upstream repo change what runs in CI without review. Append the human-readable version as an end-of-line comment
+  (`uses: actions/checkout@<sha> # v7.0.0`) and update that comment on every bump so the SHA stays auditable.
+- Gate GitHub Actions on release age: only adopt a SHA whose release (tag) is older than 7 days. Actions use a longer
+  7-day window than the JS/npm/pnpm gate because an action runs with repository scope in CI, so a fresh release is
+  higher-risk supply-chain surface. Treat the window as a hard gate, not a suggestion.
 - Pin exact versions (mandatory). Every npm/pnpm `dependencies`/`devDependencies` specifier must be an exact pin, never
   a `^` caret or `~` tilde range. Floating ranges silently pull unreviewed releases and widen the supply-chain attack
   surface, so a single exact version is the only safe and reproducible default. When a bump touches a manifest, also
@@ -149,6 +159,43 @@ See `references/pnpm.md` and `references/npm.md` for the per-manager commands (o
 overrides automatically; npm never writes `overrides`, so its flow relies on `npm audit fix` without `--force` plus
 manual targeted overrides).
 
+## GitHub Actions
+
+Workflow and composite-action files (`.github/workflows/*.yml`, `.github/actions/**/action.yml`) reference third-party
+actions. Maintain them on the same lifecycle as packages: inventory, triage by release age, bump, validate.
+
+Inventory the pins with a reproducible first pass:
+
+```bash
+node <skill-dir>/scripts/eligible-actions --days 7
+```
+
+The helper scans every external `uses:` pin and, for each action, reports the newest same-major release older than the
+cutoff plus its exact commit SHA. It needs an authenticated `gh` CLI. The action gate is 7 days; adjust
+`--days`/`--minutes` only if repo policy differs. When the same action is pinned to different SHAs across files, the
+report sets `conflictingPins` and lists each variant — reconcile those before bumping.
+
+Triage each pin:
+
+- Safe now: a newer same-major tag whose release is older than the cutoff. Bump both the SHA and the version comment.
+- Blocked (too fresh): the only newer tag is still inside the maturity window. Keep the current pin, note it, and
+  re-check after the release matures. Never bump to a release younger than the cutoff.
+- Pin drift: `conflictingPins` is true (different SHAs for the same action path). Align every workflow file to one SHA
+  and comment before applying any bump suggestion.
+- Comment drift: `commentDrift` is true (same SHA but different version comments). Align comments before bumping.
+- Major migration: a semver-major bump (for example a runner or Node baseline change). Track it in an issue instead of
+  bumping now, unless the user approves the major.
+
+Apply a bump by replacing the SHA and the trailing comment together, so they never drift:
+
+```
+- uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
++ uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+```
+
+Local actions (`uses: ./.github/actions/...`) are first-party and need no pin. See `references/github-actions.md` for the
+exact `gh` commands to resolve a tag to its commit SHA and confirm its release age.
+
 ## Validation
 
 Run the narrowest meaningful checks first, then broaden by blast radius:
@@ -158,6 +205,8 @@ Run the narrowest meaningful checks first, then broaden by blast radius:
 - lint, typecheck, build, and tests
 - repo-specific checks such as Docusaurus prebuild/build, Turbo filters, Prisma generate, Playwright/Storybook browsers,
   Docker builds, Foundry/forge, subgraph codegen/tests, or generated-doc checks
+- for GitHub Actions changes: confirm every external `uses:` is a 40-character commit SHA with a matching version
+  comment, and that each bumped release cleared the age gate
 
 If a command cannot run, report why. If CI fails, inspect the actual logs and classify the failure as introduced by the
 update, exposed baseline debt, or external/non-actionable.
@@ -167,9 +216,13 @@ update, exposed baseline debt, or external/non-actionable.
 Open the PR only after local validation is green. Opening a PR is an outward-facing action, so commit the work on a
 dedicated branch, then pause and confirm with the user before pushing and creating the PR.
 
-- Branch from the repo's base branch, stage the manifest and lockfile changes together, and commit with the repository's
-  Conventional Commit format. Do not assume a universal type or scope; use the repo-approved prefix and set the
-  description to `refresh dependencies`.
+- Branch from the repo's base branch and commit with the repository's Conventional Commit format. Match the update set:
+  - npm/pnpm only: stage manifest and lockfile changes together. Use the repo-approved scope (for example
+    `deps(global): refresh dependencies`).
+  - GitHub Actions only: stage `.github/workflows/*.yml` and `.github/actions/**/action.yml` changes together. Use
+    `deps(actions): refresh GitHub Actions` to align with Dependabot's `github-actions` commit prefix.
+  - Mixed JS and Actions updates: prefer separate commits per ecosystem, or one commit whose message names both scopes
+    explicitly.
 - Open a PR.
 
 Open English follow-up issues for deferred major upgrades or blocked migration streams. Each issue should include
@@ -185,4 +238,6 @@ trees, or CI failures that suggest a cross-cutting regression.
 
 - For npm/package-lock repositories, read `references/npm.md`.
 - For pnpm workspace/catalog/override repositories, read `references/pnpm.md`.
-- For reproducible release-age inventory, run `scripts/eligible-updates`.
+- For GitHub Actions SHA pinning and release-age checks, read `references/github-actions.md`.
+- For reproducible release-age inventory, run `scripts/eligible-updates` (npm/pnpm) or `scripts/eligible-actions`
+  (GitHub Actions).

--- a/.agents/skills/linea-dependency-maintenance/agents/openai.yaml
+++ b/.agents/skills/linea-dependency-maintenance/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
-  display_name: "Dependency Maintenance"
-  short_description: "Safe npm/pnpm upgrades, audits, PRs"
-  default_prompt: "Use this skill to refresh eligible dependencies safely, respect repo package-manager policy, document blocked work, and prepare a validated dependency PR."
+  display_name: 'Dependency Maintenance'
+  short_description: 'Safe npm/pnpm and GitHub Actions upgrades, audits, PRs'
+  default_prompt: 'Use this skill to refresh eligible dependencies and GitHub Actions safely, respect repo package-manager and SHA-pinning policy, document blocked work, and prepare a validated dependency PR.'

--- a/.agents/skills/linea-dependency-maintenance/evals/evals.json
+++ b/.agents/skills/linea-dependency-maintenance/evals/evals.json
@@ -30,6 +30,12 @@
       "prompt": "A dependency PR adds new packages and edits package.json with caret (^) and tilde (~) ranges. Bring it in line with the dependency-maintenance policy before it merges.",
       "expected_output": "Treats every ^/~ range in dependencies/devDependencies as a policy violation and rewrites it to an exact pin, keeps catalog:/workspace: references intact and pins the concrete version at the catalog definition, leaves intentional peerDependencies ranges and engines (>=) constraints untouched, and regenerates the lockfile.",
       "files": []
+    },
+    {
+      "id": 6,
+      "prompt": "Refresh the GitHub Actions used in .github/workflows and .github/actions. Some actions have newer releases, some released in the last few days, and some have a new semver-major.",
+      "expected_output": "Inventories every external uses: pin, bumps only releases older than the 7-day action maturity window (longer than the JS gate), updates both the commit SHA and its version comment together, pins to a full 40-character SHA (never a tag/branch ref), holds releases younger than the cutoff, tracks or applies semver-major action bumps per the user's instruction, leaves local (./) actions unpinned, and leaves Dependabot's github-actions job enabled.",
+      "files": []
     }
   ]
 }

--- a/.agents/skills/linea-dependency-maintenance/references/github-actions.md
+++ b/.agents/skills/linea-dependency-maintenance/references/github-actions.md
@@ -1,0 +1,85 @@
+# GitHub Actions Dependency Maintenance
+
+<!-- markdownlint-disable -->
+<!-- vale off -->
+
+Use these notes for the GitHub Actions referenced by `.github/workflows/*.yml` and `.github/actions/**/action.yml`.
+
+## Rules
+
+- Pin every external action to a full 40-character commit SHA, never a tag or branch ref (`@v4`, `@main`). A tag is
+  movable: the upstream repo can repoint it at new code that then runs in CI without review.
+- Keep the human-readable version as an end-of-line comment (`uses: actions/checkout@<sha> # v6.0.3`) and update it in
+  the same edit as the SHA, so the pin stays auditable and the two never drift.
+- Release-age gate (mandatory): only adopt a SHA whose release (tag) is older than 7 days. Actions use a longer window
+  than the 3-day JS/npm/pnpm gate because an action runs with repository scope in CI, so a fresh release is higher-risk
+  supply-chain surface. This is a hard gate — hold the bump until the release matures.
+- Default scope is same-major (patch/minor) bumps. Track semver-major action bumps as issues; they can change runner or
+  Node baselines and need deliberate migration.
+- Local actions (`uses: ./.github/actions/...`) are first-party and are not pinned.
+- Dependabot keeps opening the routine `github-actions` PRs. Do not disable that job; its cooldown in `dependabot.yml`
+  (7 days) matches this maturity window. This skill covers manual/agent sweeps and enforcing the rules above on every PR.
+
+## Baseline
+
+```bash
+gh --version            # the checks below need an authenticated gh CLI
+# list every external action pin and its current version comment
+grep -rnE 'uses:\s+[^./]' .github/workflows .github/actions
+```
+
+## Update Flow
+
+1. Inventory the pins with a reproducible first pass:
+   ```bash
+   node <skill-dir>/scripts/eligible-actions --days 7
+   ```
+2. For a candidate `owner/repo`, list same-major releases and their publish dates:
+   ```bash
+   gh api "repos/<owner>/<repo>/releases?per_page=100" --jq '.[] | "\(.tag_name)\t\(.published_at)"'
+   ```
+3. Pick the newest same-major tag whose `published_at` is older than the cutoff. Resolve it to a commit SHA:
+   ```bash
+   gh api "repos/<owner>/<repo>/commits/<tag>" --jq '.sha'
+   ```
+   For an action that publishes tags without releases, fall back to the tag commit date:
+   ```bash
+   gh api "repos/<owner>/<repo>/commits/<tag>" --jq '.commit.committer.date'
+   ```
+4. Replace the SHA and the version comment together, on the same line, everywhere the action is used:
+   ```
+   - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+   + uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+   ```
+
+## Validation
+
+- Confirm no mutable refs remain — every external `uses:` must be a 40-character SHA with a standard version comment
+  (` # vX.Y.Z` or ` # X.Y.Z`, space before `#`):
+  ```bash
+  grep -rnE 'uses:\s+[^./][^@]+@[^ ]+' .github/workflows .github/actions \
+    | grep -vE '@[0-9a-f]{40} +# v?[0-9]+\\.[0-9]+\\.[0-9]+'
+  ```
+  The command should print nothing. Any line it prints is an unpinned action, a tag/branch ref, or a non-standard
+  version comment (for example `#v7.2.0` without a leading space).
+- Re-run `scripts/eligible-actions` and confirm each bumped action now shows no eligible update, and that anything left
+  behind is either too fresh (blocked by the age gate) or a tracked major.
+
+## Inventory Script Limits
+
+`scripts/eligible-actions` scans each YAML line for `uses: owner/repo@ref` without surrounding quotes. It does not match
+refs wrapped in single or double quotes (for example `uses: 'actions/checkout@<sha>'`). This repo uses unquoted refs;
+if a workflow adopts quoted `uses:` lines, inventory that pin manually or extend the script before relying on the output.
+
+Inventory groups external actions by action path (the `uses` value before `@`), not just `owner/repo`. GitHub API
+lookups always use the first two path segments (`owner/repo`). When the same action appears on multiple lines, the
+script compares SHAs across files. If more than one SHA is pinned, the row
+includes `conflictingPins: true` and a `pinVariants` list — reconcile those pins before acting on bump suggestions for
+that action. When the same SHA carries different version comments, the row includes `commentDrift: true`.
+
+Release discovery merges GitHub releases with tag-only semver tags so newer tag-only versions are not missed when older
+formal releases still exist.
+
+Eligible bump suggestions include a commit SHA only when `gh api repos/<owner>/<repo>/commits/<tag>` resolves one. If
+SHA lookup fails for the newest mature same-major candidate, the script reports no eligible bump instead of falling back
+to an older tag.

--- a/.agents/skills/linea-dependency-maintenance/scripts/eligible-actions
+++ b/.agents/skills/linea-dependency-maintenance/scripts/eligible-actions
@@ -1,0 +1,485 @@
+#!/usr/bin/env node
+
+// Report GitHub Actions pins that have a newer same-major release older than a maturity window.
+// Requires an authenticated `gh` CLI (used for the GitHub API so auth and rate limits are handled).
+
+const { execFileSync } = require("node:child_process");
+const { readdirSync, readFileSync, statSync, existsSync } = require("node:fs");
+const { join, extname } = require("node:path");
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const MINUTE_MS = 60 * 1000;
+const SHA_RE = /^[0-9a-f]{40}$/;
+const USES_RE = /uses:\s*([^\s'"#]+)(?:\s*#\s*(\S+))?/;
+
+function parseArgs(argv) {
+  // Actions use a 7-day maturity window (longer than the 3-day JS/npm/pnpm gate).
+  const args = { days: 7, minutes: null, dir: ".github" };
+  for (let index = 2; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const next = argv[index + 1];
+    if (arg === "--days" && next) {
+      args.days = Number(next);
+      index += 1;
+    } else if (arg === "--minutes" && next) {
+      args.minutes = Number(next);
+      index += 1;
+    } else if (arg === "--dir" && next) {
+      args.dir = next;
+      index += 1;
+    } else if (arg === "--help") {
+      console.error("Usage: eligible-actions [--days N | --minutes N] [--dir .github]");
+      process.exit(0);
+    }
+  }
+  return args;
+}
+
+function walk(dir) {
+  const files = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      files.push(...walk(full));
+    } else if ([".yml", ".yaml"].includes(extname(full))) {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+// Collect every `uses:` pin, keyed by action path (uses value before @). Multiple files may reference the same action; flag SHA drift.
+function collectPins(dir) {
+  const occurrences = new Map();
+  for (const file of walk(dir)) {
+    for (const line of readFileSync(file, "utf8").split("\n")) {
+      const match = line.match(USES_RE);
+      if (!match) continue;
+      const ref = match[1];
+      const comment = String(match[2] ?? "").trim();
+      if (ref.startsWith("./") || ref.startsWith(".\\")) continue; // local action, not pinned
+      const [owner, repoName, at] = splitRef(ref);
+      if (!owner || !repoName) continue;
+      const key = actionPathFromRef(ref);
+      const sha = SHA_RE.test(at) ? at : "";
+      const list = occurrences.get(key) ?? [];
+      list.push({ file, sha, ref: at, comment });
+      occurrences.set(key, list);
+    }
+  }
+  return [...occurrences.entries()].map(([key, hits]) => finalizePin(key, hits));
+}
+
+function pickComment(comments) {
+  const unique = [...new Set(comments.filter(Boolean))].sort();
+  return unique[0] ?? "";
+}
+
+function hasCommentDrift(comments) {
+  const standard = [...new Set(comments.filter(isStandardVersion))];
+  if (standard.length <= 1) return false;
+  return new Set(standard.map((comment) => parseVersion(comment)?.raw)).size > 1;
+}
+
+function finalizePin(repo, hits) {
+  const files = [...new Set(hits.map((hit) => hit.file))].sort();
+  const hasMutableRef = hits.some((hit) => hit.sha === "" && hit.ref !== "");
+  const inventoryComment = pickComment(hits.map((hit) => hit.comment));
+  const bySha = new Map();
+  for (const hit of hits.filter((item) => item.sha !== "")) {
+    const bucket = bySha.get(hit.sha) ?? {
+      sha: hit.sha,
+      comments: new Set(),
+      files: new Set(),
+    };
+    if (hit.comment) bucket.comments.add(hit.comment);
+    bucket.files.add(hit.file);
+    bySha.set(hit.sha, bucket);
+  }
+
+  const pinVariants = [...bySha.values()]
+    .map((variant) => ({
+      sha: variant.sha,
+      comment: pickComment([...variant.comments]),
+      files: [...variant.files].sort(),
+    }))
+    .sort((a, b) => a.sha.localeCompare(b.sha));
+
+  const conflictingPins = pinVariants.length > 1;
+  const pinned = !hasMutableRef && pinVariants.length > 0;
+  const primary = pinVariants[0];
+  const primaryComments = primary ? [...bySha.get(primary.sha).comments] : [];
+  const canonicalComment = primary ? pickComment(primaryComments) : inventoryComment;
+  const commentDrift =
+    !conflictingPins && pinVariants.length === 1 && hasCommentDrift(primaryComments);
+
+  return {
+    repo,
+    pinned,
+    sha: !conflictingPins && primary ? primary.sha : "",
+    ref: hits.find((hit) => hit.sha === "")?.ref ?? primary?.sha ?? "",
+    comment: pinned && !conflictingPins ? canonicalComment : inventoryComment,
+    conflictingPins,
+    commentDrift,
+    pinVariants: conflictingPins ? pinVariants : [],
+    files,
+  };
+}
+
+function splitRef(ref) {
+  const [path, at] = ref.split("@");
+  const [owner, repo] = path.split("/");
+  return [owner, repo, at ?? ""];
+}
+
+// Inventory keys use the full `uses` path before `@`; GitHub API calls always use owner/repo only.
+function actionPathFromRef(ref) {
+  return ref.split("@")[0];
+}
+
+function apiRepo(actionPath) {
+  const parts = actionPath.split("/");
+  if (parts.length < 2 || !parts[0] || !parts[1]) return "";
+  return `${parts[0]}/${parts[1]}`;
+}
+
+function parseVersion(value) {
+  const match = String(value ?? "").match(/(\d+)\.(\d+)\.(\d+)/);
+  if (!match) return null;
+  return {
+    raw: `${match[1]}.${match[2]}.${match[3]}`,
+    major: +match[1],
+    minor: +match[2],
+    patch: +match[3],
+  };
+}
+
+// A comment we can compare against release tags: exactly `vX.Y.Z` or `X.Y.Z`. Anything else (e.g. `post-v2.0.6`,
+// an untagged commit) cannot be ranked reliably, so we flag it for manual review instead of suggesting a bump.
+function isStandardVersion(comment) {
+  return /^v?\d+\.\d+\.\d+$/.test(String(comment ?? "").trim());
+}
+
+function compareVersions(a, b) {
+  const pa = parseVersion(a);
+  const pb = parseVersion(b);
+  if (!pa || !pb) return 0;
+  return pa.major - pb.major || pa.minor - pb.minor || pa.patch - pb.patch;
+}
+
+function classify(current, target) {
+  const c = parseVersion(current);
+  const t = parseVersion(target);
+  if (!c || !t) return "unknown";
+  if (t.major !== c.major) return "major";
+  if (t.minor !== c.minor) return "minor";
+  if (t.patch !== c.patch) return "patch";
+  return "same";
+}
+
+function gh(path) {
+  const raw = execFileSync("gh", ["api", path], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  return JSON.parse(raw);
+}
+
+function ghList(path, maxPages = 10) {
+  const items = [];
+  for (let page = 1; page <= maxPages; page += 1) {
+    try {
+      const batch = gh(`${path}?per_page=100&page=${page}`);
+      if (!Array.isArray(batch) || batch.length === 0) break;
+      items.push(...batch);
+      if (batch.length < 100) break;
+    } catch {
+      break;
+    }
+  }
+  return items;
+}
+
+function releaseCandidates(repo) {
+  let releases = [];
+  try {
+    releases = ghList(`repos/${repo}/releases`);
+  } catch {
+    releases = [];
+  }
+
+  const fromReleases = releases
+    .filter(
+      (release) =>
+        !release.draft && !release.prerelease && isStandardVersion(release.tag_name),
+    )
+    .map((release) => ({
+      tag: release.tag_name,
+      published: release.published_at,
+    }));
+
+  let tags = [];
+  try {
+    tags = ghList(`repos/${repo}/tags`);
+  } catch {
+    tags = [];
+  }
+  const fromTags = tags
+    .filter((tag) => isStandardVersion(tag.name))
+    .map((tag) => ({ tag: tag.name, published: null }));
+
+  const byTag = new Map();
+  for (const candidate of fromReleases) byTag.set(candidate.tag, candidate);
+  for (const candidate of fromTags) {
+    if (!byTag.has(candidate.tag)) byTag.set(candidate.tag, candidate);
+  }
+  return [...byTag.values()];
+}
+
+function sameMajorNewer(candidates, current) {
+  const currentMajor = parseVersion(current)?.major;
+  return candidates
+    .filter((item) => parseVersion(item.tag).major === currentMajor)
+    .filter((item) => compareVersions(item.tag, current) > 0)
+    .sort((a, b) => compareVersions(a.tag, b.tag))
+    .reverse();
+}
+
+// Newest same-major release strictly newer than `current` whose publish date is at/older than the cutoff.
+function selectEligible(repo, current, cutoff) {
+  const sameMajor = sameMajorNewer(releaseCandidates(repo), current);
+
+  for (const item of sameMajor) {
+    const published = item.published ?? commitDate(repo, item.tag);
+    if (!published || new Date(published) > cutoff) continue;
+    const sha = commitSha(repo, item.tag);
+    if (!sha) return null;
+    return { tag: item.tag, published, sha };
+  }
+  return null;
+}
+
+function selectBlockedTooFresh(repo, current, cutoff) {
+  const sameMajor = sameMajorNewer(releaseCandidates(repo), current);
+
+  for (const item of sameMajor) {
+    const published = item.published ?? commitDate(repo, item.tag);
+    if (published && new Date(published) > cutoff) {
+      const sha = commitSha(repo, item.tag);
+      if (!sha) return null;
+      return { tag: item.tag, published, sha };
+    }
+  }
+  return null;
+}
+
+function tagLookupCandidates(tag) {
+  const trimmed = String(tag ?? "").trim();
+  const parsed = parseVersion(trimmed);
+  if (!parsed) return [trimmed];
+  const bare = parsed.raw;
+  const withV = `v${bare}`;
+  return [...new Set([trimmed, bare, withV])];
+}
+
+function commitSha(repo, tag) {
+  for (const candidate of tagLookupCandidates(tag)) {
+    try {
+      return gh(`repos/${repo}/commits/${candidate}`).sha;
+    } catch {
+      // try next tag form
+    }
+  }
+  return "";
+}
+
+function commitDate(repo, tag) {
+  for (const candidate of tagLookupCandidates(tag)) {
+    try {
+      return gh(`repos/${repo}/commits/${candidate}`).commit.committer.date;
+    } catch {
+      // try next tag form
+    }
+  }
+  return null;
+}
+
+function releaseDate(repo, tag) {
+  for (const candidate of tagLookupCandidates(tag)) {
+    try {
+      return gh(`repos/${repo}/releases/tags/${candidate}`).published_at;
+    } catch {
+      // try next tag form
+    }
+  }
+  return null;
+}
+
+function currentPinState(repo, current, currentSha, cutoff) {
+  const currentPublished =
+    releaseDate(repo, current) ?? commitDate(repo, current);
+  const tagSha = commitSha(repo, current);
+  const tooFresh = currentPublished
+    ? new Date(currentPublished) > cutoff
+    : false;
+  return {
+    currentPublished: currentPublished ?? "",
+    currentMature: currentPublished ? !tooFresh : false,
+    currentShaMatchesTag: tagSha ? tagSha === currentSha : null,
+    note: tooFresh ? "current pin is younger than the maturity window" : "",
+  };
+}
+
+function newestOverall(repo) {
+  try {
+    const latest = gh(`repos/${repo}/releases/latest`).tag_name;
+    return parseVersion(latest) ? latest : "";
+  } catch {
+    return "";
+  }
+}
+
+function main() {
+  const args = parseArgs(process.argv);
+  if (!existsSync(args.dir))
+    throw new Error(`Directory not found: ${args.dir}`);
+
+  const windowMs =
+    args.minutes != null ? args.minutes * MINUTE_MS : args.days * DAY_MS;
+  if (!Number.isFinite(windowMs) || windowMs < 0)
+    throw new Error("Release-age window must be a positive number");
+
+  const now = new Date();
+  const cutoff = new Date(now.getTime() - windowMs);
+  const rows = [];
+
+  for (const pin of collectPins(args.dir)) {
+    if (pin.conflictingPins) {
+      rows.push({
+        repo: pin.repo,
+        pinned: pin.pinned,
+        conflictingPins: true,
+        pinVariants: pin.pinVariants,
+        ref: pin.ref,
+        note: pin.pinned
+          ? "multiple SHAs pinned for this action — reconcile before bumping"
+          : "multiple SHAs pinned for this action — remove mutable refs and reconcile before bumping",
+        files: pin.files,
+      });
+      continue;
+    }
+    if (pin.commentDrift) {
+      rows.push({
+        repo: pin.repo,
+        pinned: pin.pinned,
+        current: pin.comment,
+        currentSha: pin.sha,
+        commentDrift: true,
+        ref: pin.ref,
+        note: "same SHA with conflicting version comments — align comments before bumping",
+        files: pin.files,
+      });
+      continue;
+    }
+    if (!pin.pinned) {
+      rows.push({
+        repo: pin.repo,
+        pinned: false,
+        ref: pin.ref,
+        comment: pin.comment,
+        files: pin.files,
+      });
+      continue;
+    }
+    if (!isStandardVersion(pin.comment)) {
+      rows.push({
+        repo: pin.repo,
+        pinned: true,
+        current: pin.comment,
+        currentSha: pin.sha,
+        note: "non-standard version comment — resolve and verify manually",
+        files: pin.files,
+      });
+      continue;
+    }
+    const current = pin.comment;
+    const ghRepo = apiRepo(pin.repo);
+    const currentState = currentPinState(ghRepo, current, pin.sha, cutoff);
+    if (currentState.currentShaMatchesTag !== true) {
+      const shaNote =
+        currentState.currentShaMatchesTag === false
+          ? "pinned SHA does not match the version comment tag — reconcile before bumping"
+          : "unable to verify pinned SHA against version tag — reconcile before bumping";
+      rows.push({
+        repo: pin.repo,
+        pinned: true,
+        current,
+        currentSha: pin.sha,
+        currentPublished: currentState.currentPublished,
+        currentMature: currentState.currentMature,
+        currentShaMatchesTag: currentState.currentShaMatchesTag,
+        eligibleTag: "",
+        eligibleSha: "",
+        eligiblePublished: "",
+        blockedTooFreshTag: "",
+        blockedTooFreshSha: "",
+        blockedTooFreshPublished: "",
+        updateType: "",
+        latest: newestOverall(ghRepo),
+        majorAvailable: false,
+        note: [shaNote, currentState.note].filter(Boolean).join("; "),
+        files: pin.files,
+      });
+      continue;
+    }
+    const latest = newestOverall(ghRepo);
+    const eligible = selectEligible(ghRepo, current, cutoff);
+    const blockedTooFresh = eligible
+      ? null
+      : selectBlockedTooFresh(ghRepo, current, cutoff);
+    rows.push({
+      repo: pin.repo,
+      pinned: true,
+      current,
+      currentSha: pin.sha,
+      currentPublished: currentState.currentPublished,
+      currentMature: currentState.currentMature,
+      currentShaMatchesTag: currentState.currentShaMatchesTag,
+      eligibleTag: eligible?.tag ?? "",
+      eligibleSha: eligible?.sha ?? "",
+      eligiblePublished: eligible?.published ?? "",
+      blockedTooFreshTag: blockedTooFresh?.tag ?? "",
+      blockedTooFreshSha: blockedTooFresh?.sha ?? "",
+      blockedTooFreshPublished: blockedTooFresh?.published ?? "",
+      updateType: eligible ? classify(current, eligible.tag) : "",
+      latest,
+      majorAvailable: latest ? classify(current, latest) === "major" : false,
+      note:
+        currentState.note ||
+        (blockedTooFresh
+          ? "newer same-major release is younger than the maturity window"
+          : ""),
+      files: pin.files,
+    });
+  }
+
+  console.log(
+    JSON.stringify(
+      {
+        now: now.toISOString(),
+        cutoff: cutoff.toISOString(),
+        ...(args.minutes != null ? { minutes: args.minutes } : { days: args.days }),
+        rows,
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+}

--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -9,7 +9,7 @@ runs:
   using: "composite"
   steps:
     - name: Install pnpm
-      uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+      uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 
     - name: Setup Node.js
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/workflows/security-code-scanner.yml
+++ b/.github/workflows/security-code-scanner.yml
@@ -25,10 +25,10 @@ jobs:
       actions: read
       contents: read
       security-events: write
-    uses: MetaMask/action-security-code-scanner/.github/workflows/security-scan.yml@ff5edd492dfd4a70813066fe9f1552a2ac13766f
+    uses: MetaMask/action-security-code-scanner/.github/workflows/security-scan.yml@ff5edd492dfd4a70813066fe9f1552a2ac13766f # v2.1.0
     with:
       repo: ${{ github.repository }}
-      scanner-ref: "0a58c584f25e8c121927884b5e8a86e846090e5c"
+      scanner-ref: "ff5edd492dfd4a70813066fe9f1552a2ac13766f"
       paths-ignored: |
         node_modules
         **/node_modules/**


### PR DESCRIPTION
## Summary
- Update the `linea-dependency-maintenance` skill (GitHub Actions support)
- Refresh GitHub Actions pins to full commit SHAs with version comments

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI-wide impact from a semver-major `pnpm/action-setup` bump in the shared setup composite action; otherwise documentation and supply-chain pinning with no app/runtime code changes.
> 
> **Overview**
> Extends the **linea-dependency-maintenance** agent skill beyond npm/pnpm to **GitHub Actions**: SHA-only pins with version comments, a **7-day** release-age gate, coexistence with Dependabot’s `github-actions` job, validation/PR commit guidance, a new **`references/github-actions.md`**, eval case **#6**, and a new **`scripts/eligible-actions`** inventory helper (via `gh`).
> 
> Applies that policy in CI: **`pnpm/action-setup`** in `setup-env` is bumped to **v6.0.9** (new SHA), and the MetaMask security scanner workflow gets an auditable **v2.1.0** comment plus **`scanner-ref`** aligned to the same commit as the reusable workflow pin.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f221c088c9ae824277a6f1aae8d5406c588aaa48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->