### PR TITLE
chore: allow AI agents to perform git operations

### DIFF
--- a/.cursor/rules/00-operating-model.mdc
+++ b/.cursor/rules/00-operating-model.mdc
@@ -3,12 +3,6 @@ description: Operating model, authority, modes, planning, tickets, strict DoD, o
 alwaysApply: true
 ---
 
-# Authority and Git
-
-Cursor is strictly forbidden from committing, pushing, rebasing, merging, force pushing, tagging, or modifying Git history.
-Git operations are informational only when explicitly requested.
-The human user is the sole authority for Git actions, releases, and deployments.
-
 # Ownership and Decision Authority
 
 Every domain or system must have a clearly identified human owner.


### PR DESCRIPTION
## Summary
- Remove the blanket "Authority and Git" restriction in `.cursor/rules/00-operating-model.mdc` that forbade Cursor from committing, pushing, rebasing, merging, or opening PRs.
- Agents can now contribute directly (commit/push/PR) instead of only reporting Git actions informationally.

## Test plan
- N/A (documentation/rules only change)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This is governance-only but raises operational risk: agents may now perform Git actions that previously required explicit human control, without new safeguards in the same file.
> 
> **Overview**
> **Policy change:** The **Authority and Git** block is deleted from `.cursor/rules/00-operating-model.mdc`, so agents are no longer globally barred from commits, pushes, rebases, merges, force-push, tags, or history rewrites, and Git is no longer limited to “informational only” reporting.
> 
> The rest of the operating model (ownership, Planner/Executor/Reviewer modes, DoD, irreversible actions, exceptions) is unchanged; only the hard Git prohibition is lifted, aligning with allowing agents to commit, push, and open PRs directly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a823eb975e7bc14f8256142fdef17b4dc7cd8a52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->