### PR TITLE
fix(explorer): pin Netlify runtime requirements

### DIFF
--- a/explorer/package.json
+++ b/explorer/package.json
@@ -15,6 +15,10 @@
   "license": "MIT",
   "author": "Consensys",
   "type": "module",
+  "engines": {
+    "node": "24.18.0",
+    "pnpm": "11.9.0"
+  },
   "scripts": {
     "build": "tsc && vite build",
     "build:netlify": "pnpm run build && pnpm run redirect",


### PR DESCRIPTION
## Summary
- declare Node 24.18.0 and pnpm 11.9.0 in the explorer package
- ensure Netlify selects the supported runtime when building from `explorer/`

## Test plan
- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm --filter verax-explorer... run build:netlify`

Made with [Cursor](https://cursor.com)