### PR TITLE
fix: unescape dot in eligible-actions validation regex

### DIFF
--- a/.agents/skills/linea-dependency-maintenance/references/github-actions.md
+++ b/.agents/skills/linea-dependency-maintenance/references/github-actions.md
@@ -58,7 +58,7 @@ grep -rnE 'uses:\s+[^./]' .github/workflows .github/actions
   (` # vX.Y.Z` or ` # X.Y.Z`, space before `#`):
   ```bash
   grep -rnE 'uses:\s+[^./][^@]+@[^ ]+' .github/workflows .github/actions \
-    | grep -vE '@[0-9a-f]{40} +# v?[0-9]+\\.[0-9]+\\.[0-9]+'
+    | grep -vE '@[0-9a-f]{40} +# v?[0-9]+\.[0-9]+\.[0-9]+'
   ```
   The command should print nothing. Any line it prints is an unpinned action, a tag/branch ref, or a non-standard
   version comment (for example `#v7.2.0` without a leading space).


### PR DESCRIPTION
## Summary
- Fix the validation regex example in `.agents/skills/linea-dependency-maintenance/references/github-actions.md`

The example was double-escaping the dot (`\\.`) inside a single-quoted shell string. `grep -E` reads that as a literal backslash followed by any character, so the pattern never matched a real version comment like `# v6.0.2` — the validation command would flag every correctly pinned action instead of printing nothing.

Same fix as raised by @eloi010 on https://github.com/Consensys/linea-hub/pull/2253#pullrequestreview-4634307662, ported here since this repo carries the same skill doc.

## Test plan
- [x] Verified `grep -vE '@[0-9a-f]{40} +# v?[0-9]+\.[0-9]+\.[0-9]+'` correctly filters a properly pinned `uses:` line and still flags an unpinned one

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to an example shell command; no workflow or runtime behavior is modified.
> 
> **Overview**
> Updates the **Validation** example in `github-actions.md` so the `grep -vE` pattern uses unescaped dots (`\.[0-9]+`) instead of `\\.`, which inside a single-quoted shell string was a literal backslash plus “any character” and caused the check to treat every properly pinned `uses:` line as invalid.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2bd18fafeeb614fd7b6091cccc7e7c8f4d96afce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->